### PR TITLE
Add Bebop EIP712 messages 

### DIFF
--- a/registry/bebop/common-eip712-base.json
+++ b/registry/bebop/common-eip712-base.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "../../specs/erc7730-v1.schema.json",
+
+  "context": {
+    "eip712": {
+      "domain": {
+        "name": "Bebop"
+      },
+
+      "deployments": [
+        [
+          {
+            "chainId": 1,
+            "address": "0x000000000022d473030f116ddee9f6b43ac78ba3"
+          },
+          {
+            "chainId": 137,
+            "address": "0x000000000022d473030f116ddee9f6b43ac78ba3"
+          },
+          {
+            "chainId": 42161,
+            "address": "0x000000000022d473030f116ddee9f6b43ac78ba3"
+          },
+          {
+            "chainId": 56,
+            "address": "0x000000000022d473030f116ddee9f6b43ac78ba3"
+          },
+          {
+            "chainId": 81457,
+            "address": "0x000000000022d473030f116ddee9f6b43ac78ba3"
+          },
+          {
+            "chainId": 324,
+            "address": "0x0000000000225e31D15943971F47aD3022F714Fa"
+          },
+          {
+            "chainId": 34443,
+            "address": "0x000000000022d473030f116ddee9f6b43ac78ba3"
+          },
+          {
+            "chainId": 10,
+            "address": "0x000000000022d473030f116ddee9f6b43ac78ba3"
+          },
+          {
+            "chainId": 8453,
+            "address": "0x000000000022d473030f116ddee9f6b43ac78ba3"
+          },
+          {
+            "chainId": 534352,
+            "address": "0x000000000022d473030f116ddee9f6b43ac78ba3"
+          },
+          {
+            "chainId": 167000,
+            "address": "0x000000000022d473030f116ddee9f6b43ac78ba3"
+          },
+          {
+            "chainId": 10143,
+            "address": "0x000000000022d473030f116ddee9f6b43ac78ba3"
+          },
+          {
+            "chainId": 80094,
+            "address": "0x000000000022d473030f116ddee9f6b43ac78ba3"
+          },
+          {
+            "chainId": 6342,
+            "address": "0x000000000022d473030f116ddee9f6b43ac78ba3"
+          },
+          {
+            "chainId": 5330,
+            "address": "0x000000000022d473030f116ddee9f6b43ac78ba3"
+          }
+        ]
+      ]
+    }
+  },
+
+  "metadata": {
+    "owner": "Bebop",
+    "info": {
+      "legalName": "Bebop Trading Limited",
+      "url": "https://bebop.xyz"
+    }
+  }
+}

--- a/registry/bebop/eip712-bebop-aggregateorder.json
+++ b/registry/bebop/eip712-bebop-aggregateorder.json
@@ -1,0 +1,137 @@
+{
+  "$schema": "../../specs/erc7730-v1.schema.json",
+  "includes": "common-eip712-base.json",
+
+  "context": {
+    "eip712": {
+      "schemas": [
+        {
+          "types": {
+            "EIP712Domain": [
+              { "name": "name", "type": "string" },
+              { "name": "chainId", "type": "uint256" },
+              { "name": "verifyingContract", "type": "address" }
+            ],
+            "PermitBatchWitnessTransferFrom": [
+              { "name": "permitted", "type": "TokenPermissions[]" },
+              { "name": "spender", "type": "address" },
+              { "name": "nonce", "type": "uint256" },
+              { "name": "deadline", "type": "uint256" },
+              { "name": "witness", "type": "AggregateOrder" }
+            ],
+            "TokenPermissions": [
+              { "name": "token", "type": "address" },
+              { "name": "amount", "type": "uint256" }
+            ],
+            "AggregateOrder": [
+              { "name": "partner_id", "type": "uint64" },
+              { "name": "expiry", "type": "uint256" },
+              { "name": "taker_address", "type": "address" },
+              { "name": "maker_addresses", "type": "address[]" },
+              { "name": "maker_nonces", "type": "uint256[]" },
+              { "name": "taker_tokens", "type": "address[][]" },
+              { "name": "taker_amounts", "type": "uint256[][]" },
+              { "name": "maker_tokens", "type": "address[][]" },
+              { "name": "maker_amounts", "type": "uint256[][]" },
+              { "name": "receiver", "type": "address" },
+              { "name": "commands", "type": "bytes" },
+              { "name": "hooksHash", "type": "bytes32" }
+            ]
+          },
+          "primaryType": "PermitBatchWitnessTransferFrom"
+        }
+      ],
+      "domain": {
+        "name": "Bebop Aggregate Order"
+      }
+    }
+  },
+
+  "display": {
+    "formats": {
+      "PermitBatchWitnessTransferFrom": {
+        "intent": "AggregateOrder Permit",
+        "fields": [
+          {
+            "path": "spender",
+            "label": "Approved Spender",
+            "format": "addressName"
+          },
+          {
+            "path": "permitted.[]",
+            "fields": [
+              {
+                "path": "token",
+                "label": "Token",
+                "format": "addressName",
+                "params": { "types": ["token"] }
+              },
+              {
+                "path": "amount",
+                "label": "Approval Amount",
+                "format": "tokenAmount",
+                "params": {
+                  "tokenPath": "token"
+                }
+              }
+            ]
+          },
+          {
+            "path": "deadline",
+            "label": "Deadline",
+            "format": "date",
+            "params": { "encoding": "timestamp" }
+          },
+          {
+            "path": "witness",
+            "fields": [
+              {
+                "path": "expiry",
+                "label": "Expiry",
+                "format": "date",
+                "params": { "encoding": "timestamp" }
+              },
+              {
+                "path": "taker_address",
+                "label": "Taker",
+                "format": "addressName"
+              },
+              {
+                "path": "taker_amounts.[index]",
+                "fields": [
+                  {
+                    "path": "[]",
+                    "label": "Sell Token",
+                    "format": "tokenAmount",
+                    "params": {
+                      "tokenPath": "witness.taker_tokens.[_outerIndex].[ _innerIndex ]"
+                    }
+                  }
+                ]
+              },
+              {
+                "path": "maker_amounts.[]",
+                "fields": [
+                  {
+                    "path": "[]",
+                    "label": "Buy Token",
+                    "format": "tokenAmount",
+                    "params": {
+                      "tokenPath": "witness.maker_tokens.[_outerIndex].[ _innerIndex ]"
+                    }
+                  }
+                ]
+              },
+              {
+                "path": "receiver",
+                "label": "Receiver",
+                "format": "addressName"
+              }
+            ]
+          }
+        ],
+        "excluded": ["hooksHash", "commands"]
+      }
+    }
+  }
+}

--- a/registry/bebop/eip712-bebop-jam.json
+++ b/registry/bebop/eip712-bebop-jam.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "../../specs/erc7730-v1.schema.json",
+  "includes": "common-eip712-base.json",
+
+  "context": {
+    "eip712": {
+      "schemas": [
+        {
+          "types": {
+            "EIP712Domain": [
+              { "name": "name", "type": "string" },
+              { "name": "chainId", "type": "uint256" },
+              { "name": "verifyingContract", "type": "address" }
+            ],
+            "TokenPermissions": [
+              { "name": "token", "type": "address" },
+              { "name": "amount", "type": "uint256" }
+            ],
+            "JamOrder": [
+              { "name": "taker", "type": "address" },
+              { "name": "receiver", "type": "address" },
+              { "name": "expiry", "type": "uint256" },
+              { "name": "exclusivityDeadline", "type": "uint256" },
+              { "name": "nonce", "type": "uint256" },
+              { "name": "executor", "type": "address" },
+              { "name": "partnerInfo", "type": "uint256" },
+              { "name": "sellTokens", "type": "address[]" },
+              { "name": "sellAmounts", "type": "uint256[]" },
+              { "name": "buyTokens", "type": "address[]" },
+              { "name": "buyAmounts", "type": "uint256[]" },
+              { "name": "hooksHash", "type": "bytes32" }
+            ],
+            "PermitBatchWitnessTransferFrom": [
+              { "name": "permitted", "type": "TokenPermissions[]" },
+              { "name": "spender", "type": "address" },
+              { "name": "nonce", "type": "uint256" },
+              { "name": "deadline", "type": "uint256" },
+              { "name": "witness", "type": "JamOrder" }
+            ]
+          },
+          "primaryType": "PermitBatchWitnessTransferFrom"
+        }
+      ]
+    }
+  },
+
+  "display": {
+    "formats": {
+      "PermitBatchWitnessTransferFrom": {
+        "intent": "Bebop Jam Order",
+        "fields": [
+          {
+            "path": "spender",
+            "label": "Approved Spender",
+            "format": "addressName"
+          },
+          {
+            "path": "permitted.[]",
+            "fields": [
+              {
+                "path": "amount",
+                "label": "Approval Amount",
+                "format": "tokenAmount",
+                "params": {
+                  "tokenPath": "token"
+                }
+              }
+            ]
+          },
+          {
+            "path": "witness",
+            "fields": [
+              {
+                "path": "taker",
+                "label": "Taker",
+                "format": "addressName"
+              },
+              {
+                "path": "receiver",
+                "label": "Receiver",
+                "format": "addressName"
+              },
+              {
+                "path": "sellAmounts.[]",
+                "fields": [
+                  {
+                    "path": "",
+                    "label": "Sell Amount",
+                    "format": "tokenAmount",
+                    "params": {
+                      "tokenPath": "witness.sellTokens.[_index]"
+                    }
+                  }
+                ]
+              },
+              {
+                "path": "buyAmounts.[]",
+                "fields": [
+                  {
+                    "path": "",
+                    "label": "Buy Amount",
+                    "format": "tokenAmount",
+                    "params": {
+                      "tokenPath": "witness.buyTokens.[_index]"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "path": "deadline",
+            "label": "Deadline",
+            "format": "date",
+            "params": { "encoding": "timestamp" }
+          }
+        ],
+        "excluded": [
+          "nonce",
+          "witness.exclusivityDeadline",
+          "witness.nonce",
+          "witness.executor",
+          "witness.partnerInfo",
+          "witness.hooksHash"
+        ]
+      }
+    }
+  }
+}

--- a/registry/bebop/eip712-bebop-multiorder.json
+++ b/registry/bebop/eip712-bebop-multiorder.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "../../specs/erc7730-v1.schema.json",
+  "includes": "common-eip712-base.json",
+
+  "context": {
+    "eip712": {
+      "schemas": [
+        {
+          "types": {
+            "EIP712Domain": [
+              { "name": "name", "type": "string" },
+              { "name": "chainId", "type": "uint256" },
+              { "name": "verifyingContract", "type": "address" }
+            ],
+            "TokenPermissions": [
+              { "name": "token", "type": "address" },
+              { "name": "amount", "type": "uint256" }
+            ],
+            "MultiOrder": [
+              { "name": "partner_id", "type": "uint64" },
+              { "name": "expiry", "type": "uint256" },
+              { "name": "taker_address", "type": "address" },
+              { "name": "maker_address", "type": "address" },
+              { "name": "maker_nonce", "type": "uint256" },
+              { "name": "taker_tokens", "type": "address[]" },
+              { "name": "maker_tokens", "type": "address[]" },
+              { "name": "taker_amounts", "type": "uint256[]" },
+              { "name": "maker_amounts", "type": "uint256[]" },
+              { "name": "receiver", "type": "address" },
+              { "name": "commands", "type": "bytes" },
+              { "name": "hooksHash", "type": "bytes32" }
+            ],
+            "PermitBatchWitnessTransferFrom": [
+              { "name": "permitted", "type": "TokenPermissions[]" },
+              { "name": "spender", "type": "address" },
+              { "name": "nonce", "type": "uint256" },
+              { "name": "deadline", "type": "uint256" },
+              { "name": "witness", "type": "MultiOrder" }
+            ]
+          },
+          "primaryType": "PermitBatchWitnessTransferFrom"
+        }
+      ],
+      "domain": {
+        "name": "Bebop Multi Order"
+      }
+    }
+  },
+
+  "display": {
+    "formats": {
+      "PermitBatchWitnessTransferFrom": {
+        "intent": "MultiOrder Permit",
+        "fields": [
+          {
+            "path": "spender",
+            "label": "Approved Spender",
+            "format": "addressName"
+          },
+          {
+            "path": "permitted.[]",
+            "fields": [
+              {
+                "path": "amount",
+                "label": "Approval Amount",
+                "format": "tokenAmount",
+                "params": { "tokenPath": "token" }
+              }
+            ]
+          },
+          {
+            "path": "witness",
+            "fields": [
+              {
+                "path": "taker_address",
+                "label": "Taker",
+                "format": "addressName"
+              },
+              {
+                "path": "taker_amounts.[]",
+                "fields": [
+                  {
+                    "path": "",
+                    "label": "Sell Token",
+                    "format": "tokenAmount",
+                    "params": {
+                      "tokenPath": "witness.taker_tokens.[_index]"
+                    }
+                  }
+                ]
+              },
+              {
+                "path": "maker_amounts.[]",
+                "fields": [
+                  {
+                    "path": "",
+                    "label": "Buy Token",
+                    "format": "tokenAmount",
+                    "params": {
+                      "tokenPath": "witness.maker_tokens.[_index]"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "path": "deadline",
+            "label": "Expiration",
+            "format": "date",
+            "params": { "encoding": "timestamp" }
+          }
+        ],
+        "excluded": [
+          "nonce",
+          "witness.partner_id",
+          "witness.maker_nonce",
+          "witness.maker_tokens",
+          "witness.taker_tokens",
+          "witness.commands",
+          "witness.hooksHash",
+          "witness.receiver"
+        ]
+      }
+    }
+  }
+}

--- a/registry/bebop/eip712-bebop-singleorder.json
+++ b/registry/bebop/eip712-bebop-singleorder.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "../../specs/erc7730-v1.schema.json",
+  "includes": "common-eip712-base.json",
+
+  "context": {
+    "eip712": {
+      "schemas": [
+        {
+          "types": {
+            "EIP712Domain": [
+              { "name": "name", "type": "string" },
+              { "name": "chainId", "type": "uint256" },
+              { "name": "verifyingContract", "type": "address" }
+            ],
+            "TokenPermissions": [
+              { "name": "token", "type": "address" },
+              { "name": "amount", "type": "uint256" }
+            ],
+            "SingleOrder": [
+              { "name": "partner_id", "type": "uint64" },
+              { "name": "expiry", "type": "uint256" },
+              { "name": "taker_address", "type": "address" },
+              { "name": "maker_address", "type": "address" },
+              { "name": "maker_nonce", "type": "uint256" },
+              { "name": "taker_token", "type": "address" },
+              { "name": "maker_token", "type": "address" },
+              { "name": "taker_amount", "type": "uint256" },
+              { "name": "maker_amount", "type": "uint256" },
+              { "name": "receiver", "type": "address" },
+              { "name": "packed_commands", "type": "uint256" },
+              { "name": "hooksHash", "type": "bytes32" }
+            ],
+            "PermitWitnessTransferFrom": [
+              { "name": "permitted", "type": "TokenPermissions" },
+              { "name": "spender", "type": "address" },
+              { "name": "nonce", "type": "uint256" },
+              { "name": "deadline", "type": "uint256" },
+              { "name": "witness", "type": "SingleOrder" }
+            ]
+          },
+          "primaryType": "PermitWitnessTransferFrom"
+        }
+      ],
+      "domain": {
+        "name": "Bebop Single Order"
+      }
+    }
+  },
+
+  "display": {
+    "formats": {
+      "PermitWitnessTransferFrom": {
+        "intent": "SingleOrder Permit",
+        "fields": [
+          {
+            "path": "spender",
+            "label": "Approved Spender",
+            "format": "addressName"
+          },
+          {
+            "path": "permitted",
+            "fields": [
+              {
+                "path": "token",
+                "label": "Token To Approve",
+                "format": "addressName",
+                "params": { "types": ["token"] }
+              },
+              {
+                "path": "amount",
+                "label": "Approval Amount",
+                "format": "tokenAmount",
+                "params": { "tokenPath": "token" }
+              }
+            ]
+          },
+          {
+            "path": "witness",
+            "fields": [
+              {
+                "path": "taker_address",
+                "label": "Taker",
+                "format": "addressName"
+              },
+              {
+                "path": "maker_address",
+                "label": "Maker",
+                "format": "addressName"
+              },
+              {
+                "path": "taker_amount",
+                "label": "Sell Token",
+                "format": "tokenAmount",
+                "params": { "tokenPath": "taker_token" }
+              },
+              {
+                "path": "maker_amount",
+                "label": "Buy Token",
+                "format": "tokenAmount",
+                "params": { "tokenPath": "maker_token" }
+              }
+            ]
+          },
+          {
+            "path": "deadline",
+            "label": "Expiration",
+            "format": "date",
+            "params": { "encoding": "timestamp" }
+          }
+        ],
+        "excluded": [
+          "nonce",
+          "witness.partner_id",
+          "witness.expiry",
+          "witness.maker_nonce",
+          "witness.packed_commands",
+          "witness.hooksHash",
+          "witness.receiver"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adding [Bebop](https://bebop.xyz/) EIP-712 messages. 

A few questions before this goes in though: 
- Is there any way to validate this beforehand?
- Currently we have a nested array type for ERC20 tokens and tokenAmounts 
```json
              { "name": "taker_tokens", "type": "address[][]" },
              { "name": "taker_amounts", "type": "uint256[][]" },
              { "name": "maker_tokens", "type": "address[][]" },
              { "name": "maker_amounts", "type": "uint256[][]" },
```

Going through the spec documentation - I can see there's an index access paragraph but I'm not clear as to how to go about nesting this behaviour. 

Can anyone shed some light on this? Current draft is in - [registry/bebop/eip712-bebop-aggregateorder.json](https://github.com/LedgerHQ/clear-signing-erc7730-registry/pull/1205/files#diff-8aae16923f0bf9380efa14cd225fa83fceb3f7bcf6fbe80b0e26d0641fbcc3ccR100-R124)