### PR TITLE
spec: allow more data types in `$.metadata.constants` section

### DIFF
--- a/specs/erc7730-v1.schema.json
+++ b/specs/erc7730-v1.schema.json
@@ -304,7 +304,7 @@
             "type": "object",
             "description": "A set of values that can be used in format parameters. Can be referenced with a path expression like $.metadata.constants.CONSTANT_NAME",
             "additionalProperties": {
-                "type": "string"
+                "type": ["string", "integer", "number", "boolean", "null"]
             }
         }, 
 


### PR DESCRIPTION
note: I did not enable arrays/objects (yet), as implementation of resolution is a bit more complex

