### PR TITLE
Correct typos in specs markdown

### DIFF
--- a/specs/erc-7730.md
+++ b/specs/erc-7730.md
@@ -121,7 +121,7 @@ In this example, the metadata section contains only the recipient information, i
 
 Finally, the `display` section contains the definitions of how to format each field of targeted contract calls under the `formats` key. 
 
-In this example, the function being described is identified by its solidity signature `transfer(address,uint256)`. This is th signature used to compute the function selector `0xa9059cbb` (using the solidity sgnature guarantees unicity in the conext of the contract). 
+In this example, the function being described is identified by its solidity signature `transfer(address,uint256)`. This is the signature used to compute the function selector `0xa9059cbb` (using the solidity signature guarantees unicity in the context of the contract). 
 * The `intent` key contains a human readable string that wallets SHOULD display to explain to the user the intent of the function call. 
 * The `fields` key contains all the parameters that CAN be displayed, and the way to format them 
   * The `required` key indicates which parameters wallets SHOULD display). 

--- a/specs/erc-7730.md
+++ b/specs/erc-7730.md
@@ -140,7 +140,7 @@ This specification intends to be extensible to describe the display formatting o
 
 By *Structured data*, we target any data format that has:
 * A well defined *type* system; the data being described itself being of a specific type
-* A description of the type system, the *schema*, that should allow splitting the data into *fields*, each field clearly identified with a *path* that can be descrived as a string.
+* A description of the type system, the *schema*, that should allow splitting the data into *fields*, each field clearly identified with a *path* that can be described as a string.
 
 Displaying structured data is often done by wallets to review its content before authorizing an action in the form of a *signature* over some serialization of the structured data. As such, the structured data is contained in a *container structure*:
 * Container structure has a well defined *signature* scheme (a serialization scheme, a hashing scheme, and signature algorithm).


### PR DESCRIPTION
I noticed a few typos while reading the specs