### PR TITLE
Update eip712-uniswap-V2DutchOrder.json

### DIFF
--- a/registry/uniswap/eip712-uniswap-V2DutchOrder.json
+++ b/registry/uniswap/eip712-uniswap-V2DutchOrder.json
@@ -78,11 +78,11 @@
             "fields": [
               {
                 "path": "endAmount",
-                "label": "Minimum amounts to receive",
+                "label": "Minimum amount to receive",
                 "format": "tokenAmount",
                 "params": { "tokenPath": "token" }
               },
-              { "path": "recipient", "label": "On Addresses", "format": "raw" }
+              { "path": "recipient", "label": "On Address", "format": "raw" }
             ]
           },
           {


### PR DESCRIPTION
https://ledgerhq.atlassian.net/browse/LIVE-21919 

Fix v2 dutch order token parsing by only displaying the first 1 ( what you receive). This excludes the fees taken from being displayed. 

Also added parsing for contract address of Uniswap once in the CAL