### PR TITLE
feat: add Aave pool addresses

### DIFF
--- a/registry/aave/calldata-lpv2.json
+++ b/registry/aave/calldata-lpv2.json
@@ -4,14 +4,33 @@
     "$id": "Lending Pool v2",
     "contract": {
       "abi": "https://github.com/LedgerHQ/ledger-asset-dapps/blob/211e75ed27de3894f592ca73710fa0b72c3ceeae/ethereum/aave/abis/0x7d2768de32b0b80b7a3454c06bdac94a69ddc7a9.abi.json",
-      "deployments": [{ "chainId": 1, "address": "0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9" }]
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9"
+        },
+        {
+          "chainId": 137,
+          "address": "0x8dFf5E27EA6b7AC08EbFdf9eB090F32ee9a30fcf"
+        },
+        {
+          "chainId": 43114,
+          "address": "0x4F01AeD16D97E3aB5ab2B501154DC9bb0F1A5A2C"
+        }
+      ]
     }
   },
   "metadata": {
     "owner": "Aave",
-    "info": { "url": "https://aave.com", "legalName": "Aave DAO", "deploymentDate": "2020-11-30T09:25:48Z" },
+    "info": {
+      "url": "https://aave.com",
+      "legalName": "Aave DAO",
+      "deploymentDate": "2020-11-30T09:25:48Z"
+    },
     "enums": { "interestRateMode": { "1": "stable", "2": "variable" } },
-    "constants": { "max": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" }
+    "constants": {
+      "max": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    }
   },
   "display": {
     "formats": {
@@ -23,7 +42,11 @@
             "path": "amount",
             "format": "tokenAmount",
             "label": "Amount to repay",
-            "params": { "tokenPath": "asset", "threshold": "$.metadata.constants.max", "message": "All" }
+            "params": {
+              "tokenPath": "asset",
+              "threshold": "$.metadata.constants.max",
+              "message": "All"
+            }
           },
           {
             "path": "rateMode",
@@ -49,7 +72,11 @@
             "label": "For asset",
             "params": { "types": ["token"], "sources": ["local", "ens"] }
           },
-          { "path": "useAsCollateral", "format": "raw", "label": "Enable use as collateral" }
+          {
+            "path": "useAsCollateral",
+            "format": "raw",
+            "label": "Enable use as collateral"
+          }
         ],
         "required": ["asset", "useAsCollateral"]
       },
@@ -60,7 +87,11 @@
             "path": "amount",
             "format": "tokenAmount",
             "label": "Amount to withdraw",
-            "params": { "tokenPath": "asset", "threshold": "$.metadata.constants.max", "message": "Max" }
+            "params": {
+              "tokenPath": "asset",
+              "threshold": "$.metadata.constants.max",
+              "message": "Max"
+            }
           },
           {
             "path": "to",
@@ -92,7 +123,12 @@
       "borrow(address,uint256,uint256,uint16,address)": {
         "intent": "Borrow",
         "fields": [
-          { "path": "amount", "format": "tokenAmount", "label": "Amount to borrow", "params": { "tokenPath": "asset" } },
+          {
+            "path": "amount",
+            "format": "tokenAmount",
+            "label": "Amount to borrow",
+            "params": { "tokenPath": "asset" }
+          },
           {
             "path": "interestRateMode",
             "format": "enum",
@@ -112,7 +148,12 @@
         "$id": "deposit",
         "intent": "Supply",
         "fields": [
-          { "path": "amount", "format": "tokenAmount", "label": "Amount to supply", "params": { "tokenPath": "asset" } },
+          {
+            "path": "amount",
+            "format": "tokenAmount",
+            "label": "Amount to supply",
+            "params": { "tokenPath": "asset" }
+          },
           {
             "path": "onBehalfOf",
             "format": "addressName",

--- a/registry/aave/calldata-lpv3.json
+++ b/registry/aave/calldata-lpv3.json
@@ -22,8 +22,12 @@
           "address": "0xc47b8C00b0f69a36fa203Ffeac0334874574a8Ac"
         },
         {
-          "chainId": 1088,
+          "chainId": 59144,
           "address": "0xc47b8C00b0f69a36fa203Ffeac0334874574a8Ac"
+        },
+        {
+          "chainId": 1088,
+          "address": "0x90df02551bB792286e8D4f13E0e357b4Bf1D6a57"
         },
         {
           "chainId": 146,

--- a/registry/aave/calldata-lpv3.json
+++ b/registry/aave/calldata-lpv3.json
@@ -4,14 +4,77 @@
     "$id": "PoolInstance",
     "contract": {
       "abi": "https://api.etherscan.io/api?module=contract&action=getabi&address=0xef434e4573b90b6ecd4a00f4888381e4d0cc5ccd",
-      "deployments": [{ "chainId": 1, "address": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2" }]
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"
+        },
+        {
+          "chainId": 8453,
+          "address": "0xA238Dd80C259a72e81d7e4664a9801593F98d1c5"
+        },
+        {
+          "chainId": 42220,
+          "address": "0x3E59A31363E2ad014dcbc521c4a0d5757d9f3402"
+        },
+        {
+          "chainId": 59144,
+          "address": "0xc47b8C00b0f69a36fa203Ffeac0334874574a8Ac"
+        },
+        {
+          "chainId": 1088,
+          "address": "0xc47b8C00b0f69a36fa203Ffeac0334874574a8Ac"
+        },
+        {
+          "chainId": 146,
+          "address": "0x5362dBb1e601abF3a4c14c22ffEdA64042E5eAA3"
+        },
+        {
+          "chainId": 100,
+          "address": "0xb50201558B00496A145fE76f7424749556E326D8"
+        },
+        {
+          "chainId": 534352,
+          "address": "0x11fCfe756c05AD438e312a7fd934381537D3cFfe"
+        },
+        {
+          "chainId": 324,
+          "address": "0x78e30497a3c7527d953c6B1E3541b021A98Ac43c"
+        },
+        {
+          "chainId": 137,
+          "address": "0x794a61358D6845594F94dc1DB02A252b5b4814aD"
+        },
+        {
+          "chainId": 1868,
+          "address": "0xDd3d7A7d03D9fD9ef45f3E587287922eF65CA38B"
+        },
+        {
+          "chainId": 42161,
+          "address": "0x794a61358D6845594F94dc1DB02A252b5b4814aD"
+        },
+        {
+          "chainId": 10,
+          "address": "0x794a61358D6845594F94dc1DB02A252b5b4814aD"
+        },
+        {
+          "chainId": 43114,
+          "address": "0x794a61358D6845594F94dc1DB02A252b5b4814aD"
+        }
+      ]
     }
   },
   "metadata": {
     "owner": "Aave",
-    "info": { "url": "https://aave.com", "legalName": "Aave DAO", "deploymentDate": "2024-10-09T21:46:47Z" },
+    "info": {
+      "url": "https://aave.com",
+      "legalName": "Aave DAO",
+      "deploymentDate": "2024-10-09T21:46:47Z"
+    },
     "enums": { "interestRateMode": { "1": "stable", "2": "variable" } },
-    "constants": { "max": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" }
+    "constants": {
+      "max": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    }
   },
   "display": {
     "formats": {
@@ -23,7 +86,11 @@
             "path": "amount",
             "format": "tokenAmount",
             "label": "Amount to repay",
-            "params": { "tokenPath": "asset", "threshold": "$.metadata.constants.max", "message": "All" }
+            "params": {
+              "tokenPath": "asset",
+              "threshold": "$.metadata.constants.max",
+              "message": "All"
+            }
           },
           {
             "path": "interestRateMode",
@@ -48,7 +115,11 @@
             "path": "amount",
             "format": "tokenAmount",
             "label": "Amount to repay",
-            "params": { "tokenPath": "asset", "threshold": "$.metadata.constants.max", "message": "All" }
+            "params": {
+              "tokenPath": "asset",
+              "threshold": "$.metadata.constants.max",
+              "message": "All"
+            }
           },
           {
             "path": "interestRateMode",
@@ -75,7 +146,11 @@
             "label": "For asset",
             "params": { "types": ["token"], "sources": ["local", "ens"] }
           },
-          { "path": "useAsCollateral", "format": "raw", "label": "Enable use as collateral" }
+          {
+            "path": "useAsCollateral",
+            "format": "raw",
+            "label": "Enable use as collateral"
+          }
         ],
         "required": ["asset", "useAsCollateral"]
       },
@@ -86,7 +161,11 @@
             "path": "amount",
             "format": "tokenAmount",
             "label": "Amount to withdraw",
-            "params": { "tokenPath": "asset", "threshold": "$.metadata.constants.max", "message": "Max" }
+            "params": {
+              "tokenPath": "asset",
+              "threshold": "$.metadata.constants.max",
+              "message": "Max"
+            }
           },
           {
             "path": "to",
@@ -100,7 +179,12 @@
       "borrow(address asset, uint256 amount, uint256 interestRateMode, uint16 referralCode, address onBehalfOf)": {
         "intent": "Borrow",
         "fields": [
-          { "path": "amount", "format": "tokenAmount", "label": "Amount to borrow", "params": { "tokenPath": "asset" } },
+          {
+            "path": "amount",
+            "format": "tokenAmount",
+            "label": "Amount to borrow",
+            "params": { "tokenPath": "asset" }
+          },
           {
             "path": "interestRateMode",
             "format": "enum",
@@ -121,7 +205,12 @@
         "$id": "deposit",
         "intent": "Supply",
         "fields": [
-          { "path": "amount", "format": "tokenAmount", "label": "Amount to supply", "params": { "tokenPath": "asset" } },
+          {
+            "path": "amount",
+            "format": "tokenAmount",
+            "label": "Amount to supply",
+            "params": { "tokenPath": "asset" }
+          },
           {
             "path": "onBehalfOf",
             "format": "addressName",
@@ -136,7 +225,12 @@
         "$id": "supply",
         "intent": "Supply",
         "fields": [
-          { "path": "amount", "format": "tokenAmount", "label": "Amount to supply", "params": { "tokenPath": "asset" } },
+          {
+            "path": "amount",
+            "format": "tokenAmount",
+            "label": "Amount to supply",
+            "params": { "tokenPath": "asset" }
+          },
           {
             "path": "onBehalfOf",
             "format": "addressName",
@@ -151,7 +245,12 @@
         "$id": "supplyWithPermit",
         "intent": "Supply",
         "fields": [
-          { "path": "amount", "format": "tokenAmount", "label": "Amount to supply", "params": { "tokenPath": "asset" } },
+          {
+            "path": "amount",
+            "format": "tokenAmount",
+            "label": "Amount to supply",
+            "params": { "tokenPath": "asset" }
+          },
           {
             "path": "onBehalfOf",
             "format": "addressName",
@@ -160,7 +259,13 @@
           }
         ],
         "required": ["amount", "onBehalfOf"],
-        "excluded": ["referralCode", "deadline", "permitV", "permitR", "permitS"]
+        "excluded": [
+          "referralCode",
+          "deadline",
+          "permitV",
+          "permitR",
+          "permitS"
+        ]
       }
     }
   }

--- a/registry/aave/calldata-lpv3.json
+++ b/registry/aave/calldata-lpv3.json
@@ -64,6 +64,10 @@
         {
           "chainId": 43114,
           "address": "0x794a61358D6845594F94dc1DB02A252b5b4814aD"
+        },
+        {
+          "chainId": 9745,
+          "address": "0x925a2A7214Ed92428B5b1B090F80b25700095e12"
         }
       ]
     }


### PR DESCRIPTION
Add Aave V2 and V3 pools for networks where Aave is deployed

Addresses can be found here: https://github.com/bgd-labs/aave-address-book it's maintained by BGD an Aave's service provider and it's directly used on multiple Aave's repo including [Aave frontend repo](https://github.com/aave/interface)