### PR TITLE
spec: add support for explicitly declaring excluded fields

### DIFF
--- a/specs/erc-7730.md
+++ b/specs/erc-7730.md
@@ -128,7 +128,7 @@ In this example, the function being described is identified by its solidity sign
 * The `intent` key contains a human readable string that wallets SHOULD display to explain to the user the intent of the function call. 
 * The `fields` key contains all the parameters that CAN be displayed, and the way to format them 
 * The `required` key indicates which parameters wallets SHOULD display. 
-* The `excluded` key indicates which parameters are intentionally been left out (none in this example). 
+* The `excluded` key indicates which parameters are intentionally left out (none in this example). 
   
 In this example, the `_to` parameter and the `_value` SHOULD both be displayed, one as an address replaceable by a trusted name (ENS or others), the other as an amount formatted using metadata of the target ERC-20 contract (USDT). 
 

--- a/specs/erc-7730.md
+++ b/specs/erc-7730.md
@@ -770,6 +770,12 @@ Required fields, as an array of *paths* referring to specific fields.
 
 Wallets SHOULD display at least all the fields referred by the `required` key.
 
+**`excluded`** 
+
+Intentionally excluded fields, as an array of *paths* referring to specific fields. 
+
+A field that has no formatter and is not declared in this list MAY be considered as an error by the wallet when interpreting the descriptor.
+
 **`screens`**
 
 Wallet specific grouping information. The structure of the `screens` sub-keys is wallet maker specific and referenced in the [Wallets](#wallets) section.

--- a/specs/erc7730-v1.schema.json
+++ b/specs/erc7730-v1.schema.json
@@ -374,6 +374,9 @@
                             "required": {
                                 "$ref": "#/$display/required"
                             },
+                            "excluded": {
+                                "$ref": "#/$display/excluded"
+                            },
                             "screens": {
                                 "title": "Screens grouping information",
                                 "description": "Screens section is used to group multiple fields to display into screens. Each key is a wallet type name. The format of the screens is wallet type dependent, as well as what can be done (reordering fields, max number of screens, etc...). See each wallet manufacturer documentation for more information.",
@@ -418,7 +421,14 @@
             "title": "Required fields",
             "description": "A list of fields that are required to be displayed to the user. A field that has a formatter and is not in this list is optional. A field that does not have a formatter should be silent, ie not shown",
             "type": "array",
-
+            "items": {
+                "type": "string"
+            }
+        },
+        "excluded": {
+            "title": "Excluded fields",
+            "description": "A list of fields that are intentionally not shown to the user. A field that has no formatter and is not declared in this list may be considered as an error by the wallet when interpreting the descriptor.",
+            "type": "array",
             "items": {
                 "type": "string"
             }


### PR DESCRIPTION
This allows validation to properly deal with omitted fields:
 - field has no formatter and not in `excluded` => descriptor is invalid
 - field has no formatter and is in `excluded` => OK, descriptor is valid

Example current linter output:
![image](https://github.com/user-attachments/assets/7b3ba1d1-f3dd-4de0-84b2-71ea0acdbd2e)
