### PR TITLE
Add metadata for imToken

### DIFF
--- a/registry/imtoken/calldata-claimable-link-v2.json
+++ b/registry/imtoken/calldata-claimable-link-v2.json
@@ -1,0 +1,448 @@
+{
+  "$schema": "../../specs/erc7730-v1.schema.json",
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 42161,
+          "address": "0x05a10D7A19585218DB515FDf3F20043614C843dB"
+        },
+        {
+          "chainId": 421614,
+          "address": "0x05a10D7A19585218DB515FDf3F20043614C843dB"
+        },
+        {
+          "chainId": 11155111,
+          "address": "0x05a10D7A19585218DB515FDf3F20043614C843dB"
+        },
+        {
+          "chainId": 11155420,
+          "address": "0x05a10D7A19585218DB515FDf3F20043614C843dB"
+        }
+      ],
+      "abi": [
+        {
+          "type": "function",
+          "name": "PERMIT2",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "contract IPermit2"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "claim",
+          "inputs": [
+            {
+              "name": "permit3009",
+              "type": "tuple",
+              "internalType": "struct IClaimableLinkV2.Permit3009",
+              "components": [
+                {
+                  "name": "authorization",
+                  "type": "tuple",
+                  "internalType": "struct IClaimableLinkV2.Authorization",
+                  "components": [
+                    {
+                      "name": "from",
+                      "type": "address",
+                      "internalType": "address"
+                    },
+                    {
+                      "name": "to",
+                      "type": "address",
+                      "internalType": "address"
+                    },
+                    {
+                      "name": "value",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "validAfter",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "validBefore",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "nonce",
+                      "type": "bytes32",
+                      "internalType": "bytes32"
+                    }
+                  ]
+                },
+                {
+                  "name": "token",
+                  "type": "address",
+                  "internalType": "address"
+                }
+              ]
+            },
+            { "name": "signature", "type": "bytes", "internalType": "bytes" },
+            {
+              "name": "recipient",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "claim",
+          "inputs": [
+            {
+              "name": "permit2",
+              "type": "tuple",
+              "internalType": "struct IClaimableLinkV2.Permit2",
+              "components": [
+                {
+                  "name": "permit",
+                  "type": "tuple",
+                  "internalType": "struct IPermit2.PermitTransferFrom",
+                  "components": [
+                    {
+                      "name": "permitted",
+                      "type": "tuple",
+                      "internalType": "struct IPermit2.TokenPermissions",
+                      "components": [
+                        {
+                          "name": "token",
+                          "type": "address",
+                          "internalType": "address"
+                        },
+                        {
+                          "name": "amount",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "nonce",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "deadline",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    }
+                  ]
+                },
+                {
+                  "name": "owner",
+                  "type": "address",
+                  "internalType": "address"
+                }
+              ]
+            },
+            { "name": "signature", "type": "bytes", "internalType": "bytes" },
+            {
+              "name": "recipient",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "commit",
+          "inputs": [
+            {
+              "name": "permitHash",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "commitHash",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "isClaimed",
+          "inputs": [
+            {
+              "name": "permitHash",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            }
+          ],
+          "outputs": [
+            { "name": "claimed", "type": "bool", "internalType": "bool" }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "permitCommit",
+          "inputs": [
+            {
+              "name": "permitHash",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "commitHash",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            }
+          ],
+          "stateMutability": "view"
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "imToken",
+    "info": {
+      "legalName": "imToken Labs",
+      "deploymentDate": "2025-07-21T00:00:00Z",
+      "url": "https://token.im/"
+    }
+  },
+  "display": {
+    "formats": {
+      "claim(((address,address,uint256,uint256,uint256,bytes32),address),bytes,address)": {
+        "$id": "claimEIP3009",
+        "intent": "Claim token via EIP-3009",
+        "fields": [
+          {
+            "path": "#.permit3009",
+            "fields": [
+              {
+                "path": "#.permit3009.authorization",
+                "fields": [
+                  {
+                    "label": "From",
+                    "format": "addressName",
+                    "params": {
+                      "types": ["wallet", "eoa"],
+                      "sources": ["ens", "local"]
+                    },
+                    "path": "#.permit3009.authorization.from"
+                  },
+                  {
+                    "label": "To",
+                    "format": "addressName",
+                    "params": {
+                      "types": ["contract"]
+                    },
+                    "path": "#.permit3009.authorization.to"
+                  },
+                  {
+                    "label": "Value",
+                    "format": "tokenAmount",
+                    "params": { "tokenPath": "#.permit3009.token" },
+                    "path": "#.permit3009.authorization.value"
+                  },
+                  {
+                    "label": "Valid After",
+                    "format": "date",
+                    "params": {
+                      "encoding": "timestamp"
+                    },
+                    "path": "#.permit3009.authorization.validAfter"
+                  },
+                  {
+                    "label": "Valid Before",
+                    "format": "date",
+                    "params": {
+                      "encoding": "timestamp"
+                    },
+                    "path": "#.permit3009.authorization.validBefore"
+                  },
+                  {
+                    "label": "Nonce",
+                    "format": "raw",
+                    "path": "#.permit3009.authorization.nonce"
+                  }
+                ]
+              },
+              {
+                "label": "Token",
+                "format": "addressName",
+                "params": {
+                  "types": ["token"]
+                },
+                "path": "#.permit3009.token"
+              }
+            ]
+          },
+          {
+            "label": "Signature",
+            "format": "raw",
+            "path": "#.signature"
+          },
+          {
+            "label": "Recipient",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens", "contract"]
+            },
+            "path": "#.recipient"
+          }
+        ],
+        "required": [
+          "#.recipient",
+          "#.permit3009.token",
+          "#.permit3009.authorization.value",
+          "#.permit3009.authorization.validAfter",
+          "#.permit3009.authorization.validBefore",
+          "#.permit3009.authorization.nonce"
+        ],
+        "excluded": ["#.signature", "#.permit3009.authorization.from"],
+        "screens": {}
+      },
+      "claim((((address,uint256),uint256,uint256),address),bytes,address)": {
+        "$id": "claimPermit2",
+        "intent": "Claim token via Permit2",
+        "fields": [
+          {
+            "path": "#.permit2",
+            "fields": [
+              {
+                "path": "#.permit2.permit",
+                "fields": [
+                  {
+                    "path": "#.permit2.permit.permitted",
+                    "fields": [
+                      {
+                        "label": "Token",
+                        "format": "addressName",
+                        "params": {
+                          "types": ["token"]
+                        },
+                        "path": "#.permit2.permit.permitted.token"
+                      },
+                      {
+                        "label": "Amount",
+                        "format": "tokenAmount",
+                        "params": {
+                          "tokenPath": "#.permit2.permit.permitted.token"
+                        },
+                        "path": "#.permit2.permit.permitted.amount"
+                      }
+                    ]
+                  },
+                  {
+                    "label": "Nonce",
+                    "format": "raw",
+                    "path": "#.permit2.permit.nonce"
+                  },
+                  {
+                    "label": "Deadline",
+                    "format": "date",
+                    "params": {
+                      "encoding": "timestamp"
+                    },
+                    "path": "#.permit2.permit.deadline"
+                  }
+                ]
+              },
+              {
+                "label": "Owner",
+                "format": "addressName",
+                "params": {
+                  "types": ["eoa", "wallet"],
+                  "sources": ["local", "ens"]
+                },
+                "path": "#.permit2.owner"
+              }
+            ]
+          },
+          {
+            "label": "Signature",
+            "format": "raw",
+            "path": "#.signature"
+          },
+          {
+            "label": "Recipient",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens"]
+            },
+            "path": "#.recipient"
+          }
+        ],
+        "required": [
+          "#.recipient",
+          "#.permit2.permit.nonce",
+          "#.permit2.permit.deadline",
+          "#.permit2.permit.permitted.token",
+          "#.permit2.permit.permitted.amount"
+        ],
+        "excluded": ["#.signature", "#.permit2.owner"],
+        "screens": {}
+      },
+      "commit(bytes32,bytes32)": {
+        "$id": "commit",
+        "intent": "Commit a claim link",
+        "fields": [
+          {
+            "label": "Permit Hash",
+            "format": "raw",
+            "path": "#.permitHash"
+          },
+          {
+            "label": "Commit Hash",
+            "format": "raw",
+            "path": "#.commitHash"
+          }
+        ],
+        "required": ["#.permitHash", "#.commitHash"],
+        "excluded": [],
+        "screens": {}
+      },
+      "isClaimed(bytes32)": {
+        "$id": "isClaimed",
+        "intent": "Checks if a permit is used",
+        "fields": [
+          {
+            "label": "Permit Hash",
+            "format": "raw",
+            "path": "#.permitHash"
+          }
+        ],
+        "required": ["#.permitHash"],
+        "excluded": [],
+        "screens": {}
+      },
+      "permitCommit(bytes32)": {
+        "$id": "permitCommit",
+        "intent": "Links a permit to its claimer",
+        "fields": [
+          {
+            "label": "Permit Hash",
+            "format": "raw",
+            "path": "#.permitHash"
+          }
+        ],
+        "required": ["#.permitHash"],
+        "excluded": [],
+        "screens": {}
+      }
+    }
+  }
+}

--- a/registry/imtoken/eip712-eip3009.json
+++ b/registry/imtoken/eip712-eip3009.json
@@ -1,0 +1,255 @@
+{
+  "$schema": "../../specs/erc7730-v1.schema.json",
+  "context": {
+    "eip712": {
+      "deployments": [
+        {
+          "chainId": 42161,
+          "address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
+        },
+        {
+          "chainId": 8453,
+          "address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+        },
+        {
+          "chainId": 1,
+          "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+        },
+        {
+          "chainId": 10,
+          "address": "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"
+        },
+        {
+          "chainId": 137,
+          "address": "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"
+        },
+        {
+          "chainId": 421614,
+          "address": "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d"
+        },
+        {
+          "chainId": 84532,
+          "address": "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+        },
+        {
+          "chainId": 11155111,
+          "address": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+        },
+        {
+          "chainId": 11155420,
+          "address": "0x5fd84259d66Cd46123540766Be93DFE6D43130D7"
+        },
+        {
+          "chainId": 80002,
+          "address": "0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582"
+        }
+      ],
+      "domain": {
+        "name": "USD Coin",
+        "version": "2"
+      },
+      "schemas": [
+        {
+          "types": {
+            "EIP712Domain": [
+              { "name": "name", "type": "string" },
+              { "name": "version", "type": "string" },
+              { "name": "chainId", "type": "uint256" },
+              { "name": "verifyingContract", "type": "address" }
+            ],
+            "TransferWithAuthorization": [
+              { "name": "from", "type": "address" },
+              { "name": "to", "type": "address" },
+              { "name": "value", "type": "uint256" },
+              { "name": "validAfter", "type": "uint256" },
+              { "name": "validBefore", "type": "uint256" },
+              { "name": "nonce", "type": "bytes32" }
+            ]
+          },
+          "primaryType": "TransferWithAuthorization"
+        },
+        {
+          "types": {
+            "EIP712Domain": [
+              { "name": "name", "type": "string" },
+              { "name": "version", "type": "string" },
+              { "name": "chainId", "type": "uint256" },
+              { "name": "verifyingContract", "type": "address" }
+            ],
+            "ReceiveWithAuthorization": [
+              { "name": "from", "type": "address" },
+              { "name": "to", "type": "address" },
+              { "name": "value", "type": "uint256" },
+              { "name": "validAfter", "type": "uint256" },
+              { "name": "validBefore", "type": "uint256" },
+              { "name": "nonce", "type": "bytes32" }
+            ]
+          },
+          "primaryType": "ReceiveWithAuthorization"
+        },
+        {
+          "types": {
+            "EIP712Domain": [
+              { "name": "name", "type": "string" },
+              { "name": "version", "type": "string" },
+              { "name": "chainId", "type": "uint256" },
+              { "name": "verifyingContract", "type": "address" }
+            ],
+            "CancelAuthorization": [
+              { "name": "authorizer", "type": "address" },
+              { "name": "nonce", "type": "bytes32" }
+            ]
+          },
+          "primaryType": "CancelAuthorization"
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "Circle",
+    "info": {
+      "legalName": "Circle Internet Financial, LLC",
+      "url": "https://www.circle.com/"
+    },
+    "token": {
+      "ticker": "USDC",
+      "name": "USD Coin",
+      "decimals": 6
+    }
+  },
+  "display": {
+    "formats": {
+      "TransferWithAuthorization": {
+        "$id": "EIP3009 TransferAuth",
+        "intent": "Authorize token transfer",
+        "fields": [
+          {
+            "path": "#.from",
+            "label": "From",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens"]
+            }
+          },
+          {
+            "path": "#.to",
+            "label": "To",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "wallet", "contract"],
+              "sources": ["local", "ens"]
+            }
+          },
+          {
+            "path": "#.value",
+            "label": "Amount",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "@.to" }
+          },
+          {
+            "path": "#.validAfter",
+            "label": "Valid after",
+            "format": "date",
+            "params": { "encoding": "timestamp" }
+          },
+          {
+            "path": "#.validBefore",
+            "label": "Valid before",
+            "format": "date",
+            "params": { "encoding": "timestamp" }
+          },
+          {
+            "path": "#.nonce",
+            "label": "Nonce",
+            "format": "raw"
+          }
+        ],
+        "required": [
+          "#.to",
+          "#.value",
+          "#.validAfter",
+          "#.validBefore",
+          "#.nonce"
+        ],
+        "excluded": ["#.from"],
+        "screens": {}
+      },
+      "ReceiveWithAuthorization": {
+        "$id": "EIP3009 ReceiveAuth",
+        "intent": "Authorize receiving tokens",
+        "fields": [
+          {
+            "path": "#.from",
+            "label": "From",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens"]
+            }
+          },
+          {
+            "path": "#.to",
+            "label": "To",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "wallet", "contract"],
+              "sources": ["local", "ens"]
+            }
+          },
+          {
+            "path": "#.value",
+            "label": "Amount",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "@.to" }
+          },
+          {
+            "path": "#.validAfter",
+            "label": "Valid after",
+            "format": "date",
+            "params": { "encoding": "timestamp" }
+          },
+          {
+            "path": "#.validBefore",
+            "label": "Valid before",
+            "format": "date",
+            "params": { "encoding": "timestamp" }
+          },
+          {
+            "path": "#.nonce",
+            "label": "Nonce",
+            "format": "raw"
+          }
+        ],
+        "required": [
+          "#.to",
+          "#.value",
+          "#.validAfter",
+          "#.validBefore",
+          "#.nonce"
+        ],
+        "excluded": ["#.from"],
+        "screens": {}
+      },
+      "CancelAuthorization": {
+        "$id": "EIP3009 CancelAuthorization",
+        "intent": "Cancel a prior authorization",
+        "fields": [
+          {
+            "path": "#.authorizer",
+            "label": "Authorizer",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens"]
+            }
+          },
+          { "path": "#.nonce", "label": "Nonce", "format": "raw" }
+        ],
+        "required": ["#.nonce"],
+        "excluded": ["#.authorizer"],
+        "screens": {}
+      }
+    }
+  }
+}

--- a/registry/imtoken/eip712-permit2.json
+++ b/registry/imtoken/eip712-permit2.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "../../specs/erc7730-v1.schema.json",
+  "includes": "../uniswap/uniswap-common-eip712.json",
+  "context": {
+    "eip712": {
+      "schemas": [
+        {
+          "types": {
+            "EIP712Domain": [
+              { "name": "name", "type": "string" },
+              { "name": "chainId", "type": "uint256" },
+              { "name": "verifyingContract", "type": "address" }
+            ],
+            "TokenPermissions": [
+              { "name": "token", "type": "address" },
+              { "name": "amount", "type": "uint256" }
+            ],
+            "PermitTransferFrom": [
+              { "name": "permitted", "type": "TokenPermissions" },
+              { "name": "spender", "type": "address" },
+              { "name": "nonce", "type": "uint256" },
+              { "name": "deadline", "type": "uint256" }
+            ]
+          },
+          "primaryType": "PermitTransferFrom"
+        },
+        {
+          "types": {
+            "EIP712Domain": [
+              { "name": "name", "type": "string" },
+              { "name": "chainId", "type": "uint256" },
+              { "name": "verifyingContract", "type": "address" }
+            ],
+            "TokenPermissions": [
+              { "name": "token", "type": "address" },
+              { "name": "amount", "type": "uint256" }
+            ],
+            "PermitBatchTransferFrom": [
+              { "name": "permitted", "type": "TokenPermissions[]" },
+              { "name": "spender", "type": "address" },
+              { "name": "nonce", "type": "uint256" },
+              { "name": "deadline", "type": "uint256" }
+            ]
+          },
+          "primaryType": "PermitBatchTransferFrom"
+        }
+      ]
+    }
+  },
+  "display": {
+    "formats": {
+      "PermitTransferFrom": {
+        "$id": "Permit2 TransferFrom",
+        "intent": "Authorize single transfer",
+        "fields": [
+          {
+            "path": "#.permitted",
+            "fields": [
+              {
+                "path": "#.permitted.token",
+                "label": "Max amount",
+                "format": "addressName",
+                "params": {
+                  "types": ["token"]
+                }
+              },
+              {
+                "path": "#.permitted.amount",
+                "label": "Max amount",
+                "format": "tokenAmount",
+                "params": { "tokenPath": "#.permitted.token" }
+              }
+            ]
+          },
+          {
+            "path": "#.spender",
+            "label": "Spender",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "wallet", "contract"],
+              "sources": ["local", "ens"]
+            }
+          },
+          {
+            "path": "#.nonce",
+            "label": "Nonce",
+            "format": "raw"
+          },
+          {
+            "path": "#.deadline",
+            "label": "Permit expires",
+            "format": "date",
+            "params": { "encoding": "timestamp" }
+          }
+        ],
+        "required": [
+          "#.spender",
+          "#.nonce",
+          "#.deadline",
+          "#.permitted.token",
+          "#.permitted.amount"
+        ],
+        "excluded": [],
+        "screens": {}
+      },
+      "PermitBatchTransferFrom": {
+        "$id": "Permit2 BatchTransferFrom",
+        "intent": "Authorize batch transfers",
+        "fields": [
+          {
+            "path": "#.permitted.[]",
+            "fields": [
+              {
+                "path": "#.permitted.[].token",
+                "label": "Max amount",
+                "format": "addressName",
+                "params": {
+                  "types": ["token"]
+                }
+              },
+              {
+                "path": "#.permitted.[].amount",
+                "label": "Max amount",
+                "format": "tokenAmount",
+                "params": { "tokenPath": "#.permitted.[].token" }
+              }
+            ]
+          },
+          {
+            "path": "spender",
+            "label": "Spender",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "wallet", "contract"],
+              "sources": ["local", "ens"]
+            }
+          },
+          {
+            "path": "#.nonce",
+            "label": "Nonce",
+            "format": "raw"
+          },
+          {
+            "path": "deadline",
+            "label": "Permit expires",
+            "format": "date",
+            "params": { "encoding": "timestamp" }
+          }
+        ],
+        "required": [
+          "#.spender",
+          "#.nonce",
+          "#.deadline",
+          "#.permitted.[].token",
+          "#.permitted.[].amount"
+        ],
+        "excluded": [],
+        "screens": {}
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add ERC-7730 metadata for ClaimableLinkV2, EIP‑3009 (USDC), and extended Uniswap Permit2 (Signature Transfer)

- ClaimableLinkV2 (calldata)
    - commit(bytes32 permitHash, bytes32 commitHash): displays the committed permit hash and the corresponding commit hash used to bind a permit to a recipient.
    - claim(Permit3009 permit3009, bytes signature, address recipient): parses the EIP‑3009 authorization payload (from/to/value/validAfter/validBefore/nonce), shows the recipient and token amount, and intentionally excludes raw signatures and redundant fields.
    - claim(IClaimableLinkV2.Permit2 permit2, bytes signature, address recipient): parses Uniswap Permit2 SignatureTransfer data (TokenPermissions/nonce/deadline/owner), shows recipient and token amount, and intentionally excludes raw signatures and redundant fields.
    - isClaimed(bytes32), permitCommit(bytes32): lightweight read-only helpers are included for completeness.

- EIP‑3009 (EIP‑712)
    - Adds structured-data schemas for USD Coin (USDC) v2 across multiple chains, covering:
        - TransferWithAuthorization
        - ReceiveWithAuthorization
        - CancelAuthorization
    - Binds the EIP‑712 domain to USDC deployments and provides concise display for addresses, amounts, and validity windows. This file enables clear-signing of the off-chain authorizations that ClaimableLinkV2 consumes.

- Uniswap Permit2 (EIP‑712)
    - Extends the existing Uniswap Permit2 coverage by adding the Signature Transfer types required by ClaimableLinkV2:
        - PermitTransferFrom
        - PermitBatchTransferFrom
    - The display focuses on spender, token(s), maximum authorized amounts, nonce(s) and deadline, with sensible exclusions to avoid clutter.