### PR TITLE
Add SwissBorg

### DIFF
--- a/registry/swissborg/calldata-ChsbToBorgMigrator.json
+++ b/registry/swissborg/calldata-ChsbToBorgMigrator.json
@@ -1,0 +1,393 @@
+{
+    "$schema": "../../specs/erc7730-v1.schema.json",
+    "context": {
+      "$id": "ChsbToBorgMigrator",
+      "contract": {
+        "deployments": [
+          {
+            "chainId": 1,
+            "address": "0xaA854688caAB725fe17b7D21b46fDA5AF365985a"
+          }
+        ],
+        "abi": [
+          {
+            "type": "function",
+            "name": "BORG",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "address",
+                "internalType": "contract IERC20Upgradeable",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "CHSB",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "address",
+                "internalType": "contract IERC20Upgradeable",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "getImplementation",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "initialize",
+            "inputs": [
+              {
+                "name": "_chsb",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "_borg",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "owner_",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "_manager",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "manager",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "migrate",
+            "inputs": [
+              {
+                "name": "_amount",
+                "type": "uint256",
+                "internalType": "uint256",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "owner",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "pause",
+            "inputs": [],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "paused",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "bool",
+                "internalType": "bool",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "proxiableUUID",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "renounceOwnership",
+            "inputs": [],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "setManager",
+            "inputs": [
+              {
+                "name": "_manager",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "totalChsbMigrated",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "transferOwnership",
+            "inputs": [
+              {
+                "name": "newOwner",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "unpause",
+            "inputs": [],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "upgradeTo",
+            "inputs": [
+              {
+                "name": "newImplementation",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "upgradeToAndCall",
+            "inputs": [
+              {
+                "name": "newImplementation",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "data",
+                "type": "bytes",
+                "internalType": "bytes",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "payable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          }
+        ],
+        "addressMatcher": null,
+        "factory": null
+      }
+    },
+    "metadata": {
+      "owner": "SwissBorg Migrator",
+      "info": {
+        "legalName": "SwissBorg",
+        "url": "https://migration.swissborg.com"
+      }
+    },
+    "display": {
+      "formats": {
+        "migrate(uint256)": {
+          "$id": "migrate",
+          "intent": "Migrate CHSB to BORG",
+          "fields": [
+            {
+              "$id": "migrate",
+              "label": "CHSB Amount",
+              "format": "tokenAmount",
+              "params": {
+                "tokenPath": "0xba9d4199faB4f26eFE3551D490E3821486f135Ba",
+                "nativeCurrencyAddress": "0xba9d4199faB4f26eFE3551D490E3821486f135Ba"
+              },
+              "path": "#._amount"
+            }
+          ],
+          "required": [
+            "amount"
+          ]
+        }
+      }
+    }
+  }

--- a/registry/swissborg/calldata-NttManager.json
+++ b/registry/swissborg/calldata-NttManager.json
@@ -1,0 +1,1457 @@
+{
+    "$schema": "../../specs/erc7730-v1.schema.json",
+    "context": {
+      "$id": "NttManager",
+      "contract": {
+        "deployments": [
+          {
+            "chainId": 1,
+            "address": "0x66a28B080918184851774a89aB94850a41f6a1e5"
+          }
+        ],
+        "abi": [
+          {
+            "type": "function",
+            "name": "NTT_MANAGER_VERSION",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "string",
+                "internalType": "string",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "attestationReceived",
+            "inputs": [
+              {
+                "name": "sourceChainId",
+                "type": "uint16",
+                "internalType": "uint16",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "sourceNttManagerAddress",
+                "type": "bytes32",
+                "internalType": "bytes32",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "payload",
+                "type": "tuple",
+                "internalType": "struct TransceiverStructs.NttManagerMessage",
+                "components": [
+                  {
+                    "name": "id",
+                    "type": "bytes32",
+                    "internalType": "bytes32",
+                    "components": null
+                  },
+                  {
+                    "name": "sender",
+                    "type": "bytes32",
+                    "internalType": "bytes32",
+                    "components": null
+                  },
+                  {
+                    "name": "payload",
+                    "type": "bytes",
+                    "internalType": "bytes",
+                    "components": null
+                  }
+                ],
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "cancelOutboundQueuedTransfer",
+            "inputs": [
+              {
+                "name": "messageSequence",
+                "type": "uint64",
+                "internalType": "uint64",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "chainId",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "uint16",
+                "internalType": "uint16",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "completeInboundQueuedTransfer",
+            "inputs": [
+              {
+                "name": "digest",
+                "type": "bytes32",
+                "internalType": "bytes32",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "completeOutboundQueuedTransfer",
+            "inputs": [
+              {
+                "name": "messageSequence",
+                "type": "uint64",
+                "internalType": "uint64",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "uint64",
+                "internalType": "uint64",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "payable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "executeMsg",
+            "inputs": [
+              {
+                "name": "sourceChainId",
+                "type": "uint16",
+                "internalType": "uint16",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "sourceNttManagerAddress",
+                "type": "bytes32",
+                "internalType": "bytes32",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "message",
+                "type": "tuple",
+                "internalType": "struct TransceiverStructs.NttManagerMessage",
+                "components": [
+                  {
+                    "name": "id",
+                    "type": "bytes32",
+                    "internalType": "bytes32",
+                    "components": null
+                  },
+                  {
+                    "name": "sender",
+                    "type": "bytes32",
+                    "internalType": "bytes32",
+                    "components": null
+                  },
+                  {
+                    "name": "payload",
+                    "type": "bytes",
+                    "internalType": "bytes",
+                    "components": null
+                  }
+                ],
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "getCurrentInboundCapacity",
+            "inputs": [
+              {
+                "name": "chainId_",
+                "type": "uint16",
+                "internalType": "uint16",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "getCurrentOutboundCapacity",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "getInboundLimitParams",
+            "inputs": [
+              {
+                "name": "chainId_",
+                "type": "uint16",
+                "internalType": "uint16",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "tuple",
+                "internalType": "struct IRateLimiter.RateLimitParams",
+                "components": [
+                  {
+                    "name": "limit",
+                    "type": "uint72",
+                    "internalType": "TrimmedAmount",
+                    "components": null
+                  },
+                  {
+                    "name": "currentCapacity",
+                    "type": "uint72",
+                    "internalType": "TrimmedAmount",
+                    "components": null
+                  },
+                  {
+                    "name": "lastTxTimestamp",
+                    "type": "uint64",
+                    "internalType": "uint64",
+                    "components": null
+                  }
+                ],
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "getInboundQueuedTransfer",
+            "inputs": [
+              {
+                "name": "digest",
+                "type": "bytes32",
+                "internalType": "bytes32",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "tuple",
+                "internalType": "struct IRateLimiter.InboundQueuedTransfer",
+                "components": [
+                  {
+                    "name": "amount",
+                    "type": "uint72",
+                    "internalType": "TrimmedAmount",
+                    "components": null
+                  },
+                  {
+                    "name": "txTimestamp",
+                    "type": "uint64",
+                    "internalType": "uint64",
+                    "components": null
+                  },
+                  {
+                    "name": "recipient",
+                    "type": "address",
+                    "internalType": "address",
+                    "components": null
+                  }
+                ],
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "getMigratesImmutables",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "bool",
+                "internalType": "bool",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "getMode",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "uint8",
+                "internalType": "uint8",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "getOutboundLimitParams",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "tuple",
+                "internalType": "struct IRateLimiter.RateLimitParams",
+                "components": [
+                  {
+                    "name": "limit",
+                    "type": "uint72",
+                    "internalType": "TrimmedAmount",
+                    "components": null
+                  },
+                  {
+                    "name": "currentCapacity",
+                    "type": "uint72",
+                    "internalType": "TrimmedAmount",
+                    "components": null
+                  },
+                  {
+                    "name": "lastTxTimestamp",
+                    "type": "uint64",
+                    "internalType": "uint64",
+                    "components": null
+                  }
+                ],
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "pure",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "getOutboundQueuedTransfer",
+            "inputs": [
+              {
+                "name": "queueSequence",
+                "type": "uint64",
+                "internalType": "uint64",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "tuple",
+                "internalType": "struct IRateLimiter.OutboundQueuedTransfer",
+                "components": [
+                  {
+                    "name": "recipient",
+                    "type": "bytes32",
+                    "internalType": "bytes32",
+                    "components": null
+                  },
+                  {
+                    "name": "refundAddress",
+                    "type": "bytes32",
+                    "internalType": "bytes32",
+                    "components": null
+                  },
+                  {
+                    "name": "amount",
+                    "type": "uint72",
+                    "internalType": "TrimmedAmount",
+                    "components": null
+                  },
+                  {
+                    "name": "txTimestamp",
+                    "type": "uint64",
+                    "internalType": "uint64",
+                    "components": null
+                  },
+                  {
+                    "name": "recipientChain",
+                    "type": "uint16",
+                    "internalType": "uint16",
+                    "components": null
+                  },
+                  {
+                    "name": "sender",
+                    "type": "address",
+                    "internalType": "address",
+                    "components": null
+                  },
+                  {
+                    "name": "transceiverInstructions",
+                    "type": "bytes",
+                    "internalType": "bytes",
+                    "components": null
+                  }
+                ],
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "getPeer",
+            "inputs": [
+              {
+                "name": "chainId_",
+                "type": "uint16",
+                "internalType": "uint16",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "tuple",
+                "internalType": "struct INttManager.NttManagerPeer",
+                "components": [
+                  {
+                    "name": "peerAddress",
+                    "type": "bytes32",
+                    "internalType": "bytes32",
+                    "components": null
+                  },
+                  {
+                    "name": "tokenDecimals",
+                    "type": "uint8",
+                    "internalType": "uint8",
+                    "components": null
+                  }
+                ],
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "getThreshold",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "uint8",
+                "internalType": "uint8",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "getTransceiverInfo",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "tuple[]",
+                "internalType": "struct TransceiverRegistry.TransceiverInfo[]",
+                "components": [
+                  {
+                    "name": "registered",
+                    "type": "bool",
+                    "internalType": "bool",
+                    "components": null
+                  },
+                  {
+                    "name": "enabled",
+                    "type": "bool",
+                    "internalType": "bool",
+                    "components": null
+                  },
+                  {
+                    "name": "index",
+                    "type": "uint8",
+                    "internalType": "uint8",
+                    "components": null
+                  }
+                ],
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "getTransceivers",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "result",
+                "type": "address[]",
+                "internalType": "address[]",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "pure",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "initialize",
+            "inputs": [],
+            "outputs": [],
+            "stateMutability": "payable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "isMessageApproved",
+            "inputs": [
+              {
+                "name": "digest",
+                "type": "bytes32",
+                "internalType": "bytes32",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "bool",
+                "internalType": "bool",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "isMessageExecuted",
+            "inputs": [
+              {
+                "name": "digest",
+                "type": "bytes32",
+                "internalType": "bytes32",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "bool",
+                "internalType": "bool",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "isPaused",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "bool",
+                "internalType": "bool",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "messageAttestations",
+            "inputs": [
+              {
+                "name": "digest",
+                "type": "bytes32",
+                "internalType": "bytes32",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [
+              {
+                "name": "count",
+                "type": "uint8",
+                "internalType": "uint8",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "migrate",
+            "inputs": [],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "mode",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "uint8",
+                "internalType": "enum IManagerBase.Mode",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "nextMessageSequence",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "uint64",
+                "internalType": "uint64",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "owner",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "pause",
+            "inputs": [],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "pauser",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "quoteDeliveryPrice",
+            "inputs": [
+              {
+                "name": "recipientChain",
+                "type": "uint16",
+                "internalType": "uint16",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "transceiverInstructions",
+                "type": "bytes",
+                "internalType": "bytes",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "uint256[]",
+                "internalType": "uint256[]",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "rateLimitDuration",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "uint64",
+                "internalType": "uint64",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "removeTransceiver",
+            "inputs": [
+              {
+                "name": "transceiver",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "setInboundLimit",
+            "inputs": [
+              {
+                "name": "limit",
+                "type": "uint256",
+                "internalType": "uint256",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "chainId_",
+                "type": "uint16",
+                "internalType": "uint16",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "setOutboundLimit",
+            "inputs": [
+              {
+                "name": "limit",
+                "type": "uint256",
+                "internalType": "uint256",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "setPeer",
+            "inputs": [
+              {
+                "name": "peerChainId",
+                "type": "uint16",
+                "internalType": "uint16",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "peerContract",
+                "type": "bytes32",
+                "internalType": "bytes32",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "decimals",
+                "type": "uint8",
+                "internalType": "uint8",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "inboundLimit",
+                "type": "uint256",
+                "internalType": "uint256",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "setThreshold",
+            "inputs": [
+              {
+                "name": "threshold",
+                "type": "uint8",
+                "internalType": "uint8",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "setTransceiver",
+            "inputs": [
+              {
+                "name": "transceiver",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "token",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "tokenDecimals",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "uint8",
+                "internalType": "uint8",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "transceiverAttestedToMessage",
+            "inputs": [
+              {
+                "name": "digest",
+                "type": "bytes32",
+                "internalType": "bytes32",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "index",
+                "type": "uint8",
+                "internalType": "uint8",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "bool",
+                "internalType": "bool",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "transfer",
+            "inputs": [
+              {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "recipientChain",
+                "type": "uint16",
+                "internalType": "uint16",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "recipient",
+                "type": "bytes32",
+                "internalType": "bytes32",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "uint64",
+                "internalType": "uint64",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "payable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "transfer",
+            "inputs": [
+              {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "recipientChain",
+                "type": "uint16",
+                "internalType": "uint16",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "recipient",
+                "type": "bytes32",
+                "internalType": "bytes32",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "refundAddress",
+                "type": "bytes32",
+                "internalType": "bytes32",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "shouldQueue",
+                "type": "bool",
+                "internalType": "bool",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "transceiverInstructions",
+                "type": "bytes",
+                "internalType": "bytes",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "uint64",
+                "internalType": "uint64",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "payable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "transferOwnership",
+            "inputs": [
+              {
+                "name": "newOwner",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "transferPauserCapability",
+            "inputs": [
+              {
+                "name": "newPauser",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "unpause",
+            "inputs": [],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "upgrade",
+            "inputs": [
+              {
+                "name": "newImplementation",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          }
+        ],
+        "addressMatcher": null,
+        "factory": null
+      }
+    },
+    "metadata": {
+      "owner": "SwissBorg Bridge",
+      "info": {
+        "legalName": "SwissBorg",
+        "url": "https://swissborg.com/bridge"
+      }
+    },
+    "display": {
+      "formats": {
+        "transfer(uint256,uint16,bytes32)": {
+          "$id": "transfer",
+          "intent": "Bridge BORG",
+          "fields": [
+            {
+              "$id": "amount",
+              "label": "Amount",
+              "format": "tokenAmount",
+              "params": {
+                "tokenPath": "0xba9d4199faB4f26eFE3551D490E3821486f135Ba",
+                "nativeCurrencyAddress": "0xba9d4199faB4f26eFE3551D490E3821486f135Ba",
+                "threshold": "1000000000000000000000000000",
+                "message": "Unlimited"
+              },
+              "path": "#.amount"
+            },
+            {
+              "$id": "destinationChain",
+              "label": "Destination Chain",
+              "format": "raw",
+              "params": null,
+              "path": "#.recipientChain"
+            },
+            {
+              "$id": "encodedDestinationAddress",
+              "label": "Encoded Destination Address",
+              "format": "raw",
+              "params": null,
+              "path": "#.recipient",
+            }
+          ],
+          "required": [
+            "#.amount",
+            "#.recipientChain",
+            "#.recipient"
+          ],
+        },
+        "transfer(uint256,uint16,bytes32,bytes32,bool,bytes)": {
+          "$id": "transfer2",
+          "intent": "Bridge BORG",
+          "fields": [
+            {
+              "$id": "amount",
+              "label": "Amount",
+              "format": "tokenAmount",
+              "params": {
+                "tokenPath": "0xba9d4199faB4f26eFE3551D490E3821486f135Ba",
+                "nativeCurrencyAddress": "0xba9d4199faB4f26eFE3551D490E3821486f135Ba",
+              },
+              "path": "#.amount"
+            },
+            {
+              "$id": "destinationChain",
+              "label": "Destination Chain",
+              "format": "raw",
+              "params": null,
+              "path": "#.recipientChain"
+            },
+            {
+              "$id": "encodedDestinationAddress",
+              "label": "Encoded Destination Address",
+              "format": "raw",
+              "params": null,
+              "path": "#.recipient"
+            },
+            {
+              "$id": "refundAddress",
+              "label": "Refund Address",
+              "format": "raw",
+              "params": null,
+              "path": "#.refundAddress"
+            },
+            {
+              "$id": "shouldQueue",
+              "label": "Should Queue",
+              "format": "raw",
+              "params": null,
+              "path": "#.shouldQueue"
+            },
+            {
+              "$id": "transceiverInstructions",
+              "label": "Transceiver Instructions",
+              "format": "raw",
+              "params": null,
+              "path": "#.transceiverInstructions"
+            }
+          ],
+          "required": [
+            "#.amount",
+            "#.recipientChain",
+            "#.recipient"
+          ]
+        }
+      }
+    }
+  }

--- a/registry/swissborg/calldata-WormholeTransceiver.json
+++ b/registry/swissborg/calldata-WormholeTransceiver.json
@@ -1,0 +1,943 @@
+{
+    "$schema": "../../specs/erc7730-v1.schema.json",
+    "context": {
+      "$id": "WormholeTransceiver",
+      "contract": {
+        "deployments": [
+          {
+            "chainId": 1,
+            "address": "0x45E581d6841F0a99Fc34F70871ef56b353813ddb"
+          }
+        ],
+        "abi": [
+          {
+            "type": "function",
+            "name": "WORMHOLE_TRANSCEIVER_VERSION",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "string",
+                "internalType": "string",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "consistencyLevel",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "uint8",
+                "internalType": "uint8",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "encodeWormholeTransceiverInstruction",
+            "inputs": [
+              {
+                "name": "instruction",
+                "type": "tuple",
+                "internalType": "struct IWormholeTransceiver.WormholeTransceiverInstruction",
+                "components": [
+                  {
+                    "name": "shouldSkipRelayerSend",
+                    "type": "bool",
+                    "internalType": "bool",
+                    "components": null
+                  }
+                ],
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "bytes",
+                "internalType": "bytes",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "pure",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "gasLimit",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "getMigratesImmutables",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "bool",
+                "internalType": "bool",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "getNttManagerOwner",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "getNttManagerToken",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "getWormholePeer",
+            "inputs": [
+              {
+                "name": "chainId",
+                "type": "uint16",
+                "internalType": "uint16",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "initialize",
+            "inputs": [],
+            "outputs": [],
+            "stateMutability": "payable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "isPaused",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "bool",
+                "internalType": "bool",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "isSpecialRelayingEnabled",
+            "inputs": [
+              {
+                "name": "chainId",
+                "type": "uint16",
+                "internalType": "uint16",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "bool",
+                "internalType": "bool",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "isVAAConsumed",
+            "inputs": [
+              {
+                "name": "hash",
+                "type": "bytes32",
+                "internalType": "bytes32",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "bool",
+                "internalType": "bool",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "isWormholeEvmChain",
+            "inputs": [
+              {
+                "name": "chainId",
+                "type": "uint16",
+                "internalType": "uint16",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "bool",
+                "internalType": "bool",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "isWormholeRelayingEnabled",
+            "inputs": [
+              {
+                "name": "chainId",
+                "type": "uint16",
+                "internalType": "uint16",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "bool",
+                "internalType": "bool",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "migrate",
+            "inputs": [],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "nttManager",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "nttManagerToken",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "owner",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "parseWormholeTransceiverInstruction",
+            "inputs": [
+              {
+                "name": "encoded",
+                "type": "bytes",
+                "internalType": "bytes",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [
+              {
+                "name": "instruction",
+                "type": "tuple",
+                "internalType": "struct IWormholeTransceiver.WormholeTransceiverInstruction",
+                "components": [
+                  {
+                    "name": "shouldSkipRelayerSend",
+                    "type": "bool",
+                    "internalType": "bool",
+                    "components": null
+                  }
+                ],
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "pure",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "pauser",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "quoteDeliveryPrice",
+            "inputs": [
+              {
+                "name": "targetChain",
+                "type": "uint16",
+                "internalType": "uint16",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "instruction",
+                "type": "tuple",
+                "internalType": "struct TransceiverStructs.TransceiverInstruction",
+                "components": [
+                  {
+                    "name": "index",
+                    "type": "uint8",
+                    "internalType": "uint8",
+                    "components": null
+                  },
+                  {
+                    "name": "payload",
+                    "type": "bytes",
+                    "internalType": "bytes",
+                    "components": null
+                  }
+                ],
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "receiveMessage",
+            "inputs": [
+              {
+                "name": "encodedMessage",
+                "type": "bytes",
+                "internalType": "bytes",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "receiveWormholeMessages",
+            "inputs": [
+              {
+                "name": "payload",
+                "type": "bytes",
+                "internalType": "bytes",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "additionalMessages",
+                "type": "bytes[]",
+                "internalType": "bytes[]",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "sourceAddress",
+                "type": "bytes32",
+                "internalType": "bytes32",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "sourceChain",
+                "type": "uint16",
+                "internalType": "uint16",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "deliveryHash",
+                "type": "bytes32",
+                "internalType": "bytes32",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "payable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "sendMessage",
+            "inputs": [
+              {
+                "name": "recipientChain",
+                "type": "uint16",
+                "internalType": "uint16",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "instruction",
+                "type": "tuple",
+                "internalType": "struct TransceiverStructs.TransceiverInstruction",
+                "components": [
+                  {
+                    "name": "index",
+                    "type": "uint8",
+                    "internalType": "uint8",
+                    "components": null
+                  },
+                  {
+                    "name": "payload",
+                    "type": "bytes",
+                    "internalType": "bytes",
+                    "components": null
+                  }
+                ],
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "nttManagerMessage",
+                "type": "bytes",
+                "internalType": "bytes",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "recipientNttManagerAddress",
+                "type": "bytes32",
+                "internalType": "bytes32",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "refundAddress",
+                "type": "bytes32",
+                "internalType": "bytes32",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "payable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "setIsSpecialRelayingEnabled",
+            "inputs": [
+              {
+                "name": "chainId",
+                "type": "uint16",
+                "internalType": "uint16",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "isEnabled",
+                "type": "bool",
+                "internalType": "bool",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "setIsWormholeEvmChain",
+            "inputs": [
+              {
+                "name": "chainId",
+                "type": "uint16",
+                "internalType": "uint16",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "isEvm",
+                "type": "bool",
+                "internalType": "bool",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "setIsWormholeRelayingEnabled",
+            "inputs": [
+              {
+                "name": "chainId",
+                "type": "uint16",
+                "internalType": "uint16",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "isEnabled",
+                "type": "bool",
+                "internalType": "bool",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "setWormholePeer",
+            "inputs": [
+              {
+                "name": "peerChainId",
+                "type": "uint16",
+                "internalType": "uint16",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              },
+              {
+                "name": "peerContract",
+                "type": "bytes32",
+                "internalType": "bytes32",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "payable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "specialRelayer",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "address",
+                "internalType": "contract ISpecialRelayer",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "transferOwnership",
+            "inputs": [
+              {
+                "name": "newOwner",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "transferPauserCapability",
+            "inputs": [
+              {
+                "name": "newPauser",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "transferTransceiverOwnership",
+            "inputs": [
+              {
+                "name": "newOwner",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "upgrade",
+            "inputs": [
+              {
+                "name": "newImplementation",
+                "type": "address",
+                "internalType": "address",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "wormhole",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "address",
+                "internalType": "contract IWormhole",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "wormholeRelayer",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "address",
+                "internalType": "contract IWormholeRelayer",
+                "components": null,
+                "indexed": null,
+                "unit": null
+              }
+            ],
+            "stateMutability": "view",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          }
+        ],
+        "addressMatcher": null,
+        "factory": null
+      }
+    },
+    "metadata": {
+      "owner": "SwissBorg Bridge",
+      "info": {
+        "legalName": "SwissBorg",
+        "url": "https://swissborg.com/bridge"
+      }
+    },
+    "display": {
+      "formats": {
+        "receiveMessage(bytes)": {
+          "$id": "receiveMessage",
+          "intent": "Receive Bridged BORG",
+          "fields": [
+            {
+              "$id": "encodedMessage",
+              "label": "Encoded Message",
+              "format": "raw",
+              "params": null,
+              "path": "#.encodedMessage"
+            }
+          ],
+          "required": [
+            "#.encodedMessage"
+          ]
+        }
+      }
+    }
+  }


### PR DESCRIPTION
SwissBorg contracts:
- `ChsbToBorgMigrator`, Migrator contract to get BORG from CHSB tokens, see https://docs.swissborg.com/borg-migration/contract-addresses
- `NttManager`, Contract to bridge out of Ethereum, see https://docs.swissborg.com/bridge/contract-addresses
- `WormholeTransceiver`, Contract to bridge in on Ethereum, see https://docs.swissborg.com/bridge/contract-addresses