### PR TITLE
fix: typos

### DIFF
--- a/registry/paraswap/calldata-AugustusSwapper.json
+++ b/registry/paraswap/calldata-AugustusSwapper.json
@@ -65,14 +65,18 @@
                 "label": "Exchange",
                 "format": "addressName",
                 "params": {
-                    "types": ["contract"]
+                    "types": [
+                        "contract"
+                    ]
                 }
             },
             "factory": {
                 "label": "Uniswap Factory",
                 "format": "addressName",
                 "params": {
-                    "types": ["contract"]
+                    "types": [
+                        "contract"
+                    ]
                 }
             }
         },
@@ -265,7 +269,7 @@
                         }
                     },
                     {
-                        "path": "toAmount",
+                        "path": "amountOutMin",
                         "$ref": "$.display.definitions.minReceiveAmount",
                         "params": {
                             "tokenPath": "toToken"
@@ -293,7 +297,7 @@
                         }
                     },
                     {
-                        "path": "toAmount",
+                        "path": "amountOutMin",
                         "$ref": "$.display.definitions.minReceiveAmount",
                         "params": {
                             "tokenPath": "toToken"
@@ -427,7 +431,7 @@
                         "path": "data.toAmount",
                         "$ref": "$.display.definitions.minReceiveAmount",
                         "params": {
-                            "tokenPath": "data.path.-1.to"
+                            "tokenPath": "data.path.[-1].to"
                         }
                     },
                     {

--- a/registry/uniswap/calldata-UniswapV3Router02.json
+++ b/registry/uniswap/calldata-UniswapV3Router02.json
@@ -165,7 +165,7 @@
                         "label": "Amount to Send",
                         "format": "tokenAmount",
                         "params": {
-                            "tokenPath": "path[0]"
+                            "tokenPath": "path.[0]"
                         }
                     },
                     {


### PR DESCRIPTION
- Fix incorrect fields in `registry/paraswap/calldata-AugustusSwapper.json`
- Fix path typo in `registry/paraswap/calldata-AugustusSwapper.json`
- Fix path typo in `registry/uniswap/calldata-UniswapV3Router02.json`