### PR TITLE
fix: add missing parameters for `addressName` formats

### DIFF
--- a/ercs/calldata-erc20-tokens.json
+++ b/ercs/calldata-erc20-tokens.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "../specs/erc7730-v1.schema.json",
     "context": {
         "contract" : {
             "abi": [
@@ -60,7 +61,16 @@
                     {
                         "path": "_to",
                         "label": "To",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     },
                     {
                         "path": "_value",
@@ -79,7 +89,16 @@
                     {
                         "path": "_spender",
                         "label": "Spender",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     },
                     {
                         "path": "_value",

--- a/ercs/calldata-erc721-nfts.json
+++ b/ercs/calldata-erc721-nfts.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "../specs/erc7730-v1.schema.json",
     "context": {
         "contract" : {
             "abi": [
@@ -83,15 +84,42 @@
         "definitions": {
             "from" : {
                 "label": "From",
-                "format": "addressName"
+                "format": "addressName",
+                "params": {
+                    "types": [
+                        "eoa"
+                    ],
+                    "sources": [
+                        "local",
+                        "ens"
+                    ]
+                }
             },
             "to" : {
                 "label": "To",
-                "format": "addressName"
+                "format": "addressName",
+                "params": {
+                    "types": [
+                        "eoa"
+                    ],
+                    "sources": [
+                        "local",
+                        "ens"
+                    ]
+                }
             },
-            "operator":{ 
+            "operator":{
                 "label": "Operator",
-                "format": "addressName"
+                "format": "addressName",
+                "params": {
+                    "types": [
+                        "contract"
+                    ],
+                    "sources": [
+                        "local",
+                        "ens"
+                    ]
+                }
             },
             "tokenId" : {
                 "label": "NFT",
@@ -131,12 +159,18 @@
                 "$id": "setApprovalForAll",
                 "intent": "Manage operator rights for",
                 "fields": [
-                    { 
+                    {
                         "path": "@.to",
                         "label": "Collection",
                         "format": "addressName",
                         "params": {
-                            "types": ["collection"]
+                            "types": [
+                                "collection"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
                         }
                     },
                     { "path": "_operator", "$ref": "$.display.definitions.operator" },

--- a/ercs/eip712-erc2612-permit.json
+++ b/ercs/eip712-erc2612-permit.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "../specs/erc7730-v1.schema.json",
     "context": {
         "eip712": {
             "schemas": [
@@ -58,7 +59,16 @@
                     {
                         "path": "spender",
                         "label": "Spender",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "contract"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     },
                     {
                         "path": "value",

--- a/registry/aave/calldata-lpv2.json
+++ b/registry/aave/calldata-lpv2.json
@@ -58,7 +58,16 @@
                     {
                         "path": "onBehalfOf",
                         "format": "addressName",
-                        "label": "For debt holder"
+                        "label": "For debt holder",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     }
                 ],
                 "required": ["amount", "rateMode", "onBehalfOf"]
@@ -71,7 +80,13 @@
                         "format": "addressName",
                         "label": "For asset",
                         "params": {
-                            "types": ["token"]
+                            "types": [
+                                "token"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
                         }
                     },
                     {
@@ -98,7 +113,16 @@
                     {
                         "path": "to",
                         "format": "addressName",
-                        "label": "To recipient"
+                        "label": "To recipient",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     }
                 ],
                 "required": ["amount", "to"]
@@ -111,7 +135,13 @@
                         "format": "addressName",
                         "label": "For asset",
                         "params": {
-                            "types": ["token"]
+                            "types": [
+                                "token"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
                         }
                     },
                     {
@@ -147,7 +177,16 @@
                     {
                         "path": "onBehalfOf",
                         "format": "addressName",
-                        "label": "Debtor"
+                        "label": "Debtor",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     }
                 ],
                 "required": ["amount", "onBehalfOf", "interestRateMode"]
@@ -167,7 +206,16 @@
                     {
                         "path": "onBehalfOf",
                         "format": "addressName",
-                        "label": "Collateral recipient"
+                        "label": "Collateral recipient",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     }
                 ],
                 "required": ["amount", "onBehalfOf"]

--- a/registry/lido/calldata-OssifiableProxy.json
+++ b/registry/lido/calldata-OssifiableProxy.json
@@ -43,7 +43,16 @@
                     {
                         "path": "_owner",
                         "label": "Beneficiary",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     }
                 ],
                 "required": ["_amounts", "_owner"]
@@ -62,7 +71,16 @@
                     {
                         "path": "_owner",
                         "label": "Beneficiary",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     }
                 ],
                 "required": ["_amounts", "_owner"],
@@ -82,7 +100,16 @@
                     {
                         "path": "_owner",
                         "label": "Beneficiary",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     }
                 ],
                 "required": ["_amounts", "_owner"]
@@ -101,7 +128,16 @@
                     {
                         "path": "_owner",
                         "label": "Beneficiary",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     }
                 ],
                 "required": ["_amounts", "_owner"],
@@ -118,7 +154,16 @@
                     {
                         "path": "@.from",
                         "label": "Beneficiary",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     }
                 ],
                 "required": ["_requestId", "@.from"]
@@ -134,7 +179,16 @@
                     {
                         "path": "@.from",
                         "label": "Beneficiary",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     }
                 ],
                 "required": ["_requestIds", "@.from"],
@@ -151,7 +205,16 @@
                     {
                         "path": "_recipient",
                         "label": "Beneficiary",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     }
                 ],
                 "required": ["_requestIds", "_recipient"],

--- a/registry/lido/calldata-stETH.json
+++ b/registry/lido/calldata-stETH.json
@@ -36,7 +36,16 @@
                     {
                         "path": "_referral",
                         "label": "Referral",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     }
                 ],
                 "required": ["@.value"]
@@ -47,7 +56,16 @@
                     {
                         "path": "_spender",
                         "label": "Spender",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "contract"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     },
                     {
                         "path": "_amount",

--- a/registry/lido/calldata-wstETH.json
+++ b/registry/lido/calldata-wstETH.json
@@ -60,7 +60,16 @@
                     {
                         "path": "spender",
                         "label": "Spender",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "contract"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     },
                     {
                         "path": "amount",

--- a/registry/paraswap/calldata-AugustusSwapper.json
+++ b/registry/paraswap/calldata-AugustusSwapper.json
@@ -118,10 +118,7 @@
                     },
                     {
                         "path": "data.beneficiary",
-                        "$ref": "$.display.definitions.beneficiary",
-                        "params": {
-                            "tokenPath": "data.beneficiary"
-                        }
+                        "$ref": "$.display.definitions.beneficiary"
                     }
                 ],
                 "required": [
@@ -150,10 +147,7 @@
                     },
                     {
                         "path": "data.beneficiary",
-                        "$ref": "$.display.definitions.beneficiary",
-                        "params": {
-                            "tokenPath": "data.beneficiary"
-                        }
+                        "$ref": "$.display.definitions.beneficiary"
                     }
                 ],
                 "required": [
@@ -262,10 +256,7 @@
                     },
                     {
                         "path": "data.beneficiary",
-                        "$ref": "$.display.definitions.beneficiary",
-                        "params": {
-                            "tokenPath": "data.beneficiary"
-                        }
+                        "$ref": "$.display.definitions.beneficiary"
                     }
                 ],
                 "required": [
@@ -453,10 +444,7 @@
                     },
                     {
                         "path": "data.beneficiary",
-                        "$ref": "$.display.definitions.beneficiary",
-                        "params": {
-                            "tokenPath": "data.beneficiary"
-                        }
+                        "$ref": "$.display.definitions.beneficiary"
                     }
                 ],
                 "required": [

--- a/registry/paraswap/calldata-AugustusSwapper.json
+++ b/registry/paraswap/calldata-AugustusSwapper.json
@@ -59,7 +59,16 @@
             },
             "beneficiary": {
                 "label": "Beneficiary",
-                "format": "addressName"
+                "format": "addressName",
+                "params": {
+                    "types": [
+                        "eoa"
+                    ],
+                    "sources": [
+                        "local",
+                        "ens"
+                    ]
+                }
             },
             "exchange": {
                 "label": "Exchange",
@@ -67,6 +76,10 @@
                 "params": {
                     "types": [
                         "contract"
+                    ],
+                    "sources": [
+                        "local",
+                        "ens"
                     ]
                 }
             },
@@ -76,6 +89,10 @@
                 "params": {
                     "types": [
                         "contract"
+                    ],
+                    "sources": [
+                        "local",
+                        "ens"
                     ]
                 }
             }

--- a/registry/poap/calldata-PoapBridge.json
+++ b/registry/poap/calldata-PoapBridge.json
@@ -36,7 +36,16 @@
                     {
                         "path": "receiver",
                         "label": "Beneficiary",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     },
                     {
                         "path": "expirationTime",

--- a/registry/quickswap/calldata-QuickSwap.json
+++ b/registry/quickswap/calldata-QuickSwap.json
@@ -46,7 +46,16 @@
                     {
                         "path": "to",
                         "label": "Beneficiary",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     },
                     {
                         "path": "deadline",
@@ -79,7 +88,16 @@
                     {
                         "path": "to",
                         "label": "Beneficiary",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     },
                     {
                         "path": "deadline",
@@ -107,7 +125,16 @@
                    {
                         "path": "to",
                         "label": "Beneficiary",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                    },
                    {
                         "path": "deadline",
@@ -143,7 +170,16 @@
                     {
                         "path": "to",
                         "label": "Beneficiary",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     },
                     {
                         "path": "deadline",
@@ -179,7 +215,16 @@
                     {
                         "path": "to",
                         "label": "Beneficiary",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     },
                     {
                         "path": "deadline",
@@ -212,7 +257,16 @@
                     {
                         "path": "to",
                         "label": "Beneficiary",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     },
                     {
                         "path": "deadline",
@@ -240,7 +294,16 @@
                     {
                         "path": "to",
                         "label": "Beneficiary",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     },
                     {
                         "path": "deadline",
@@ -292,7 +355,16 @@
                     {
                         "path": "to",
                         "label": "Beneficiary",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     },
                     {
                         "path": "deadline",
@@ -333,7 +405,16 @@
                     {
                         "path": "to",
                         "label": "Beneficiary",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     },
                     {
                         "path": "deadline",
@@ -369,7 +450,16 @@
                     {
                         "path": "to",
                         "label": "Beneficiary",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     },
                     {
                         "path": "deadline",
@@ -402,7 +492,16 @@
                     {
                         "path": "to",
                         "label": "Beneficiary",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     },
                     {
                         "path": "deadline",
@@ -438,7 +537,16 @@
                     {
                         "path": "to",
                         "label": "Beneficiary",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     },
                     {
                         "path": "deadline",
@@ -471,7 +579,16 @@
                     {
                         "path": "to",
                         "label": "Beneficiary",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     },
                     {
                         "path": "deadline",
@@ -504,7 +621,16 @@
                     {
                         "path": "to",
                         "label": "Beneficiary",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     },
                     {
                         "path": "deadline",
@@ -537,7 +663,16 @@
                     {
                         "path": "to",
                         "label": "Beneficiary",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     },
                     {
                         "path": "deadline",

--- a/registry/uniswap/calldata-UniswapV3Router02.json
+++ b/registry/uniswap/calldata-UniswapV3Router02.json
@@ -48,7 +48,16 @@
                     {
                         "path": "params.recipient",
                         "label": "Beneficiary",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     }
                 ],
                 "required": ["params.amountIn", "params.amountOutMinimum", "params.recipient"]
@@ -86,7 +95,16 @@
                     {
                         "path": "params.recipient",
                         "label": "Beneficiary",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     }
                 ],
                 "required": ["params.amountIn", "params.amountOutMininimum", "params.fee", "params.recipient"]
@@ -114,7 +132,16 @@
                     {
                         "path": "params.recipient",
                         "label": "Beneficiary",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     }
                 ],
                 "required": ["params.amountInMaximum", "params.amountOut", "params.recipient"]
@@ -152,7 +179,16 @@
                     {
                         "path": "params.recipient",
                         "label": "Beneficiary",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "eoa"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     }
                 ]
             },

--- a/registry/uniswap/eip712-UniswapX-DutchOrder.json
+++ b/registry/uniswap/eip712-UniswapX-DutchOrder.json
@@ -142,7 +142,16 @@
                     {
                         "path": "spender",
                         "label": "Approve to spender",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "contract"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     },
                     {
                         "path": "permitted.amount",
@@ -174,7 +183,16 @@
                             {
                                 "path": "recipient",
                                 "label": "On Addresses",
-                                "format": "addressName"
+                                "format": "addressName",
+                                "params": {
+                                    "types": [
+                                        "contract"
+                                    ],
+                                    "sources": [
+                                        "local",
+                                        "ens"
+                                    ]
+                                }
                             }
                         ]
                     },

--- a/registry/uniswap/eip712-UniswapX-ExclusiveDutchOrder.json
+++ b/registry/uniswap/eip712-UniswapX-ExclusiveDutchOrder.json
@@ -151,7 +151,16 @@
                     {
                         "path": "spender",
                         "label": "Approve to spender",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "contract"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     },
                     {
                         "path": "permitted.amount",
@@ -183,7 +192,16 @@
                             {
                                 "path": "recipient",
                                 "label": "On Addresses",
-                                "format": "addressName"
+                                "format": "addressName",
+                                "params": {
+                                    "types": [
+                                        "contract"
+                                    ],
+                                    "sources": [
+                                        "local",
+                                        "ens"
+                                    ]
+                                }
                             }
                         ]
                     },

--- a/registry/uniswap/eip712-UniswapX-LimitOrder.json
+++ b/registry/uniswap/eip712-UniswapX-LimitOrder.json
@@ -124,7 +124,16 @@
                     {
                         "path": "spender",
                         "label": "Approve to spender",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "contract"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     },
                     {
                         "path": "permitted.amount",
@@ -156,7 +165,16 @@
                             {
                                 "path": "recipient",
                                 "label": "On Address",
-                                "format": "addressName"
+                                "format": "addressName",
+                                "params": {
+                                    "types": [
+                                        "contract"
+                                    ],
+                                    "sources": [
+                                        "local",
+                                        "ens"
+                                    ]
+                                }
                             }
                         ]
                     },

--- a/registry/uniswap/eip712-uniswap-permit2.json
+++ b/registry/uniswap/eip712-uniswap-permit2.json
@@ -122,7 +122,16 @@
                         {
                             "path": "spender",
                             "label": "Spender",
-                            "format": "addressName"
+                            "format": "addressName",
+                            "params": {
+                                "types": [
+                                    "contract"
+                                ],
+                                "sources": [
+                                    "local",
+                                    "ens"
+                                ]
+                            }
                         },
                         {
                             "path": "details.amount",
@@ -158,7 +167,16 @@
                     {
                         "path": "spender",
                         "label": "Spender",
-                        "format": "addressName"
+                        "format": "addressName",
+                        "params": {
+                            "types": [
+                                "contract"
+                            ],
+                            "sources": [
+                                "local",
+                                "ens"
+                            ]
+                        }
                     },
                     {
                         "path": "details.[]",


### PR DESCRIPTION
`types` and `sources` are mandatory for `addressName` format

(actual values I used probably needs some refinement)

Related: https://github.com/LedgerHQ/python-erc7730/pull/112