### PR TITLE
ci: don't use matrix job

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -49,14 +49,31 @@ jobs:
     name: 🔁 trigger updates
     runs-on: public-ledgerhq-shared-small
     timeout-minutes: 60
-    strategy:
-      matrix:
-        repo: ['LedgerHQ/crypto-assets', 'LedgerHQ/crypto-assets-clear-signing-initiative', 'LedgerHQ/python-erc7730']
     steps:
-      - name: Trigger update on ${{ matrix.repo }}
+
+      - name: Trigger update on LedgerHQ/crypto-assets
+        if: ${{ !cancelled() }}
         timeout-minutes: 60
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.CI_BOT_TOKEN }}
-          repository: ${{ matrix.repo }}
+          repository: LedgerHQ/crypto-assets
+          event-type: submodules
+
+      - name: Trigger update on LedgerHQ/crypto-assets-clear-signing-initiative
+        if: ${{ !cancelled() }}
+        timeout-minutes: 60
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CI_BOT_TOKEN }}
+          repository: LedgerHQ/crypto-assets-clear-signing-initiative
+          event-type: submodules
+
+      - name: Trigger update on LedgerHQ/python-erc7730
+        if: ${{ !cancelled() }}
+        timeout-minutes: 60
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CI_BOT_TOKEN }}
+          repository: LedgerHQ/python-erc7730
           event-type: submodules


### PR DESCRIPTION
we only have 1 runner available so using a matrix job takes forever to schedule

