### PR TITLE
fix: fix `@.amount`/`@.value` confusion

### DIFF
--- a/registry/lido/calldata-stETH.json
+++ b/registry/lido/calldata-stETH.json
@@ -29,7 +29,7 @@
                 "intent": "Stake ETH",
                 "fields": [
                     {
-                        "path": "@.amount",
+                        "path": "@.value",
                         "label": "Amount to Stake",
                         "format": "amount"
                     },
@@ -39,7 +39,7 @@
                         "format": "addressName"
                     }
                 ],
-                "required": ["@.amount"]
+                "required": ["@.value"]
             },
             "approve(address,uint256)" : {
                 "intent": "Approve a spender",

--- a/specs/erc-7730.md
+++ b/specs/erc-7730.md
@@ -223,7 +223,7 @@ References to values in the format specification file
 * `$.display.definitions.minReceiveAmount` refers to a common definition reused accross fields formatting definition
 
 References to values in the container (here a EVM Tx container)
-* `@.amount` refers to the enclosing transaction native currency amount
+* `@.value` refers to the enclosing transaction native currency amount
 * `@.to` refers to the enclosing transaction destination address (usually, a smartcontract bound to this ERC-7730 through the `context` section)
 
 #### Organizing files


### PR DESCRIPTION
fix "native currency value of the transaction" sometimes referred as `@.amount`, sometimes `@.value` => use `@.value` everywhere