### PR TITLE
fix: slices end index is exclusive

### DIFF
--- a/registry/uniswap/calldata-UniswapV3Router02.json
+++ b/registry/uniswap/calldata-UniswapV3Router02.json
@@ -21,13 +21,13 @@
             "path": "params.amountIn",
             "label": "Amount to Send",
             "format": "tokenAmount",
-            "params": { "tokenPath": "params.path.[0:19]" }
+            "params": { "tokenPath": "params.path.[0:20]" }
           },
           {
             "path": "params.amountOutMinimum",
             "label": "Minimum amount to Receive",
             "format": "tokenAmount",
-            "params": { "tokenPath": "params.path.[-20:-1]" }
+            "params": { "tokenPath": "params.path.[-20:]" }
           },
           {
             "path": "params.recipient",
@@ -67,13 +67,13 @@
             "path": "params.amountInMaximum",
             "label": "Maximum Amount to Send",
             "format": "tokenAmount",
-            "params": { "tokenPath": "params.path.[0:19]" }
+            "params": { "tokenPath": "params.path.[0:20]" }
           },
           {
             "path": "params.amountOut",
             "label": "Amount to Receive",
             "format": "tokenAmount",
-            "params": { "tokenPath": "params.path.[-20:-1]" }
+            "params": { "tokenPath": "params.path.[-20:]" }
           },
           {
             "path": "params.recipient",


### PR DESCRIPTION
Slices end index is exclusive since that spec modification:

https://github.com/LedgerHQ/clear-signing-erc7730-registry/pull/83

It's also exclusive in SignerSDK and in the device, so that descriptor should be updated accordingly