### PR TITLE
Add ERC-7730 metadata for Compound Protocol

### DIFF
--- a/registry/compound/calldata-CometETH.json
+++ b/registry/compound/calldata-CometETH.json
@@ -117,31 +117,6 @@
           }
         ],
         "required": ["amount", "asset", "dst"]
-      },
-      "transferAsset(address dst, address asset, uint amount)": {
-        "$id": "transferAsset",
-        "intent": "Transfer asset within Compound",
-        "fields": [
-          {
-            "path": "amount",
-            "format": "tokenAmount",
-            "label": "Amount to transfer",
-            "params": { "tokenPath": "asset" }
-          },
-          {
-            "path": "asset",
-            "format": "addressName",
-            "label": "Asset",
-            "params": { "types": ["token"], "sources": ["local", "ens"] }
-          },
-          {
-            "path": "dst",
-            "format": "addressName",
-            "label": "Recipient",
-            "params": { "types": ["eoa"], "sources": ["local", "ens"] }
-          }
-        ],
-        "required": ["amount", "asset", "dst"]
       }
     }
   }

--- a/registry/compound/calldata-CometETH.json
+++ b/registry/compound/calldata-CometETH.json
@@ -1,0 +1,166 @@
+{
+  "$schema": "../../specs/erc7730-v1.schema.json",
+  "context": {
+    "$id": "CometETH",
+    "contract": {
+      "abi": "https://api.etherscan.io/api?module=contract&action=getabi&address=0xA17581A9E3356d9A858b789D68B4d866e593aE94",
+      "deployments": [
+        { "chainId": 1, "address": "0xA17581A9E3356d9A858b789D68B4d866e593aE94" }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "Compound Labs",
+    "info": {
+      "url": "https://compound.finance",
+      "legalName": "Compound Labs, Inc.",
+      "deploymentDate": "2023-01-09T00:00:00Z"
+    },
+    "constants": {
+      "max": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    }
+  },
+  "display": {
+    "formats": {
+      "supply(address asset, uint amount)": {
+        "$id": "supply",
+        "intent": "Supply asset to Compound",
+        "fields": [
+          {
+            "path": "amount",
+            "format": "tokenAmount",
+            "label": "Amount to supply",
+            "params": { "tokenPath": "asset" }
+          },
+          {
+            "path": "asset",
+            "format": "addressName",
+            "label": "Asset",
+            "params": { "types": ["token"], "sources": ["local", "ens"] }
+          }
+        ],
+        "required": ["amount", "asset"]
+      },
+      "supplyTo(address dst, address asset, uint amount)": {
+        "$id": "supplyTo",
+        "intent": "Supply asset to Compound for recipient",
+        "fields": [
+          {
+            "path": "amount",
+            "format": "tokenAmount",
+            "label": "Amount to supply",
+            "params": { "tokenPath": "asset" }
+          },
+          {
+            "path": "asset",
+            "format": "addressName",
+            "label": "Asset",
+            "params": { "types": ["token"], "sources": ["local", "ens"] }
+          },
+          {
+            "path": "dst",
+            "format": "addressName",
+            "label": "Recipient",
+            "params": { "types": ["eoa"], "sources": ["local", "ens"] }
+          }
+        ],
+        "required": ["amount", "asset", "dst"]
+      },
+      "withdraw(address asset, uint amount)": {
+        "$id": "withdraw",
+        "intent": "Withdraw asset from Compound",
+        "fields": [
+          {
+            "path": "amount",
+            "format": "tokenAmount",
+            "label": "Amount to withdraw",
+            "params": { 
+              "tokenPath": "asset", 
+              "threshold": "$.metadata.constants.max", 
+              "message": "Max" 
+            }
+          },
+          {
+            "path": "asset",
+            "format": "addressName",
+            "label": "Asset",
+            "params": { "types": ["token"], "sources": ["local", "ens"] }
+          }
+        ],
+        "required": ["amount", "asset"]
+      },
+      "withdrawTo(address dst, address asset, uint amount)": {
+        "$id": "withdrawTo",
+        "intent": "Withdraw asset from Compound to recipient",
+        "fields": [
+          {
+            "path": "amount",
+            "format": "tokenAmount",
+            "label": "Amount to withdraw",
+            "params": { 
+              "tokenPath": "asset", 
+              "threshold": "$.metadata.constants.max", 
+              "message": "Max" 
+            }
+          },
+          {
+            "path": "asset",
+            "format": "addressName",
+            "label": "Asset",
+            "params": { "types": ["token"], "sources": ["local", "ens"] }
+          },
+          {
+            "path": "dst",
+            "format": "addressName",
+            "label": "Recipient",
+            "params": { "types": ["eoa"], "sources": ["local", "ens"] }
+          }
+        ],
+        "required": ["amount", "asset", "dst"]
+      },
+      "transferAsset(address dst, address asset, uint amount)": {
+        "$id": "transferAsset",
+        "intent": "Transfer asset within Compound",
+        "fields": [
+          {
+            "path": "amount",
+            "format": "tokenAmount",
+            "label": "Amount to transfer",
+            "params": { "tokenPath": "asset" }
+          },
+          {
+            "path": "asset",
+            "format": "addressName",
+            "label": "Asset",
+            "params": { "types": ["token"], "sources": ["local", "ens"] }
+          },
+          {
+            "path": "dst",
+            "format": "addressName",
+            "label": "Recipient",
+            "params": { "types": ["eoa"], "sources": ["local", "ens"] }
+          }
+        ],
+        "required": ["amount", "asset", "dst"]
+      },
+      "absorb(address absorber, address[] accounts)": {
+        "$id": "absorb",
+        "intent": "Liquidate underwater accounts",
+        "fields": [
+          {
+            "path": "absorber",
+            "format": "addressName",
+            "label": "Absorber",
+            "params": { "types": ["eoa"], "sources": ["local", "ens"] }
+          },
+          {
+            "path": "accounts",
+            "format": "raw",
+            "label": "Accounts to liquidate"
+          }
+        ],
+        "required": ["absorber", "accounts"]
+      }
+    }
+  }
+}

--- a/registry/compound/calldata-CometETH.json
+++ b/registry/compound/calldata-CometETH.json
@@ -142,24 +142,6 @@
           }
         ],
         "required": ["amount", "asset", "dst"]
-      },
-      "absorb(address absorber, address[] accounts)": {
-        "$id": "absorb",
-        "intent": "Liquidate underwater accounts",
-        "fields": [
-          {
-            "path": "absorber",
-            "format": "addressName",
-            "label": "Absorber",
-            "params": { "types": ["eoa"], "sources": ["local", "ens"] }
-          },
-          {
-            "path": "accounts",
-            "format": "raw",
-            "label": "Accounts to liquidate"
-          }
-        ],
-        "required": ["absorber", "accounts"]
       }
     }
   }

--- a/registry/compound/calldata-CometUSDC.json
+++ b/registry/compound/calldata-CometUSDC.json
@@ -117,31 +117,6 @@
           }
         ],
         "required": ["amount", "asset", "dst"]
-      },
-      "transferAsset(address dst, address asset, uint amount)": {
-        "$id": "transferAsset",
-        "intent": "Transfer asset within Compound",
-        "fields": [
-          {
-            "path": "amount",
-            "format": "tokenAmount",
-            "label": "Amount to transfer",
-            "params": { "tokenPath": "asset" }
-          },
-          {
-            "path": "asset",
-            "format": "addressName",
-            "label": "Asset",
-            "params": { "types": ["token"], "sources": ["local", "ens"] }
-          },
-          {
-            "path": "dst",
-            "format": "addressName",
-            "label": "Recipient",
-            "params": { "types": ["eoa"], "sources": ["local", "ens"] }
-          }
-        ],
-        "required": ["amount", "asset", "dst"]
       }
     }
   }

--- a/registry/compound/calldata-CometUSDC.json
+++ b/registry/compound/calldata-CometUSDC.json
@@ -1,0 +1,166 @@
+{
+  "$schema": "../../specs/erc7730-v1.schema.json",
+  "context": {
+    "$id": "CometUSDC",
+    "contract": {
+      "abi": "https://api.etherscan.io/api?module=contract&action=getabi&address=0xc3d688B66703497DAA19211EEdff47f25384cdc3",
+      "deployments": [
+        { "chainId": 1, "address": "0xc3d688B66703497DAA19211EEdff47f25384cdc3" }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "Compound Labs",
+    "info": {
+      "url": "https://compound.finance",
+      "legalName": "Compound Labs, Inc.",
+      "deploymentDate": "2022-08-26T00:00:00Z"
+    },
+    "constants": {
+      "max": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    }
+  },
+  "display": {
+    "formats": {
+      "supply(address asset, uint amount)": {
+        "$id": "supply",
+        "intent": "Supply asset to Compound",
+        "fields": [
+          {
+            "path": "amount",
+            "format": "tokenAmount",
+            "label": "Amount to supply",
+            "params": { "tokenPath": "asset" }
+          },
+          {
+            "path": "asset",
+            "format": "addressName",
+            "label": "Asset",
+            "params": { "types": ["token"], "sources": ["local", "ens"] }
+          }
+        ],
+        "required": ["amount", "asset"]
+      },
+      "supplyTo(address dst, address asset, uint amount)": {
+        "$id": "supplyTo",
+        "intent": "Supply asset to Compound for recipient",
+        "fields": [
+          {
+            "path": "amount",
+            "format": "tokenAmount",
+            "label": "Amount to supply",
+            "params": { "tokenPath": "asset" }
+          },
+          {
+            "path": "asset",
+            "format": "addressName",
+            "label": "Asset",
+            "params": { "types": ["token"], "sources": ["local", "ens"] }
+          },
+          {
+            "path": "dst",
+            "format": "addressName",
+            "label": "Recipient",
+            "params": { "types": ["eoa"], "sources": ["local", "ens"] }
+          }
+        ],
+        "required": ["amount", "asset", "dst"]
+      },
+      "withdraw(address asset, uint amount)": {
+        "$id": "withdraw",
+        "intent": "Withdraw asset from Compound",
+        "fields": [
+          {
+            "path": "amount",
+            "format": "tokenAmount",
+            "label": "Amount to withdraw",
+            "params": { 
+              "tokenPath": "asset", 
+              "threshold": "$.metadata.constants.max", 
+              "message": "Max" 
+            }
+          },
+          {
+            "path": "asset",
+            "format": "addressName",
+            "label": "Asset",
+            "params": { "types": ["token"], "sources": ["local", "ens"] }
+          }
+        ],
+        "required": ["amount", "asset"]
+      },
+      "withdrawTo(address dst, address asset, uint amount)": {
+        "$id": "withdrawTo",
+        "intent": "Withdraw asset from Compound to recipient",
+        "fields": [
+          {
+            "path": "amount",
+            "format": "tokenAmount",
+            "label": "Amount to withdraw",
+            "params": { 
+              "tokenPath": "asset", 
+              "threshold": "$.metadata.constants.max", 
+              "message": "Max" 
+            }
+          },
+          {
+            "path": "asset",
+            "format": "addressName",
+            "label": "Asset",
+            "params": { "types": ["token"], "sources": ["local", "ens"] }
+          },
+          {
+            "path": "dst",
+            "format": "addressName",
+            "label": "Recipient",
+            "params": { "types": ["eoa"], "sources": ["local", "ens"] }
+          }
+        ],
+        "required": ["amount", "asset", "dst"]
+      },
+      "transferAsset(address dst, address asset, uint amount)": {
+        "$id": "transferAsset",
+        "intent": "Transfer asset within Compound",
+        "fields": [
+          {
+            "path": "amount",
+            "format": "tokenAmount",
+            "label": "Amount to transfer",
+            "params": { "tokenPath": "asset" }
+          },
+          {
+            "path": "asset",
+            "format": "addressName",
+            "label": "Asset",
+            "params": { "types": ["token"], "sources": ["local", "ens"] }
+          },
+          {
+            "path": "dst",
+            "format": "addressName",
+            "label": "Recipient",
+            "params": { "types": ["eoa"], "sources": ["local", "ens"] }
+          }
+        ],
+        "required": ["amount", "asset", "dst"]
+      },
+      "absorb(address absorber, address[] accounts)": {
+        "$id": "absorb",
+        "intent": "Liquidate underwater accounts",
+        "fields": [
+          {
+            "path": "absorber",
+            "format": "addressName",
+            "label": "Absorber",
+            "params": { "types": ["eoa"], "sources": ["local", "ens"] }
+          },
+          {
+            "path": "accounts",
+            "format": "raw",
+            "label": "Accounts to liquidate"
+          }
+        ],
+        "required": ["absorber", "accounts"]
+      }
+    }
+  }
+}

--- a/registry/compound/calldata-CometUSDC.json
+++ b/registry/compound/calldata-CometUSDC.json
@@ -142,24 +142,6 @@
           }
         ],
         "required": ["amount", "asset", "dst"]
-      },
-      "absorb(address absorber, address[] accounts)": {
-        "$id": "absorb",
-        "intent": "Liquidate underwater accounts",
-        "fields": [
-          {
-            "path": "absorber",
-            "format": "addressName",
-            "label": "Absorber",
-            "params": { "types": ["eoa"], "sources": ["local", "ens"] }
-          },
-          {
-            "path": "accounts",
-            "format": "raw",
-            "label": "Accounts to liquidate"
-          }
-        ],
-        "required": ["absorber", "accounts"]
       }
     }
   }

--- a/registry/compound/eip712-compound-governance.json
+++ b/registry/compound/eip712-compound-governance.json
@@ -98,7 +98,8 @@
           {
             "path": "expiry",
             "format": "date",
-            "label": "Expires at"
+            "label": "Expires at",
+            "params": { "encoding": "timestamp" }
           }
         ],
         "required": ["delegatee", "nonce", "expiry"]

--- a/registry/compound/eip712-compound-governance.json
+++ b/registry/compound/eip712-compound-governance.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "../../specs/erc7730-v1.schema.json",
+  "context": {
+    "$id": "CompoundGovernance",
+    "eip712": {
+      "schemas": [
+        {
+          "types": {
+            "EIP712Domain": [
+              { "name": "name", "type": "string" },
+              { "name": "chainId", "type": "uint256" },
+              { "name": "verifyingContract", "type": "address" }
+            ],
+            "Ballot": [
+              { "name": "proposalId", "type": "uint256" },
+              { "name": "support", "type": "uint8" }
+            ]
+          },
+          "primaryType": "Ballot"
+        },
+        {
+          "types": {
+            "EIP712Domain": [
+              { "name": "name", "type": "string" },
+              { "name": "version", "type": "string" },
+              { "name": "chainId", "type": "uint256" },
+              { "name": "verifyingContract", "type": "address" }
+            ],
+            "Delegation": [
+              { "name": "delegatee", "type": "address" },
+              { "name": "nonce", "type": "uint256" },
+              { "name": "expiry", "type": "uint256" }
+            ]
+          },
+          "primaryType": "Delegation"
+        }
+      ],
+      "domain": {
+        "name": "Compound Governor Bravo",
+        "chainId": 1,
+        "verifyingContract": "0xc0Da02939E1441F497fd74F78cE7Decb17B66529"
+      },
+      "deployments": [
+        { "chainId": 1, "address": "0xc0Da02939E1441F497fd74F78cE7Decb17B66529" }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "Compound Labs",
+    "info": {
+      "url": "https://compound.finance",
+      "legalName": "Compound Labs, Inc.",
+      "deploymentDate": "2021-04-30T00:00:00Z"
+    },
+    "enums": {
+      "voteSupport": {
+        "0": "Against",
+        "1": "For",
+        "2": "Abstain"
+      }
+    }
+  },
+  "display": {
+    "formats": {
+      "Ballot": {
+        "$id": "ballot",
+        "intent": "Vote on Compound governance proposal",
+        "fields": [
+          {
+            "path": "proposalId",
+            "format": "raw",
+            "label": "Proposal ID"
+          },
+          {
+            "path": "support",
+            "format": "enum",
+            "label": "Vote",
+            "params": { "$ref": "$.metadata.enums.voteSupport" }
+          }
+        ],
+        "required": ["proposalId", "support"]
+      },
+      "Delegation": {
+        "$id": "delegation",
+        "intent": "Delegate COMP voting power",
+        "fields": [
+          {
+            "path": "delegatee",
+            "format": "addressName",
+            "label": "Delegate to",
+            "params": { "types": ["eoa"], "sources": ["local", "ens"] }
+          },
+          {
+            "path": "nonce",
+            "format": "raw",
+            "label": "Nonce"
+          },
+          {
+            "path": "expiry",
+            "format": "date",
+            "label": "Expires at"
+          }
+        ],
+        "required": ["delegatee", "nonce", "expiry"]
+      }
+    }
+  }
+}

--- a/registry/compound/eip712-permit-COMP.json
+++ b/registry/compound/eip712-permit-COMP.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "../../specs/erc7730-v1.schema.json",
+  "context": {
+    "$id": "COMPPermit",
+    "eip712": {
+      "schemas": [
+        {
+          "types": {
+            "EIP712Domain": [
+              { "name": "name", "type": "string" },
+              { "name": "chainId", "type": "uint256" },
+              { "name": "verifyingContract", "type": "address" }
+            ],
+            "Permit": [
+              { "name": "owner", "type": "address" },
+              { "name": "spender", "type": "address" },
+              { "name": "value", "type": "uint256" },
+              { "name": "nonce", "type": "uint256" },
+              { "name": "deadline", "type": "uint256" }
+            ]
+          },
+          "primaryType": "Permit"
+        }
+      ],
+      "domain": {
+        "name": "Compound",
+        "chainId": 1,
+        "verifyingContract": "0xc00e94Cb662C3520282E6f5717214004A7f26888"
+      },
+      "deployments": [
+        { "chainId": 1, "address": "0xc00e94Cb662C3520282E6f5717214004A7f26888" }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "Compound Labs",
+    "info": {
+      "url": "https://compound.finance",
+      "legalName": "Compound Labs, Inc.",
+      "deploymentDate": "2020-06-15T00:00:00Z"
+    },
+    "constants": {
+      "max": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    }
+  },
+  "display": {
+    "formats": {
+      "Permit": {
+        "$id": "permit",
+        "intent": "Approve COMP token spending",
+        "fields": [
+          {
+            "path": "owner",
+            "format": "addressName",
+            "label": "Token owner",
+            "params": { "types": ["eoa"], "sources": ["local", "ens"] }
+          },
+          {
+            "path": "spender",
+            "format": "addressName",
+            "label": "Approved spender",
+            "params": { "types": ["eoa", "contract"], "sources": ["local", "ens"] }
+          },
+          {
+            "path": "value",
+            "format": "tokenAmount",
+            "label": "Approval amount",
+            "params": { 
+              "token": "0xc00e94Cb662C3520282E6f5717214004A7f26888",
+              "threshold": "$.metadata.constants.max",
+              "message": "Unlimited"
+            }
+          },
+          {
+            "path": "deadline",
+            "format": "date",
+            "label": "Permit expires at"
+          }
+        ],
+        "required": ["owner", "spender", "value", "deadline"],
+        "excluded": ["nonce"]
+      }
+    }
+  }
+}

--- a/registry/compound/eip712-permit-COMP.json
+++ b/registry/compound/eip712-permit-COMP.json
@@ -74,7 +74,8 @@
           {
             "path": "deadline",
             "format": "date",
-            "label": "Permit expires at"
+            "label": "Permit expires at",
+            "params": { "encoding": "timestamp" }
           }
         ],
         "required": ["owner", "spender", "value", "deadline"],


### PR DESCRIPTION
- Add calldata metadata for Compound V3 USDC market (CometUSDC)
- Add calldata metadata for Compound V3 ETH market (CometETH)
- Add EIP-712 metadata for Compound governance voting
- Add EIP-712 metadata for COMP token permit functionality

These files enable clear signing for major Compound Protocol interactions including:
- Supply/withdraw operations
- Asset transfers
- Liquidations
- Governance voting
- Token approvals via permit

