### PR TITLE
fix: correct input field

### DIFF
--- a/registry/uniswap/calldata-UniswapV3Router02.json
+++ b/registry/uniswap/calldata-UniswapV3Router02.json
@@ -36,7 +36,7 @@
                         }
                     },
                     {
-                        "path": "params.amountOut",
+                        "path": "params.amountOutMinimum",
                         "label": "Minimum amount to Receive",
                         "format": "tokenAmount",
                         "params": {
@@ -49,7 +49,7 @@
                         "format": "addressName"
                     }
                 ],
-                "required": ["params.amountIn", "params.amountOut", "params.recipient"]
+                "required": ["params.amountIn", "params.amountOutMinimum", "params.recipient"]
             },
             "0x04e45aaf": {
                 "$id": "exactInputSingle",


### PR DESCRIPTION
See https://github.com/LedgerHQ/ledger-asset-dapps/blob/211e75ed27de3894f592ca73710fa0b72c3ceeae/ethereum/uniswap/abis/0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45.abi.json#L164-L199

Input field is `amountOutMinimum` (`amountOut` is the output)