### PR TITLE
Add Yield.xyz USDe (Ethena) Vault

### DIFF
--- a/registry/ethena/calldata-ethena.json
+++ b/registry/ethena/calldata-ethena.json
@@ -1,0 +1,159 @@
+{
+    "$schema": "../../specs/erc7730-v1.schema.json",
+    "context": {
+      "$id": "Staked USDe",
+      "contract": {
+        "deployments": [
+          {
+            "chainId": 1,
+            "address": "0x9D39A5DE30e57443BfF2A8307A4256c8797A3497"
+          }
+        ],
+        "abi": [
+          {
+            "type": "function",
+            "name": "cooldownAssets",
+            "inputs": [
+              {
+                "name": "assets",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "shares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "cooldownShares",
+            "inputs": [
+              {
+                "name": "shares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "assets",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          },
+          {
+            "type": "function",
+            "name": "unstake",
+            "inputs": [
+              {
+                "name": "receiver",
+                "type": "address",
+                "internalType": "address"
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "constant": null,
+            "payable": null,
+            "gas": null,
+            "signature": null
+          }
+        ],
+        "addressMatcher": null,
+        "factory": null
+      }
+    },
+    "metadata": {
+      "owner": "Ethena",
+      "info": {
+        "legalName": "Ethena",
+        "url": "https://ethena.fi/"
+      }
+    },
+    "display": {
+      "formats": {
+        "cooldownShares(uint256)": {
+          "$id": null,
+          "intent": "Cooldown Shares",
+          "screens": null,
+          "fields": [
+            {
+              "$id": null,
+              "label": "Amount",
+              "format": "tokenAmount",
+              "params": {
+                "tokenPath": "0x9D39A5DE30e57443BfF2A8307A4256c8797A3497"
+              },
+              "path": "#.shares",
+              "value": null
+            }
+          ],
+          "required": [
+            "#.shares"
+          ],
+          "excluded": null
+        },
+        "cooldownAssets(uint256)": {
+          "$id": null,
+          "intent": "Cooldown Assets",
+          "screens": null,
+          "fields": [
+            {
+              "$id": null,
+              "label": "Amount",
+              "format": "tokenAmount",
+              "params": {
+                "tokenPath": "0x4c9EDD5852cd905f086C759E8383e09bff1E68B3"
+              },
+              "path": "#.assets",
+              "value": null
+            }
+          ],
+          "required": [
+            "#.assets"
+          ],
+          "excluded": null
+        },
+        "unstake(address)": {
+          "$id": null,
+          "intent": "Unstake",
+          "screens": null,
+          "fields": [
+            {
+              "$id": null,
+              "label": "Receiver",
+              "format": "addressName",
+              "params": {
+                "types": [
+                  "eoa",
+                  "wallet"
+                ],
+                "sources": null
+              },
+              "path": "#.receiver",
+              "value": null
+            }
+          ],
+          "required": [
+            "#.receiver"
+          ],
+          "excluded": null
+        }
+      }
+    }
+  }

--- a/registry/yieldxyz/calldata-yieldxyz-usde-vault.json
+++ b/registry/yieldxyz/calldata-yieldxyz-usde-vault.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../specs/erc7730-v1.schema.json",
+  "includes": "../../ercs/calldata-erc4626-vaults.json",
+  "metadata": {
+    "owner": "Yield.xyz",
+    "info": { "legalName": "Yield.xyz", "url": "https://yield.xyz/" },
+    "constants": { "underlyingToken": "0x4c9EDD5852cd905f086C759E8383e09bff1E68B3", "underlyingTicker": "USDe", "vaultTicker": "stk-USDe" }
+  },
+  "context": { "contract": { "deployments": [{ "chainId": 1, "address": "0x4E6189F16a348E6233a33317C6480F2fd4fc7870" }] } }
+}


### PR DESCRIPTION
This pull request adds clear signing for two contracts: Yield.xyz's USDe vault and Ethena's staking contract. 

Yield.xyz USDe Vault Configuration (`registry/yieldxyz/calldata-yieldxyz-usde-vault.json`):
* Yield.xyz's USDe is using existing erc4626 calldata schema

Ethena Staking Contract Configuration (`registry/ethena/calldata-ethena.json`):
* Metadata and functions for `cooldownAssets`, `cooldownShares`, and `unstake`.

