### PR TITLE
Add Clear Signing Metadata for MyAsset Contract (v1.0)

### DIFF
--- a/registry/MyEntityName/calldata_MyAsset.json
+++ b/registry/MyEntityName/calldata_MyAsset.json
@@ -1,0 +1,53 @@
+{
+    "$schema": "https://github.com/LedgerHQ/clear-signing-erc7730-registry/blob/master/specs/erc7730-v1.schema.json",
+    "context": {
+      "$id": "MyAsset",
+      "contract": {
+        "name": "MyAsset",
+        "version": "1.0",
+        "description": "A contract for managing ownership and setting/retrieving a value.",
+        "abi": [
+          {
+            "inputs": [],
+            "name": "getValue",
+            "outputs": [{ "name": "", "type": "uint256" }],
+            "stateMutability": "view",
+            "type": "function"
+          },
+          {
+            "inputs": [{ "name": "_value", "type": "uint256" }],
+            "name": "setValue",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+          },
+          {
+            "inputs": [{ "name": "newOwner", "type": "address" }],
+            "name": "transferOwnership",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+          }
+        ],
+        "events": [
+          {
+            "name": "OwnershipTransferred",
+            "inputs": [
+              { "indexed": true, "name": "previousOwner", "type": "address" },
+              { "indexed": true, "name": "newOwner", "type": "address" }
+            ],
+            "type": "event"
+          },
+          {
+            "name": "ValueSet",
+            "inputs": [
+              { "indexed": false, "name": "_newValue", "type": "uint256" }
+            ],
+            "type": "event"
+          }
+        ],
+ 
+        "address": "0xf8e81D47203A594245E36C48e151709F0C19fBe8"
+      }
+    }
+  }


### PR DESCRIPTION
This pull request adds the metadata for the smart contract "MyAsset" version 1.0 to the ERC-7730 Clear Signing Registry. The contract includes the following key features:

- Contract Name: MyAsset
- Version: 1.0
- Description: A contract for managing ownership and setting/retrieving a value.
- Functions:
  - `setValue(uint256 _value)`: Sets a value in the contract.
  - `getValue()`: Retrieves the stored value.
  - `transferOwnership(address newOwner)`: Transfers ownership to a new address.
- Events:
  - `OwnershipTransferred(address indexed previousOwner, address indexed newOwner)`: Emitted when ownership is transferred.
  - `ValueSet(uint256 _newValue)`: Emitted when the value is set.

This metadata includes the contract's ABI, events, and contract address (`0xf8e81D47203A594245E36C48e151709F0C19fBe8`). The metadata is compliant with the ERC-7730 standard and validated against the schema.

Please review the metadata and merge it into the registry to enable clear signing support for the MyAsset contract on Ledger devices.
