### PR TITLE
Add support for slices applied on primitive static types

### DIFF
--- a/specs/erc-7730.md
+++ b/specs/erc-7730.md
@@ -800,9 +800,9 @@ A *field format specification* is a json object defining how to format a single 
 
 #### Slices in paths
 
-A slice can be applied at the end of paths for dynamic types like bytes, string and arrays.
+A slice can be applied at the end of paths.
 
-A slice on a primitive type like bytes and string means that the associated [field format specification](#field-format-specification) MUST only be applied to the corresponding slice of bytes of the underlying data. 
+A slice on a primitive type like uint256, bytes and string means that the associated [field format specification](#field-format-specification) MUST only be applied to the corresponding slice of bytes of the underlying data.
 
 A slice on an array type means that the associated [field format specification](#field-format-specification) or recursive [structured data format specification](#structured-data-format-specification) MUST be applied to ALL the array elements part of the slice.
 


### PR DESCRIPTION
We need to be able to slice even primitive static types, as there are contracts encoding an address in a uint256 to add some metadata on remaining bytes.
That's the case for 1inch aggregation router v6.

The ethereum app on device already supports slices on static leafs.