### PR TITLE
ci: fix labels action

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,33 +13,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  setup_pull_request:
-    name: 🤖 setup pull request
-    runs-on: public-ledgerhq-shared-small
-    timeout-minutes: 10
-    steps:
-
-      - name: Checkout
-        timeout-minutes: 10
-        uses: actions/checkout@v4
-
-      - name: Add labels
-        timeout-minutes: 5
-        uses: actions/labeler@v5
-
-      - name: Enforce labels
-        timeout-minutes: 5
-        uses: mheap/github-action-required-labels@v5
-        with:
-          mode: minimum
-          count: 1
-          labels: |
-            documentation
-            specifications
-            descriptors
-            ci
-          add_comment: true
-
   validate_descriptors:
     name: 🔎 validate descriptors
     runs-on: public-ledgerhq-shared-small
@@ -49,23 +22,6 @@ jobs:
       - name: Checkout
         timeout-minutes: 10
         uses: actions/checkout@v4
-
-      - name: Add labels
-        timeout-minutes: 5
-        uses: actions/labeler@v5
-
-      - name: Enforce labels
-        timeout-minutes: 5
-        uses: mheap/github-action-required-labels@v5
-        with:
-          add_comment: true
-          mode: minimum
-          count: 1
-          labels: |
-            documentation
-            specifications
-            descriptors
-            ci
 
       - name: Get all changed descriptor files
         timeout-minutes: 5

--- a/.github/workflows/pull_request_setup.yml
+++ b/.github/workflows/pull_request_setup.yml
@@ -1,0 +1,40 @@
+name: ✨ pull request setup
+
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  setup_pull_request:
+    name: 🤖 setup pull request
+    runs-on: public-ledgerhq-shared-small
+    timeout-minutes: 10
+    steps:
+
+      - name: Checkout
+        timeout-minutes: 10
+        uses: actions/checkout@v4
+
+      - name: Add labels
+        timeout-minutes: 5
+        uses: actions/labeler@v5
+
+      - name: Enforce labels
+        timeout-minutes: 5
+        uses: mheap/github-action-required-labels@v5
+        with:
+          mode: minimum
+          count: 1
+          labels: |
+            documentation
+            specifications
+            descriptors
+            ci
+          add_comment: true


### PR DESCRIPTION
to run from fork, labels action must be triggered with `pull_request_target` event, split workflow in 2 see https://github.com/actions/labeler#permissions

issue seen in #18