### PR TITLE
Add calldata for the w3.labs `BatchDeposit` contract

### DIFF
--- a/registry/w3labs/calldata-BatchDeposit.json
+++ b/registry/w3labs/calldata-BatchDeposit.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "../../specs/erc7730-v1.schema.json",
+  "context": {
+    "$id": "Ethereum Staking BatchDeposit",
+    "contract": {
+      "deployments": [
+        { "chainId": 1, "address": "0x8fC32441C13706bB981A506FdE65DeDD5dEF3981" },
+        { "chainId": 17000, "address": "0xf079e540F598a85C22dA6eb570236B2169bE4962" }
+      ],
+      "abi": "https://api.etherscan.io/api?module=contract&action=getabi&address=0x8fC32441C13706bB981A506FdE65DeDD5dEF3981"
+    }
+  },
+  "metadata": {
+    "owner": "w3.labs",
+    "info": { "url": "https://www.w3labs.xyz", "legalName": "w3.labs GmbH", "lastUpdate": "2025-01-04T16:27:00Z" }
+  },
+  "display": {
+    "formats": {
+      "batchDeposit(address withdrawalAddress,bytes[] pubkeys,bytes[] signatures,bytes32[] depositDataRoots)": {
+        "$id": "BatchDeposit",
+        "intent": "Deposit to Validators",
+        "fields": [
+          { "path": "@.value", "label": "Amount to Deposit", "format": "amount" },
+          {
+            "path": "withdrawalAddress",
+            "label": "Address for Withdrawal",
+            "format": "addressName",
+            "params": { "types": ["eoa"], "sources": ["local", "ens"] }
+          },
+          { "path": "pubkeys.[]", "label": "Public Keys", "format": "raw" }
+        ],
+        "required": ["@.value", "withdrawalAddress", "pubkeys.[]"],
+        "excluded": ["signatures.[]", "depositDataRoots.[]"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
In this PR, I am adding the erc7730 calldata specification for [our `BatchDeposit` contract](https://github.com/w3labsxyz/ethereum-batch-deposit-contracts), a permissionless contract for depositing to multiple Ethereum validators in a single transaction.

The function we want to being clear signed [can be found here](https://github.com/w3labsxyz/ethereum-batch-deposit-contracts/blob/main/contracts/lib/BatchDeposit.sol#L64). The contract has been deployed to [Holesky](https://holesky.etherscan.io/address/0xf079e540f598a85c22da6eb570236b2169be4962) and [Mainnet](https://etherscan.io/address/0x8fc32441c13706bb981a506fde65dedd5def3981), is [verified on Etherscan](https://etherscan.io/address/0x8fc32441c13706bb981a506fde65dedd5def3981#code), and [audited](https://github.com/w3labsxyz/ethereum-batch-deposit-contracts/tree/main/audit-reports) by Hacken and CredShields.

### Clear Signing Preview
![Screenshot 2025-01-04 at 16-51-55 Clear Signing Preview](https://github.com/user-attachments/assets/30ebb1ea-904a-4d76-8a00-d6eb82bc137d)

