### PR TITLE
Remove duplicate address links

### DIFF
--- a/developer-preview/src/app/ContractInfo.tsx
+++ b/developer-preview/src/app/ContractInfo.tsx
@@ -1,11 +1,15 @@
 import { UI } from "~/ui/UI";
-import { type Deploymnent, type PreviewData } from "~/types/PreviewData";
+import { type PreviewData } from "~/types/PreviewData";
 import { formatShortAddress } from "~/app/formatShortAddress";
 
 export const ContractInfo = ({ data }: { data: PreviewData }) => {
   if (data.contract.deployments.length === 0) {
     return <UI.FauxInput error>No deployments found</UI.FauxInput>;
   }
+
+  const uniqueAddresses = Array.from(
+    new Set(data.contract.deployments.map(({ address }) => address)),
+  );
 
   return (
     <div>
@@ -14,7 +18,7 @@ export const ContractInfo = ({ data }: { data: PreviewData }) => {
           <UI.InputText>{data.contract.name}</UI.InputText>
 
           <div className="flex gap-5">
-            {data.contract.deployments.map(({ address }: Deploymnent) => (
+            {uniqueAddresses.map((address: string) => (
               <UI.GreyLink
                 href={`https://etherscan.io/address/${address}`}
                 key={address}


### PR DESCRIPTION
# Why

- Some contracts are deployed on multiple chains but have the same address on each
- We show a link to etherscan.io for each deployment address
- This meant we were showing lots of duplicates

# What

-[x] Remove the duplicates

|Before|After|
|-|-|
|<img width="1511" alt="Screenshot 2024-10-15 at 14 20 31" src="https://github.com/user-attachments/assets/9669b475-e2b2-4e9b-b116-a9083ff9624e">|<img width="1512" alt="Screenshot 2024-10-15 at 14 20 46" src="https://github.com/user-attachments/assets/2804b9da-2609-4be8-b978-cfe6fc17804d">|
