### PR TITLE
Replace lastUpdate by deploymentDate

### DIFF
--- a/developer-preview/src/app/Screens.tsx
+++ b/developer-preview/src/app/Screens.tsx
@@ -10,7 +10,7 @@ interface Props {
   chainId: number;
   contractAddress: string;
   chosenOperation: Operation;
-  info: { lastUpdate: string; legalName: string; url: string };
+  info: { deploymentDate: string; legalName: string; url: string };
   owner: string;
   operationType: string;
 }

--- a/developer-preview/src/lib/getPreviewData.test.tsx
+++ b/developer-preview/src/lib/getPreviewData.test.tsx
@@ -22,7 +22,7 @@ const minimumERC7730Schema: ERC7730Schema = {
   $schema: "unused",
   metadata: {
     owner: "",
-    info: { legalName: "", lastUpdate: "", url: "" },
+    info: { legalName: "", deploymentDate: "", url: "" },
   },
   context: exampleTransactionContext,
 };
@@ -35,7 +35,7 @@ describe("getPreviewData", () => {
         info: {
           url: "https://poap.xyz/",
           legalName: "legalName",
-          lastUpdate: "2022-03-03T17:56:02Z",
+          deploymentDate: "2022-03-03T17:56:02Z",
         },
       };
 

--- a/developer-preview/src/types/ERC7730Schema.d.ts
+++ b/developer-preview/src/types/ERC7730Schema.d.ts
@@ -44,7 +44,7 @@ interface Metadata {
 
 interface OwnerInfo {
   legalName: string;
-  lastUpdate: string;
+  deploymentDate: string;
   url: string;
 }
 

--- a/developer-preview/src/types/PreviewData.d.ts
+++ b/developer-preview/src/types/PreviewData.d.ts
@@ -8,7 +8,7 @@ export type PreviewData = {
     owner: string;
     info?: {
       legalName: string;
-      lastUpdate?: string;
+      deploymentDate?: string;
       url: string;
     };
   };

--- a/registry/1inch/calldata-AggregationRouterV3.json
+++ b/registry/1inch/calldata-AggregationRouterV3.json
@@ -13,7 +13,7 @@
   },
   "metadata": {
     "owner": "1inch",
-    "info": { "url": "https://1inch.io/", "legalName": "1inch Network", "lastUpdate": "2021-03-14T20:28:50Z" },
+    "info": { "url": "https://1inch.io/", "legalName": "1inch Network", "deploymentDate": "2021-03-14T20:28:50Z" },
     "constants": {
       "addressAsEth": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
       "addressAsNull": "0x0000000000000000000000000000000000000000"

--- a/registry/1inch/calldata-AggregationRouterV5.json
+++ b/registry/1inch/calldata-AggregationRouterV5.json
@@ -15,7 +15,7 @@
   },
   "metadata": {
     "owner": "1inch",
-    "info": { "url": "https://1inch.io/", "legalName": "1inch Network", "lastUpdate": "2022-11-04T06:04:59Z" },
+    "info": { "url": "https://1inch.io/", "legalName": "1inch Network", "deploymentDate": "2022-11-04T06:04:59Z" },
     "constants": {
       "addressAsEth": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
       "addressAsNull": "0x0000000000000000000000000000000000000000"

--- a/registry/1inch/common-AggregationRouterV4.json
+++ b/registry/1inch/common-AggregationRouterV4.json
@@ -6,7 +6,7 @@
         "info": {
             "url": "https://1inch.io/",
             "legalName": "1inch Network",
-            "lastUpdate": "2021-11-05T10:18:09Z"
+            "deploymentDate": "2021-11-05T10:18:09Z"
         },
         "constants": {
             "addressAsEth": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",

--- a/registry/aave/calldata-lpv2.json
+++ b/registry/aave/calldata-lpv2.json
@@ -9,7 +9,7 @@
   },
   "metadata": {
     "owner": "Aave",
-    "info": { "url": "https://aave.com", "legalName": "Aave DAO", "lastUpdate": "2020-11-30T09:25:48Z" },
+    "info": { "url": "https://aave.com", "legalName": "Aave DAO", "deploymentDate": "2020-11-30T09:25:48Z" },
     "enums": { "interestRateMode": { "1": "stable", "2": "variable" } },
     "constants": { "max": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" }
   },

--- a/registry/aave/calldata-lpv3.json
+++ b/registry/aave/calldata-lpv3.json
@@ -9,7 +9,7 @@
   },
   "metadata": {
     "owner": "Aave",
-    "info": { "url": "https://aave.com", "legalName": "Aave DAO", "lastUpdate": "2024-10-09T21:46:47Z" },
+    "info": { "url": "https://aave.com", "legalName": "Aave DAO", "deploymentDate": "2024-10-09T21:46:47Z" },
     "enums": { "interestRateMode": { "1": "stable", "2": "variable" } },
     "constants": { "max": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" }
   },

--- a/registry/lido/calldata-OssifiableProxy.json
+++ b/registry/lido/calldata-OssifiableProxy.json
@@ -9,7 +9,7 @@
   },
   "metadata": {
     "owner": "Lido",
-    "info": { "url": "https://lido.fi", "legalName": "Lido DAO", "lastUpdate": "2023-05-02T10:38:47Z" },
+    "info": { "url": "https://lido.fi", "legalName": "Lido DAO", "deploymentDate": "2023-05-02T10:38:47Z" },
     "constants": {
       "stETHaddress": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
       "wstETHaddress": "0x0B925eD163218f6662a35e0f0371Ac234f9E9371"

--- a/registry/lido/calldata-stETH.json
+++ b/registry/lido/calldata-stETH.json
@@ -7,7 +7,7 @@
       "abi": "https://github.com/LedgerHQ/ledger-asset-dapps/blob/211e75ed27de3894f592ca73710fa0b72c3ceeae/ethereum/lido/abis/0xae7ab96520de3a18e5e111b5eaab095312d7fe84.abi.json"
     }
   },
-  "metadata": { "owner": "Lido", "info": { "url": "https://lido.fi", "legalName": "Lido DAO", "lastUpdate": "2021-02-19T04:37:20Z" } },
+  "metadata": { "owner": "Lido", "info": { "url": "https://lido.fi", "legalName": "Lido DAO", "deploymentDate": "2021-02-19T04:37:20Z" } },
   "display": {
     "formats": {
       "submit(address)": {

--- a/registry/lido/calldata-wstETH.json
+++ b/registry/lido/calldata-wstETH.json
@@ -9,7 +9,7 @@
   },
   "metadata": {
     "owner": "Lido",
-    "info": { "url": "https://lido.fi", "legalName": "Lido DAO", "lastUpdate": "2021-02-19T04:37:20Z" },
+    "info": { "url": "https://lido.fi", "legalName": "Lido DAO", "deploymentDate": "2021-02-19T04:37:20Z" },
     "constants": { "stETHaddress": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84" }
   },
   "display": {

--- a/registry/makerdao/eip712-permit-DAI.json
+++ b/registry/makerdao/eip712-permit-DAI.json
@@ -9,7 +9,7 @@
   "includes": "../../ercs/eip712-erc2612-permit.json",
   "metadata": {
     "owner": "MakerDAO",
-    "info": { "legalName": "Maker Foundation", "url": "https://makerdao.com/", "lastUpdate": "2017-12-18T00:00:00Z" },
+    "info": { "legalName": "Maker Foundation", "url": "https://makerdao.com/", "deploymentDate": "2017-12-18T00:00:00Z" },
     "token": { "name": "Dai Stablecoin", "ticker": "DAI", "decimals": 18 }
   },
   "display": {

--- a/registry/paraswap/calldata-AugustusSwapper.json
+++ b/registry/paraswap/calldata-AugustusSwapper.json
@@ -9,7 +9,7 @@
   },
   "metadata": {
     "owner": "Paraswap",
-    "info": { "url": "https://www.paraswap.io/", "legalName": "ParaSwap", "lastUpdate": "2021-08-18T12:42:05Z" },
+    "info": { "url": "https://www.paraswap.io/", "legalName": "ParaSwap", "deploymentDate": "2021-08-18T12:42:05Z" },
     "constants": { "addressAsEth": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE" }
   },
   "display": {

--- a/registry/poap/calldata-PoapBridge.json
+++ b/registry/poap/calldata-PoapBridge.json
@@ -9,7 +9,7 @@
   },
   "metadata": {
     "owner": "POAP",
-    "info": { "url": "https://poap.xyz/", "legalName": "Proof of Attendance Protocol", "lastUpdate": "2022-03-03T17:56:02Z" }
+    "info": { "url": "https://poap.xyz/", "legalName": "Proof of Attendance Protocol", "deploymentDate": "2022-03-03T17:56:02Z" }
   },
   "display": {
     "formats": {

--- a/registry/quickswap/calldata-QuickSwap.json
+++ b/registry/quickswap/calldata-QuickSwap.json
@@ -8,7 +8,7 @@
   },
   "metadata": {
     "owner": "QuickSwap",
-    "info": { "legalName": "QuickSwap", "lastUpdate": "2024-10-01T00:00:00Z", "url": "https://quickswap.exchange" }
+    "info": { "legalName": "QuickSwap", "deploymentDate": "2020-09-25T10:52:01Z", "url": "https://quickswap.exchange" }
   },
   "display": {
     "formats": {

--- a/registry/starkgate/calldata-StarkGate-STRK.json
+++ b/registry/starkgate/calldata-StarkGate-STRK.json
@@ -9,7 +9,7 @@
   },
   "metadata": {
     "owner": "Starknet",
-    "info": { "url": "https://starkgate.starknet.io/", "legalName": "StarkWare", "lastUpdate": "2024-10-01T00:00:00Z" }
+    "info": { "url": "https://starkgate.starknet.io/", "legalName": "StarkWare", "deploymentDate": "2024-10-01T00:00:00Z" }
   },
   "display": {
     "formats": {

--- a/registry/tether/calldata-usdt.json
+++ b/registry/tether/calldata-usdt.json
@@ -7,7 +7,7 @@
   "includes": "../../ercs/calldata-erc20-tokens.json",
   "metadata": {
     "owner": "Tether",
-    "info": { "legalName": "Tether Limited", "url": "https://tether.to/", "lastUpdate": "2017-11-28T12:41:21Z" },
+    "info": { "legalName": "Tether Limited", "url": "https://tether.to/", "deploymentDate": "2017-11-28T12:41:21Z" },
     "token": { "ticker": "USDT", "name": "Tether USD", "decimals": 6 }
   }
 }

--- a/registry/uniswap/calldata-UniswapV3Router02.json
+++ b/registry/uniswap/calldata-UniswapV3Router02.json
@@ -9,7 +9,7 @@
   },
   "metadata": {
     "owner": "Uniswap",
-    "info": { "legalName": "Uniswap Labs", "lastUpdate": "2021-12-14T00:00:00Z", "url": "https://uniswap.org/" }
+    "info": { "legalName": "Uniswap Labs", "deploymentDate": "2021-12-14T00:00:00Z", "url": "https://uniswap.org/" }
   },
   "display": {
     "formats": {

--- a/registry/uniswap/uniswap-common-eip712.json
+++ b/registry/uniswap/uniswap-common-eip712.json
@@ -71,7 +71,7 @@
         "owner": "Uniswap",
         "info": {
             "legalName": "Uniswap Labs",
-            "lastUpdate": "2021-12-14T00:00:00Z",
+            "deploymentDate": "2021-12-14T00:00:00Z",
             "url": "https://uniswap.org/"
         }
     }

--- a/specs/erc-7730.md
+++ b/specs/erc-7730.md
@@ -78,7 +78,7 @@ The following is a simple example of how to clear sign a `transfer` function cal
         "info": {
             "legalName": "Tether Limited",
             "url": "https://tether.to/",
-            "lastUpdate": "2017-11-28T12:41:21Z"  
+            "deploymentDate": "2017-11-28T12:41:21Z"  
         }
     },
 
@@ -316,7 +316,7 @@ The following file would include this generic interface and bind it to the speci
         "info": {
             "legalName": "Tether Limited",
             "url": "https://tether.to/",
-            "lastUpdate": "2017-11-28T12:41:21Z"  
+            "deploymentDate": "2017-11-28T12:41:21Z"  
         },
         "token": {
             "ticker": "USDT",
@@ -536,7 +536,7 @@ Wallet MAY use this value to display the target of the interaction being reviewe
 
 A key containing additional structured info about the *owner* of the contract:
   * `legalName` is the legal owner entity name
-  * `lastUpdate` is the date of the contract (or verifying contract) last update 
+  * `deploymentDate` is the date of deployment of the contract (or verifying contract)
   * `url` is the official URL of the owner
 
 A wallet MAY use this information to display additional details about the targeted contract.

--- a/specs/erc7730-v1.schema.json
+++ b/specs/erc7730-v1.schema.json
@@ -258,11 +258,11 @@
                     "type": "string",
                     "description": "The full legal name of the owner if different from the owner field."
                 },
-                "lastUpdate": {
-                    "title": "Last Update of the contract / message",
+                "deploymentDate": {
+                    "title": "Deployment date of the contract / message",
                     "type": "string",
                     "format": "date-time",
-                    "description": "The date of the last update of the contract / message."
+                    "description": "The date of deployment of the contract / message."
                 },
                 "url": {
                     "title": "Owner URL",


### PR DESCRIPTION
Among the informations to be provided about the contract : `lastUpdate` has been replaced by `deploymentDate`. 

As smart contracts are immutable, it makes more sense to display the contract's deployment date.

Note : This change has already been taken into account in the Ethereum app UI for the generic parser.