### PR TITLE
spec: typos/fixes

### DIFF
--- a/specs/erc-7730.md
+++ b/specs/erc-7730.md
@@ -1,7 +1,7 @@
 ---
 eip: 7730
 title: Structured Data Clear Signing Format
-description: Draft specification of a json format providing additional description of how to clear-sign smartcontract calls and typed messages
+description: Draft specification of a json format providing additional description of how to clear-sign smart contract calls and typed messages
 author: Laurent Castillo (@lcastillo-ledger)
 discussions-to: https://ethereum-magicians.org/t/eip-7730-proposal-for-a-clear-signing-standard-format-for-wallets/20403
 status: Draft
@@ -15,7 +15,7 @@ requires: 712
 
 This specification defines a JSON format carrying additional information required to correctly display structured data to a human for review on a wallet screen, before signature by the wallet. 
 
-The [ERC-7730](./eip-7730.md) specification enriches type data contained in the ABIs and schemas of structured messages (structures like the calldata of an EVM transaction or an [EIP-712](./eip-712.md) message) with additional formatting information, so that wallets can construct a better UI when displaying the data before signature. For instance, a solidity field containing an amount, encoded as a uint256, can be converted to the right magnitude and appended with the correct ticker.
+The [ERC-7730](./eip-7730.md) specification enriches type data contained in the ABIs and schemas of structured messages (structures like the calldata of an EVM transaction or an [EIP-712](./eip-712.md) message) with additional formatting information, so that wallets can construct a better UI when displaying the data before signature. For instance, a solidity field containing an amount, encoded as an uint256, can be converted to the right magnitude and appended with the correct ticker.
 
 Wallets will use (wallet-curated) ERC-7730 files alongside the raw data to sign in order to construct a display adapted to be reviewed by humans.
 
@@ -36,13 +36,13 @@ Providing this additional formatting information requires deep knowledge of the 
 > *Deployment model*
 > 
 > Making the ERC-7730 available for wallets is a key factor of adoption. We have a few options:
-> - In each dApps github repository or web site: good for autonomy but can be problematic for discoverability by wallets of new ERC-7730 files
+> - In each dApps GitHub repository or website: good for autonomy but can be problematic for discoverability by wallets of new ERC-7730 files
 > - Foundation operated repository, like ethereum chainID list: good alternative between decentralization and discoverability.
-> - Ledger repository: as a short term solution, Ledger is providing a central repository (See Ledger github repository)
+> - Ledger repository: as a short term solution, Ledger is providing a central repository (See Ledger GitHub repository)
 
 ## Specification
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
 ### Simple example
 
@@ -59,15 +59,15 @@ The following is a simple example of how to clear sign a `transfer` function cal
             "deployments": [ 
                 {
                     "chainId": 1,
-                    "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                    "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7"
                 },
                 {
                     "chainId": 137,
-                    "address": "0xc2132D05D31c914a87C6611C10748AEb04B58e8F",
+                    "address": "0xc2132D05D31c914a87C6611C10748AEb04B58e8F"
                 },
                 {
                     "chainId": 42161,
-                    "address": "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+                    "address": "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"
                 }
             ]
         }
@@ -125,7 +125,7 @@ In this example, the metadata section contains only the recipient information, i
 Finally, the `display` section contains the definitions of how to format each field of targeted contract calls under the `formats` key. 
 
 In this example, the function being described is identified by its solidity signature `transfer(address _to,uint256 _value)`. This is the signature used to compute the function selector `0xa9059cbb` (using the solidity signature guarantees unicity in the context of the contract). 
-* The `intent` key contains a human readable string that wallets SHOULD display to explain to the user the intent of the function call. 
+* The `intent` key contains a human-readable string that wallets SHOULD display to explain to the user the intent of the function call. 
 * The `fields` key contains all the parameters that CAN be displayed, and the way to format them 
 * The `required` key indicates which parameters wallets SHOULD display. 
 * The `excluded` key indicates which parameters are intentionally left out (none in this example). 
@@ -143,11 +143,11 @@ In all the specification, key names starting with `$` are *internal* and have no
 This specification intends to be extensible to describe the display formatting of any kind of *structured data*. 
 
 By *Structured data*, we target any data format that has:
-* A well defined *type* system; the data being described itself being of a specific type
+* A well-defined *type* system; the data being described itself being of a specific type
 * A description of the type system, the *schema*, that should allow splitting the data into *fields*, each field clearly identified with a *path* that can be described as a string.
 
 Displaying structured data is often done by wallets to review its content before authorizing an action in the form of a *signature* over some serialization of the structured data. As such, the structured data is contained in a *container structure*:
-* Container structure has a well defined *signature* scheme (a serialization scheme, a hashing scheme, and signature algorithm).
+* Container structure has a well-defined *signature* scheme (a serialization scheme, a hashing scheme, and signature algorithm).
 * The container structure does not necessarily follow the same type system as the structured data.
 * Wallets receive the full container structure and uses the signature scheme to generate a signature on the overall structure.
 
@@ -172,13 +172,13 @@ block-beta
 
 Current specification covers EVM smart contract calldata:
 * Defined in Solidity
-* The schema is the ABI (expected in json format when linked to))
+* The schema is the ABI (expected in json format when linked to)
 * The container structure is an EVM Transaction serialized in RLP encoding
 
 It also supports EIP-712 messages
 * Defined in EIP-712
 * The schema is extracted from the message itself, from the `types` definitions and the `primaryType` key.
-* An EIP-712 message is self contained, the signature is applied to the hashed message itself.
+* An EIP-712 message is self-contained, the signature is applied to the hashed message itself.
   
 In the future, it could be extended to structured data like Meta Transaction in [EIP-2771](./eip-2771.md) or User Operations in [EIP-4337](./eip-4337.md).
 
@@ -193,19 +193,19 @@ It is sometime necessary for formatting of fields of the structured data to refe
 This specification uses a limited [json path](https://www.rfc-editor.org/rfc/rfc9535) notation to reference values that can be found in multiple json documents. 
 
 Limitation to the json path specification are the following:
-* Pathes MUST use the dot notation, including for slice and array selectors (i.e an element of an array should be selected through `array_name.[index]`) 
+* Paths MUST use the dot notation, including for slice and array selectors (i.e. an element of an array should be selected through `array_name.[index]`) 
 * Only name, index and slices selectors are supported.
 * Slices selectors MUST NOT contain the optional step.
 
 In addition, additional *roots* are introduced to support description of paths over multiple files in a single common notation. The root node identifier indicates which document or data location this path references, according to the following table:
 
-| Root node identifier | Refers to | Value location |
-| --- | --- | --- |
-| # | Path applies to the structured data *schema* (ABI path for contracts, path in the message types itself for EIP-712) | Values can be found in the serialized representation of the structured data | 
-| $ | Path applies to the current file describing the structured data formatting, after merging with includes | Values can be found in the merged file itself | 
-| @ | Path applies to the container of the structured data to be signed | Values can be found in the serialized container to sign, and are uniquely defined per container in the [Reference](#reference) section |
+| Root node identifier | Refers to                                                                                                           | Value location                                                                                                                         |
+|----------------------|---------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| #                    | Path applies to the structured data *schema* (ABI path for contracts, path in the message types itself for EIP-712) | Values can be found in the serialized representation of the structured data                                                            | 
+| $                    | Path applies to the current file describing the structured data formatting, after merging with includes             | Values can be found in the merged file itself                                                                                          | 
+| @                    | Path applies to the container of the structured data to be signed                                                   | Values can be found in the serialized container to sign, and are uniquely defined per container in the [Reference](#reference) section |
 
-Root nodes and following separator can be omitted, in which case the path is *relative* to the structure being described. In case there is no encapsulating structure, relative pathes refer to the top-level structure described in the current file and are equivalent to `#.` root node. 
+Root nodes and following separator can be omitted, in which case the path is *relative* to the structure being described. In case there is no encapsulating structure, relative paths refer to the top-level structure described in the current file and are equivalent to `#.` root node. 
 
 For paths referring to structured data fields, if a field has a variable length primitive type (like `bytes` or `string` in solidity), a slice selector can be appended to the path, to refer to the specific set of bytes indicated by the slice.
 
@@ -220,23 +220,23 @@ References to values in the serialized structured data
 
 References to values in the format specification file
 * `$.metadata.enums.interestRateMode` refers to the values of an enum defined in the specification file (typically to convert an integer into a displayed string)
-* `$.display.definitions.minReceiveAmount` refers to a common definition reused accross fields formatting definition
+* `$.display.definitions.minReceiveAmount` refers to a common definition reused across fields formatting definition
 
-References to values in the container (here a EVM Tx container)
+References to values in the container (here an EVM Tx container)
 * `@.value` refers to the enclosing transaction native currency amount
-* `@.to` refers to the enclosing transaction destination address (usually, a smartcontract bound to this ERC-7730 through the `context` section)
+* `@.to` refers to the enclosing transaction destination address (usually, a smart contract bound to this ERC-7730 through the `context` section)
 
 #### Organizing files
 
 Smart contracts and EIP-712 messages are often re-using common interfaces or types that share similar display formatting. This specification supports a basic inclusion mechanism that enables sharing files describing specific interfaces or types.
 
-The `includes` top-level key is an URL pointing to an ERC-7730 file that MUST follow this specification.
+The `includes` top-level key is a URL pointing to an ERC-7730 file that MUST follow this specification.
 
 A wallet using an ERC-7730 file including another file SHOULD merge those files into a single reference file. When merging, conflicts between common unique keys are resolved by prioritizing the including file.
 
 *Merging field format specifications*
 
-Special care must be taken when merging [field format specifications](#field-format-specification). These objects are grouped in a array under the `fields` key, allowing ordering of field formatters. When merging the two arrays, a wallet SHOULD:
+Special care must be taken when merging [field format specifications](#field-format-specification). These objects are grouped in an array under the `fields` key, allowing ordering of field formatters. When merging the two arrays, a wallet SHOULD:
 * Merge together objects sharing the same `path` value, overriding parameters of the included file with those of the including file.
 * Append objects with `path` values not part of the included file to the resulting array.
 
@@ -246,7 +246,7 @@ This file defines a generic ERC-20 interface for a single `approve` function:
 ```json
 {
     "context": {
-        "contract" : {
+        "contract": {
             "abi": [
                 {
                     "inputs": [
@@ -265,7 +265,6 @@ This file defines a generic ERC-20 interface for a single `approve` function:
             ]
         }
     },
-
     "display": {
         "formats": {
             "approve(address _spender,uint256 _value)": {
@@ -288,6 +287,7 @@ This file defines a generic ERC-20 interface for a single `approve` function:
                     }
                 ],
                 "required": ["_spender", "_value"]
+            }
         }
     }
 }
@@ -349,7 +349,7 @@ The `context` section describes a set of *constraints* that must be verified by 
 
 The current version of this specification only supports two types of binding context, EVM smart contracts and EIP-712 domains. 
 
-All context support an `$id` sub-key as an internal identifier (only relevant to provide a human readable name to the ERC-7730 file)
+All context support an `$id` sub-key as an internal identifier (only relevant to provide a human-readable name to the ERC-7730 file)
 
 #### EVM smart contract binding context (denoted 'calldata')
 
@@ -363,14 +363,14 @@ A wallet MUST verify that the ABI is applicable to the contract being called.
 
 All paths described in the ERC-7730 starting with the `#.` root node (typically used to describe a single parameter of the contract call) are using selectors names coming from the parameter names of the ABI referenced.
 
-The `contract.abi` key is mandatory for a smartcontract ERC-7730 file.
+The `contract.abi` key is mandatory for a smart contract ERC-7730 file.
 
 **`contract.deployments`**
 
 An array of deployments options. Wallets MUST verify that the target chain and contract address of the containing transaction MUST match one of these deployment options.
 
 A deployment option is an object with:
-  * `chainId`: an [EIP-155 identifier](./eip-155.md) of the chain the descibed contract is deployed on.
+  * `chainId`: an [EIP-155 identifier](./eip-155.md) of the chain the described contract is deployed on.
   * `address`: the address of the deployed contract on specified `chainId` chain.
 
 ---
@@ -384,7 +384,7 @@ A wallet MAY use this URL to check unknown addresses, default is to fail constra
 
 **`contract.factory`**
 
-An object describing the factory used to deploy smartcontracts that can be clear signed using the ERC-7730 file.
+An object describing the factory used to deploy smart contracts that can be clear signed using the ERC-7730 file.
 
 A factory is a json object with:
 * `deployEvent` key, specifying the solidity signature of the events emitted when deploying a clear-signable contract.
@@ -428,7 +428,7 @@ In the sample EIP-712 message included in the specification [here](../assets/eip
                             { "name": "name", "type": "string" },
                             { "name": "version", "type": "string" },
                             { "name": "chainId", "type": "uint256" },
-                            { "name": "verifyingContract", "type": "address" },
+                            { "name": "verifyingContract", "type": "address" }
                         ],
                         "Person": [
                             { "name": "name", "type": "string" },
@@ -438,7 +438,7 @@ In the sample EIP-712 message included in the specification [here](../assets/eip
                             { "name": "from", "type": "Person" },
                             { "name": "to", "type": "Person" },
                             { "name": "contents", "type": "string" }
-                        ],
+                        ]
                     },
                     "primaryType": "Mail"
                 }
@@ -470,16 +470,16 @@ When an `eip712.deployments` constraint is set, the wallet MUST verify that:
 * The `chainId` and `verifyingContract` values in the domain match ONE of the deployment option specified in `eip712.deployments`
 
 A deployment option is an object with:
-* `chainId`: an EIP-155 identifier of the chain the descibed contract is deployed on.
+* `chainId`: an EIP-155 identifier of the chain the described contract is deployed on.
 * `address`: the address of the deployed contract on specified `chainId` chain.
 
 **`eip712.domainSeparator`**
 
-An hex string containg the value of the *domainSeparator* to check. 
+An hex string containing the value of the *domainSeparator* to check. 
 
 Wallet MUST verify that the message *EIP-712 Domain* hashes (as defined in EIP-712) to the value in `eip712.domainSeparator`. 
 
-When the exact construction of the EIP-712 domain is not known (for instance, when the smartcontract code only contains the hashe value of the domain separator), `domainSeparator` and `domain.verifyingContract` can still be used to target the right message recipients. 
+When the exact construction of the EIP-712 domain is not known (for instance, when the smart contract code only contains the hash value of the domain separator), `domainSeparator` and `domain.verifyingContract` can still be used to target the right message recipients. 
 
 *Examples*
 
@@ -545,7 +545,7 @@ A wallet MAY use this information to display additional details about the target
 
 The `token` key is only relevant for `contract` ERC-7730 files and only for contracts supporting an ERC-20 interface. 
 
-It contains the ERC-20 metadata when the contract itself does not support the optional calls to retrieve it. It SHOULD NOT be present if the contract does support the `name()`, `symbol()` and `decimals()` smartcontract calls. 
+It contains the ERC-20 metadata when the contract itself does not support the optional calls to retrieve it. It SHOULD NOT be present if the contract does support the `name()`, `symbol()` and `decimals()` smart contract calls. 
 
 The ERC-20 token metadata for the contract described is in the sub-keys `name`, `ticker` and `decimals`
 
@@ -566,11 +566,11 @@ It is a list of key / value pairs, the key being used to reference this constant
     }
 }
 ```
-This snippet introduces a constant `nativeAssetAddress` (an address typically used to represet the native network underying currency, which is smart contract specific). This constant can be referenced using the path `$.metadata.constants.nativeAssetAddress`
+This snippet introduces a constant `nativeAssetAddress` (an address typically used to represent the native network underlying currency, which is smart contract specific). This constant can be referenced using the path `$.metadata.constants.nativeAssetAddress`
 
 **`metadata.enums`**
 
-The `enums` key contains displayable values for parameters that are enumerations (in a loose sense including parameters taking fixed number of well known values). These `enums` are used to replace specific paramater values with a human readable one. 
+The `enums` key contains displayable values for parameters that are enumerations (in a loose sense including parameters taking fixed number of well known values). These `enums` are used to replace specific parameter values with a human-readable one. 
 
 Each key of the `enums` object is an *enumeration* name. Enumeration names can be referred to in the `display` section formatters by using a path starting with root node `$.` (i.e. `$.metadata.enums.ENUM_NAME`). 
 
@@ -581,7 +581,7 @@ An enum is a json object with a flat list of key / value pairs, each key being t
 
 Alternatively, rather than a json object with displayable values, an enum can be a simple string containing an URL. That URL MUST return the json object with the enumeration key-values.
 
-A wallet MAY use this URL to resolve more dynamic enumeration values uner the control of the owner of the URL.
+A wallet MAY use this URL to resolve more dynamic enumeration values under the control of the owner of the URL.
 
 *Examples*
 
@@ -589,11 +589,11 @@ A wallet MAY use this URL to resolve more dynamic enumeration values uner the co
 {
     "metadata": {
         "enums": {
-            "interestRateMode" : {
+            "interestRateMode": {
                 "1": "stable",
                 "2": "variable"
             },
-            "vaultIDs": "http://example.com/vaultIDs"
+            "vaultIDs": "https://example.com/vaultIDs"
         }
     }
 }
@@ -653,15 +653,15 @@ A *Structured data format specification* is used to describe how to format all t
 
 **`$id`**
 
-This key is purely internal and used to specify a human readable identifier for this specification.
+This key is purely internal and used to specify a human-readable identifier for this specification.
 
 **`intent`** 
 
-Use to specify the *intent* of the function call or message signature in a user friendly way.
+Use to specify the *intent* of the function call or message signature in a user-friendly way.
 
 An intent can take two forms:
-* A simple string with human readable content
-* A json object with a flat list of string key-value pairs, representing more complex intents. Both keys and values should be human readable and user friendly.
+* A simple string with human-readable content
+* A json object with a flat list of string key-value pairs, representing more complex intents. Both keys and values should be human-readable and user-friendly.
 
 Wallets SHOULD use this `intent` value to display a clear intent when reviewing the structured data before signature. When displaying a complex json intent, it is expected that keys represent labels, and values should be displayed after their label. 
 
@@ -679,7 +679,7 @@ Wallets SHOULD use this `intent` value to display a clear intent when reviewing 
     }
 }
 ```
-This snippet defines an intent for a withdraw function on a contract, with an expectation that the intent would be displayed in a structured way on the wallet screen.
+This snippet defines an intent for a withdrawal function on a contract, with an expectation that the intent would be displayed in a structured way on the wallet screen.
 
 **`fields`**
 
@@ -822,6 +822,7 @@ A slice on an array type means that the associated [field format specification](
                             "tokenPath": "params.path.[0:19]"
                         }
                     }
+                ]
             }
         }
     }
@@ -891,19 +892,19 @@ This section describes all container structure supported by this specification a
 
 #### EVM Transaction container
 
-| Value reference | Value Description | Examples |
-| --- | --- | --- |
-| @.from         | The address of the sender of the transaction | |
-| @.value        | The native currency value of the transaction | |
-| @.to           | The destination address of the containing transaction, ie the target smart contract address | |
+| Value reference | Value Description                                                                           | Examples |
+|-----------------|---------------------------------------------------------------------------------------------|----------|
+| @.from          | The address of the sender of the transaction                                                |          |
+| @.value         | The native currency value of the transaction                                                |          |
+| @.to            | The destination address of the containing transaction, ie the target smart contract address |          |
 
 #### EIP-712 container
 
-| Value reference | Value Description | Examples |
-| --- | --- | --- |
-| @.from         | The address of the signer of the message | |
-| @.value        | EIP-712 have no underlying currency value transferred, so a wallet MAY interpret it as 0 | |
-| @.to           | The verifying contract address, when known. If not known a wallet SHOULD reject using the ERC-7730 file to clear sign the message | |
+| Value reference | Value Description                                                                                                                 | Examples |
+|-----------------|-----------------------------------------------------------------------------------------------------------------------------------|----------|
+| @.from          | The address of the signer of the message                                                                                          |          |
+| @.value         | EIP-712 have no underlying currency value transferred, so a wallet MAY interpret it as 0                                          |          |
+| @.to            | The verifying contract address, when known. If not known a wallet SHOULD reject using the ERC-7730 file to clear sign the message |          |
 
 ### Field formats
 
@@ -912,160 +913,160 @@ In the following references, the format title is the value to use under the `for
 
 #### Integer formats
 
-Formats useable for uint/int solidity types. 
+Formats usable for uint/int solidity types. 
 
 ---
-| **`raw`** | |
-| --- | --- |
-| *Description*   | Display the integer as a raw int in natural, localized representation  |
-| *Parameters*    | None  |
-| *Examples*      | Value 1000 displayed as `1000`  |
+| **`raw`**     |                                                                       |
+|---------------|-----------------------------------------------------------------------|
+| *Description* | Display the integer as a raw int in natural, localized representation |
+| *Parameters*  | None                                                                  |
+| *Examples*    | Value 1000 displayed as `1000`                                        |
 
 ---
-| **`amount`** | |
-| --- | --- |
-| *Description*   | Display as an amount in native currency, using best ticker / magnitude match  |
-| *Parameters*    | None  |
-| *Examples*      | Value 0x2c1c986f1c48000 is displayed as `0.19866144 ETH`  |
+| **`amount`**  |                                                                              |
+|---------------|------------------------------------------------------------------------------|
+| *Description* | Display as an amount in native currency, using best ticker / magnitude match |
+| *Parameters*  | None                                                                         |
+| *Examples*    | Value 0x2c1c986f1c48000 is displayed as `0.19866144 ETH`                     |
 
 ---
-| **`tokenAmount`** | |
-| --- | --- |
-| *Description*   | Convert value using token decimals, and append token ticker name. If value is above optional `threshold`, display instead `message` with ticker. |
-| *Parameters*    | ---  |
-| `tokenPath`               | path reference to the address of the token contract. Used to associate correct ticker. If ticker is not found or tokenPath is not set, the wallet SHOULD display the raw value instead with an "Unknown token" warning |
-| `nativeCurencyAddress`    | Either a string or an array of strings. If the address pointed to by `tokenPath` is equal to one of the addresses in `nativeCurrencyAddress`, the tokenAmount is interpreted as expressed in native currency |
-| `threshold`               | integer value, above which value is displayed as a special message. Optional  |
-| `message`                 | message to display above threshold. Optional, defaults to "Unlimited" |
-| *Examples*      | --- |
-| `1 DAI`         | Field value = 1000000 <br> `tokenPath` =0x6B17...1d0F (DAI, 6 decimals)   |
-| `Unlimited DAI` | Field value = 0xFFFFFFFF <br> `tokenPath` =0x6B17...1d0F (DAI, 6 decimals) <br> `threshold` "0xFFFFFFFF" |
-| `Max DAI`       | Field value = 0xFFFFFFFF <br> `tokenPath` =0x6B17...1d0F (DAI, 6 decimals) <br> `threshold` "0xFFFFFFFF" <br> `message` = "Max" |
+| **`tokenAmount`**      |                                                                                                                                                                                                                        |
+|------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| *Description*          | Convert value using token decimals, and append token ticker name. If value is above optional `threshold`, display instead `message` with ticker.                                                                       |
+| *Parameters*           | ---                                                                                                                                                                                                                    |
+| `tokenPath`            | path reference to the address of the token contract. Used to associate correct ticker. If ticker is not found or tokenPath is not set, the wallet SHOULD display the raw value instead with an "Unknown token" warning |
+| `nativeCurencyAddress` | Either a string or an array of strings. If the address pointed to by `tokenPath` is equal to one of the addresses in `nativeCurrencyAddress`, the tokenAmount is interpreted as expressed in native currency           |
+| `threshold`            | integer value, above which value is displayed as a special message. Optional                                                                                                                                           |
+| `message`              | message to display above threshold. Optional, defaults to "Unlimited"                                                                                                                                                  |
+| *Examples*             | ---                                                                                                                                                                                                                    |
+| `1 DAI`                | Field value = 1000000 <br> `tokenPath` =0x6B17...1d0F (DAI, 6 decimals)                                                                                                                                                |
+| `Unlimited DAI`        | Field value = 0xFFFFFFFF <br> `tokenPath` =0x6B17...1d0F (DAI, 6 decimals) <br> `threshold` "0xFFFFFFFF"                                                                                                               |
+| `Max DAI`              | Field value = 0xFFFFFFFF <br> `tokenPath` =0x6B17...1d0F (DAI, 6 decimals) <br> `threshold` "0xFFFFFFFF" <br> `message` = "Max"                                                                                        |
 
 ---
-| **`nftName`** | |
-| --- | --- |
-| *Description*   | Display value as a specific NFT in a collection, if found by wallet, or fallback to a raw int token ID if not |
-| *Parameters*     | ---  |
-| `collectionPath` | A path reference to the collection address |
-| *Examples*       | --- |
-| `ETH-USD December 10, 2021 3:48 PM GMT` | Field Value = 674 <br> `collectionPath` = "0xaa3a...84ea" (from rarible) |
+| **`nftName`**                           |                                                                                                               |
+|-----------------------------------------|---------------------------------------------------------------------------------------------------------------|
+| *Description*                           | Display value as a specific NFT in a collection, if found by wallet, or fallback to a raw int token ID if not |
+| *Parameters*                            | ---                                                                                                           |
+| `collectionPath`                        | A path reference to the collection address                                                                    |
+| *Examples*                              | ---                                                                                                           |
+| `ETH-USD December 10, 2021 3:48 PM GMT` | Field Value = 674 <br> `collectionPath` = "0xaa3a...84ea" (from rarible)                                      |
 
 ---
-| **`date`** | |
-| --- | --- |
-| *Description*   | Display int as a date, using specified encoding. Date display RECOMMENDED use of RFC 3339 |
-| *Parameters*    | ---  |
-| `"encoding": "timestamp"`  | value is encoded as a unix timestamp |
-| `"encoding": "blockheight"`  | value is a blockheight and is converted to an approximate unix timestamp |
-| *Examples*      | --- |
-| `2024-02-29T08:27:12`  | Field Value = 1709191632 <br> `encoding` = "timestamp"  |
-| `2024-02-29T09:00:35` | Field Value = 19332140 <br> `encoding` = "blockheight" |
+| **`date`**                  |                                                                                           |
+|-----------------------------|-------------------------------------------------------------------------------------------|
+| *Description*               | Display int as a date, using specified encoding. Date display RECOMMENDED use of RFC 3339 |
+| *Parameters*                | ---                                                                                       |
+| `"encoding": "timestamp"`   | value is encoded as a unix timestamp                                                      |
+| `"encoding": "blockheight"` | value is a blockheight and is converted to an approximate unix timestamp                  |
+| *Examples*                  | ---                                                                                       |
+| `2024-02-29T08:27:12`       | Field Value = 1709191632 <br> `encoding` = "timestamp"                                    |
+| `2024-02-29T09:00:35`       | Field Value = 19332140 <br> `encoding` = "blockheight"                                    |
 
 ---
-| **`duration`** | |
-| --- | --- |
-| *Description*   | Display int as a duration interpreted in seconds and represented as a duration HH:MM:ss |
-| *Parameters*    | None  |
-| *Examples*      | --- |
+| **`duration`** |                                                                                         |
+|----------------|-----------------------------------------------------------------------------------------|
+| *Description*  | Display int as a duration interpreted in seconds and represented as a duration HH:MM:ss |
+| *Parameters*   | None                                                                                    |
+| *Examples*     | ---                                                                                     |
 
 ---
-| **`unit`** | |
-| --- | --- |
-| *Description*   | Value is converted to a float using `decimals` (`value / 10^decimals`) and displayed appending the corresponding unit. If `prefix` is true, the value is further converted to scientific representation, minimizing the significand and converting the exponent to an SI prefix added in front of the unit symbol |
-| *Parameters*    | ---  |
-| `base`          | The symbol of the base unit, an SI unit or other acceptable symbols like "%", "bps" |
-| `decimals`      | Number of decimals in integer representation, defaults to 0 |
-| `prefix`        | A boolean indicating whether an SI prefix should be appended, defaults to `False`  |
-| *Examples*      | --- |
+| **`unit`**    |                                                                                                                                                                                                                                                                                                                   |
+|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| *Description* | Value is converted to a float using `decimals` (`value / 10^decimals`) and displayed appending the corresponding unit. If `prefix` is true, the value is further converted to scientific representation, minimizing the significand and converting the exponent to an SI prefix added in front of the unit symbol |
+| *Parameters*  | ---                                                                                                                                                                                                                                                                                                               |
+| `base`        | The symbol of the base unit, an SI unit or other acceptable symbols like "%", "bps"                                                                                                                                                                                                                               |
+| `decimals`    | Number of decimals in integer representation, defaults to 0                                                                                                                                                                                                                                                       |
+| `prefix`      | A boolean indicating whether an SI prefix should be appended, defaults to `False`                                                                                                                                                                                                                                 |
+| *Examples*    | ---                                                                                                                                                                                                                                                                                                               |
 
 ---
-| **`enum`** | |
-| --- | --- |
-| *Description*   | Value is converted using referenced constant enumeration values |
-| *Parameters*    | ---  |
-| `$ref`          | An internal path (starting with root node `$.`) to an enumerations in `metadata.constants` |
-| *Examples*      |  |
+| **`enum`**    |                                                                                            |
+|---------------|--------------------------------------------------------------------------------------------|
+| *Description* | Value is converted using referenced constant enumeration values                            |
+| *Parameters*  | ---                                                                                        |
+| `$ref`        | An internal path (starting with root node `$.`) to an enumerations in `metadata.constants` |
+| *Examples*    |                                                                                            |
 
 #### String formats
 
-Formats useable for strings.
+Formats usable for strings.
 
 ---
-| **`raw`** | |
-| --- | --- |
-| *Description*   | Display as an UTF-8 encoded string |
-| *Parameters*    | None  |
-| *Examples*      | --- |
-| `Ledger`        | Field Value = ['4c','65','64','67','65','72'] |
+| **`raw`**     |                                               |
+|---------------|-----------------------------------------------|
+| *Description* | Display as an UTF-8 encoded string            |
+| *Parameters*  | None                                          |
+| *Examples*    | ---                                           |
+| `Ledger`      | Field Value = ['4c','65','64','67','65','72'] |
 
 #### Bytes formats
 
-Formats useable for bytes
+Formats usable for bytes
 
 ---
-| **`raw`** | |
-| --- | --- |
-| *Description*   | Display byte array as an hex-encoded string |
-| *Parameters*    | None  |
-| *Examples*      | --- |
-| `123456789A`    | Field Value = Value ['12','34','56','78','9a'] |
+| **`raw`**     |                                                |
+|---------------|------------------------------------------------|
+| *Description* | Display byte array as an hex-encoded string    |
+| *Parameters*  | None                                           |
+| *Examples*    | ---                                            |
+| `123456789A`  | Field Value = Value ['12','34','56','78','9a'] |
 
 ---
-| **`calldata`** | |
-| --- | --- |
-| *Description*   | Data contains a call to another smartcontract. To look for relevant ERC-7730 files matching this embedded calldata, use `callee` parameter and `selector`. If an ERC-7730 is not found or if embedded calldata are not supported by the wallet, it MAY display a hash of the embedded calldata instead, with target `calleePath` resolved to a trusted name if possible.  |
-| *Parameters*    | ---  |
-| `selector`      | Optional selector, if not present the first 4 bytes of the calldata are interpreted as the selector |
-| `calleePath`    | A path reference to the contract being called |
-| *Examples*      |  |
+| **`calldata`** |                                                                                                                                                                                                                                                                                                                                                                           |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| *Description*  | Data contains a call to another smart contract. To look for relevant ERC-7730 files matching this embedded calldata, use `callee` parameter and `selector`. If an ERC-7730 is not found or if embedded calldata are not supported by the wallet, it MAY display a hash of the embedded calldata instead, with target `calleePath` resolved to a trusted name if possible. |
+| *Parameters*   | ---                                                                                                                                                                                                                                                                                                                                                                       |
+| `selector`     | Optional selector, if not present the first 4 bytes of the calldata are interpreted as the selector                                                                                                                                                                                                                                                                       |
+| `calleePath`   | A path reference to the contract being called                                                                                                                                                                                                                                                                                                                             |
+| *Examples*     |                                                                                                                                                                                                                                                                                                                                                                           |
 
 #### Address
 
-Formats useable for address
+Formats usable for address
 
 ---
-| **`raw`** | |
-| --- | --- |
-| *Description*   | Display address as an [EIP-55](./eip-55.md) formatted string. Truncation is device dependent  |
-| *Parameters*    | None  |
-| *Examples*      | --- |
-| `0x5aAe...eAed`       | Field Value 0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed  |
+| **`raw`**       |                                                                                              |
+|-----------------|----------------------------------------------------------------------------------------------|
+| *Description*   | Display address as an [EIP-55](./eip-55.md) formatted string. Truncation is device dependent |
+| *Parameters*    | None                                                                                         |
+| *Examples*      | ---                                                                                          |
+| `0x5aAe...eAed` | Field Value 0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed                                       |
 
 ---
-| **`addressName`** | |
-| --- | --- |
-| *Description*   | Display address as a trusted name if a trusted source exists, an EIP-55 formatted address otherwise. See [next section](#address-trusted-sources) for a reference of trusted sources |
-| *Parameters*    | ---  |
-| `types`          | An array of expected types of the address (see [next section](#address-types-and-sources)). If set, the wallet SHOULD check that the address matches one of the types provided |
-| `sources`        | An array of acceptable sources for names (see [next section](#address-types-and-sources)). If set, the wallet SHOULD restrict name lookup to relevant sources |
-| *Examples*      | --- |
-| `vitalik.eth`      | Field Value 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045  |
+| **`addressName`** |                                                                                                                                                                                        |
+|-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| *Description*     | Display address as a trusted name if a trusted source exists, an EIP-55 formatted address otherwise. See [next section](#address-types-and-sources) for a reference of trusted sources |
+| *Parameters*      | ---                                                                                                                                                                                    |
+| `types`           | An array of expected types of the address (see [next section](#address-types-and-sources)). If set, the wallet SHOULD check that the address matches one of the types provided         |
+| `sources`         | An array of acceptable sources for names (see [next section](#address-types-and-sources)). If set, the wallet SHOULD restrict name lookup to relevant sources                          |
+| *Examples*        | ---                                                                                                                                                                                    |
+| `vitalik.eth`     | Field Value 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045                                                                                                                                 |
 
 #### Address types and sources
 
-Address names trusted sources specify which type and source of trusted names SHOULD be used to replace an address with a human readable names. 
+Address names trusted sources specify which type and source of trusted names SHOULD be used to replace an address with a human-readable names. 
 
 When specified a wallet MUST only use specified sources to resolve address names. Wallet MUST verify the type of the address if able to. 
 
 When omitted, a wallet MAY use any source to resolve an address.
 
-| Address type  | Description |
-| ---           | --- |
-| wallet        | Address is an account controlled by the wallet |
-| eoa           | Address is an Externally Owned Account         |
-| contract      | Address is a well known smartcontract  |
-| token         | Address is a well known ERC-20 token  |
-| collection    | Address is a well known NFT collection  |
+| Address type | Description                                    |
+|--------------|------------------------------------------------|
+| wallet       | Address is an account controlled by the wallet |
+| eoa          | Address is an Externally Owned Account         |
+| contract     | Address is a well known smart contract         |
+| token        | Address is a well known ERC-20 token           |
+| collection   | Address is a well known NFT collection         |
 
 A wallet MAY verify that a `wallet` address is in fact controlled by the wallet, and reject signing if not the case.
 
 Sources values are wallet manufacturer specific. Some example values could be:
 
-| Source type | Description |
-|-------------| --- |
+| Source type | Description                                                                                                                        |
+|-------------|------------------------------------------------------------------------------------------------------------------------------------|
 | local       | Address MAY be replaced with a local name trusted by user. Wallets MAY consider that `local` setting for `sources` is always valid |
-| ens         | Address MAY be replaced with an associated ENS domain |
+| ens         | Address MAY be replaced with an associated ENS domain                                                                              |
 
 ### Wallets
 
@@ -1092,7 +1093,7 @@ Wide support by wallets is key for adoption of this specification.
 Hardware wallets tend to have more limited capabilities that will impact what they can display securely, especially since the intention of the specification is to create a strong security binding between the spec and the data being reviewed.
 
 This consideration is driving a few choices done for ERC-7730:
-* Complex UI constructs like layouts, grouping and re-ordering of fields have been left to a wallet specific section, yet unspecified. After a time, we may see patterns emerge between wallets in term of minimal features.
+* Complex UI constructs like layouts, grouping and re-ordering of fields have been left to a wallet specific section, yet unspecified. After a time, we may see patterns emerge between wallets in terms of minimal features.
 * Representation of fields has been created to allow "flattening" the list of fields, when handling complex message structures. This flattened representation is expected to work better with Hardware wallets in particular, and is recommended at first.
 * Some formatters that require recursive constructs, like `calldata` are expected to work with restrictions at first, especially on Hardware wallets.  
 
@@ -1120,7 +1121,7 @@ It is also expected that the way the formatting is applied to the data is not vu
 
 ### Curation model
 
-The second attack is not directly mitigated by the specification (beyond providing recommendations). It is rather expected that wallets will use a two step curation process, and NOT trust ERC-7730 files coming directly from the public repository. 
+The second attack is not directly mitigated by the specification (beyond providing recommendations). It is rather expected that wallets will use a two-step curation process, and NOT trust ERC-7730 files coming directly from the public repository. 
 
 Rather wallets SHOULD do some additional verifications on the ERC-7730 file itself and corresponding dApps before trusting the file to build their user's UI.
 


### PR DESCRIPTION
went through jetbrains checks:
 - fixed a few typos
 - applied a few grammatical suggestions
 - formatted tables
 - fixed some invalid JSON examples

