### PR TITLE
spec: add support for providing a single URL for all EIP-712 schemas

### DIFF
--- a/specs/erc7730-v1.schema.json
+++ b/specs/erc7730-v1.schema.json
@@ -129,22 +129,32 @@
                     "properties" : {
                         "schemas" : 
                         {
-                            "title": "EIP 712 Schemas constraint",
-                            "type": "array",
-                            "description": "An array of EIP712 schemas that can be used to validate the message. The message types should match exactly one of those schema.",
-                            "items": {
-                                "oneOf": [
-                                    {
-                                        "$ref": "#/$definitions/eip712-json-schema"
-                                    },
-                                    {
-                                        "title": "An EIP712 Schema url",
-                                        "description": "URL of an EIP712 Schema bound to this file.",
-                                        "type": "string",
-                                        "format": "uri-reference"
+                            "oneOf": [
+                                {
+                                    "title": "An EIP712 Schemas url",
+                                    "description": "URL of an array of EIP712 schemas that can be used to validate the message. The message types should match exactly one of those schema.",
+                                    "type": "string",
+                                    "format": "uri-reference"
+                                },
+                                {
+                                    "title": "EIP 712 Schemas constraint",
+                                    "type": "array",
+                                    "description": "An array of EIP712 schemas that can be used to validate the message. The message types should match exactly one of those schema.",
+                                    "items": {
+                                        "oneOf": [
+                                            {
+                                                "$ref": "#/$definitions/eip712-json-schema"
+                                            },
+                                            {
+                                                "title": "An EIP712 Schema url",
+                                                "description": "URL of an EIP712 Schema bound to this file.",
+                                                "type": "string",
+                                                "format": "uri-reference"
+                                            }
+                                        ]
                                     }
-                                ]
-                            }
+                                }
+                            ]
                         },
                         "domain": {
                             "title": "EIP 712 Domain Binding constraint",


### PR DESCRIPTION
- `schemas` property can be `uri-reference | array[schema | uri-reference]`
- `uri-reference` can be a `<scheme>://` URL, or directly a relative (or absolute) path (`./foo` or `/foo`)
- Note that our implementation will allow `https` and `file` URL schemes, or relative paths. This is not enforced by schema/spec, not sure if it should

