### PR TITLE
Fix StarkGate descriptor

### DIFF
--- a/registry/starkgate/calldata-StarkGate-STRK.json
+++ b/registry/starkgate/calldata-StarkGate-STRK.json
@@ -17,9 +17,9 @@
         "$id": "deposit",
         "intent": "Bridge",
         "fields": [
-          { "path": "token", "label": "Token", "format": "addressName", "params": { "types": ["token"] } },
-          { "path": "amount", "label": "Amount", "format": "amount" },
-          { "path": "l2Recipient", "label": "Recipient", "format": "raw" }
+          { "path": "amount", "label": "Amount to deposit", "format": "tokenAmount", "params": { "tokenPath": "token" } },
+          { "path": "l2Recipient", "label": "Recipient", "format": "raw" },
+          { "path": "@.value", "label": "Deposit fee", "format": "amount" }
         ],
         "required": ["token", "amount", "l2Recipient"]
       }


### PR DESCRIPTION
When testing on a device, I noticed 2 issues:
* Amount is displayed in ETH, and token in raw. Both should belong to the same tokenAmount field
* Those transactions have an ETH value, which should be clear signed as a deposit fee

