### PR TITLE
Add ERC7730 support for Kiln Native ETH Staking Helper contracts (Post-Pectra)

### DIFF
--- a/registry/kiln/calldata-kiln-batch-deposit-v2.json
+++ b/registry/kiln/calldata-kiln-batch-deposit-v2.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../specs/erc7730-v1.schema.json",
   "context": {
-    "$id": "Kiln ETH Native Staking - Batch Deposit",
+    "$id": "Kiln Staking - Batch Deposit",
     "contract": {
       "deployments": [
         { "chainId": 1, "address": "0x576834cB068e677db4aFF6ca245c7bde16C3867e" },
@@ -85,41 +85,41 @@
       "batchDeposit(bytes,bytes,bytes,bytes32[])": {
         "intent": "Stake 32ETH per validators",
         "fields": [
-          { "label": "Validators", "format": "raw", "params": null, "path": "#.publicKeys" },
-          { "label": "Type and owner", "format": "raw", "params": null, "path": "#.withdrawalCreds" },
-          { "label": "Signatures", "format": "raw", "params": null, "path": "#.signatures" },
-          { "label": "Data Roots", "format": "raw", "params": null, "path": "#.dataRoots.[]" }
+          { "label": "Validators", "format": "raw", "path": "#.publicKeys" },
+          { "label": "Type and owner", "format": "raw", "path": "#.withdrawalCreds" },
+          { "label": "Signatures", "format": "raw", "path": "#.signatures" },
+          { "label": "Data Roots", "format": "raw", "path": "#.dataRoots.[]" }
         ],
         "required": ["#.publicKeys", "#.withdrawalCreds"]
       },
       "batchDepositCustom(bytes,bytes,bytes,bytes32[],uint256)": {
-        "intent": "Stake custom amount of ETH per validators",
+        "intent": "Stake any amount per validator",
         "fields": [
-          { "label": "Validators", "format": "raw", "params": null, "path": "#.publicKeys" },
-          { "label": "Type and owner", "format": "raw", "params": null, "path": "#.withdrawalCreds" },
-          { "label": "Signatures", "format": "raw", "params": null, "path": "#.signatures" },
-          { "label": "Data Roots", "format": "raw", "params": null, "path": "#.dataRoots.[]" },
+          { "label": "Validators", "format": "raw", "path": "#.publicKeys" },
+          { "label": "Type and owner", "format": "raw", "path": "#.withdrawalCreds" },
+          { "label": "Signatures", "format": "raw", "path": "#.signatures" },
+          { "label": "Data Roots", "format": "raw", "path": "#.dataRoots.[]" },
           { "label": "Amount Per Validator", "format": "amount", "path": "#.amountPerValidator" }
         ],
         "required": ["#.publicKeys", "#.withdrawalCreds", "#.amountPerValidator"]
       },
       "bigBatchDeposit(bytes,bytes,bytes,bytes32[])": {
-        "intent": "Large Batch Deposit",
+        "intent": "Stake 32ETH per validators",
         "fields": [
-          { "label": "Validators", "format": "raw", "params": null, "path": "#.publicKeys" },
-          { "label": "Type and owner", "format": "raw", "params": null, "path": "#.withdrawalCreds" },
-          { "label": "Signatures", "format": "raw", "params": null, "path": "#.signatures" },
-          { "label": "Data Roots", "format": "raw", "params": null, "path": "#.dataRoots.[]" }
+          { "label": "Validators", "format": "raw", "path": "#.publicKeys" },
+          { "label": "Type and owner", "format": "raw", "path": "#.withdrawalCreds" },
+          { "label": "Signatures", "format": "raw", "path": "#.signatures" },
+          { "label": "Data Roots", "format": "raw", "path": "#.dataRoots.[]" }
         ],
         "required": ["#.publicKeys", "#.withdrawalCreds"]
       },
       "bigBatchDepositCustom(bytes,bytes,bytes,bytes32[],uint256)": {
-        "intent": "Large Batch Deposit Custom",
+        "intent": "Stake any amount per validator",
         "fields": [
-          { "label": "Validators", "format": "raw", "params": null, "path": "#.publicKeys" },
-          { "label": "Type and owner", "format": "raw", "params": null, "path": "#.withdrawalCreds" },
-          { "label": "Signatures", "format": "raw", "params": null, "path": "#.signatures" },
-          { "label": "Data Roots", "format": "raw", "params": null, "path": "#.dataRoots.[]" },
+          { "label": "Validators", "format": "raw", "path": "#.publicKeys" },
+          { "label": "Type and owner", "format": "raw", "path": "#.withdrawalCreds" },
+          { "label": "Signatures", "format": "raw", "path": "#.signatures" },
+          { "label": "Data Roots", "format": "raw", "path": "#.dataRoots.[]" },
           { "label": "Amount Per Validator", "format": "amount", "path": "#.amountPerValidator" }
         ],
         "required": ["#.publicKeys", "#.withdrawalCreds", "#.amountPerValidator"]

--- a/registry/kiln/calldata-kiln-batch-exit.json
+++ b/registry/kiln/calldata-kiln-batch-exit.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../specs/erc7730-v1.schema.json",
   "context": {
-    "$id": "Kiln ETH Native Staking - Batch Exit",
+    "$id": "Kiln Staking - Batch Exit",
     "contract": {
       "deployments": [
         { "chainId": 1, "address": "0x004c226fff73aa94b78a4df1a0e861797ba16819" },

--- a/registry/kiln/calldata-kiln-fee-splitter-factory.json
+++ b/registry/kiln/calldata-kiln-fee-splitter-factory.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://eips.ethereum.org/assets/eip-7730/erc7730-v1.schema.json",
   "context": {
-    "$id": "Kiln ETH Native Staking - Fee Splitter Factory",
+    "$id": "Kiln Staking - Fee Splitter",
     "contract": {
       "deployments": [
         { "chainId": 1, "address": "0x8659EEFF31CFcff580D37AF8e7Af250F8998aA83" },


### PR DESCRIPTION
# Add ERC7730 support for Kiln Native ETH Staking Helper contracts (Post-Pectra)

## Summary
Add ERC7730 support for Kiln ETH Native Staking helper contracts, allowing Ledger users to transparently review before signing all staking-related operations in Ledger Live after the Pectra upgrade.

It includes:
- Fee Splitter Factory – create fee splitter and stake in one transaction
- Batch Deposit V2 – deposit into one or multiple validators 32ETH or more
- Batch Exit – exit multiple validators (pre-EIP-7002)

---

## Feature Context
With the Pectra upgrade, Kiln introduces native ETH staking via 0x02 compounding validators in Ledger Live.
To enable Kiln to collect its service fee, users must deploy a Fee Splitter smart contract through the Kiln Fee Splitter Factory.

When staking, users deploy a Fee Splitter linked to their wallet and set it as the execution fee recipient on their validator.
As the validator generates execution rewards, the user-specific Fee Splitter automatically distributes these execution-layer rewards (MEV, transaction fees, etc.) between Ledger/Kiln and the user, according to the predefined Ledger × Kiln fee structure.

---

## Smart Contracts:

| Component | Network | Address | Link |
|------------|----------|----------|------|
| Fee Splitter | Mainnet | `0x8659EEFF31CFcff580D37AF8e7Af250F8998aA83` | [Etherscan](https://etherscan.io/address/0x8659EEFF31CFcff580D37AF8e7Af250F8998aA83#code) |
| Fee Splitter | Hoodi Testnet | `0x1A76bc69922744807E86375f8B8AB8A7cf18Eb7a` | [HoodiScan](https://hoodi.etherscan.io/address/0x1A76bc69922744807E86375f8B8AB8A7cf18Eb7a) |
| Kiln Batch Deposit V2 | Mainnet | `0x576834cB068e677db4aFF6ca245c7bde16C3867e` | [Etherscan](https://etherscan.io/address/0x576834cB068e677db4aFF6ca245c7bde16C3867e) |
| Kiln Batch Deposit V2 | Hoodi Testnet | `0x00ae9b96Ef8D5D54cFCC02d9A1Ccc19ACD688B72` | [HoodiScan](https://hoodi.etherscan.io/address/0x00ae9b96Ef8D5D54cFCC02d9A1Ccc19ACD688B72#code) |
| Kiln Batch Exit | Mainnet | `0x004c226fff73aa94b78a4df1a0e861797ba16819` | [Etherscan](https://etherscan.io/address/0x004c226fff73aa94b78a4df1a0e861797ba16819) |
| Kiln Batch Exit | Hoodi Testnet | `0x06f9C32A3093DDE837a2E172041DF79B4b850A2e` | [HoodiScan](https://hoodi.etherscan.io/address/0x06f9C32A3093DDE837a2E172041DF79B4b850A2e) |

---

## Components Added

### 1. Fee Splitter Factory
**File:** `registry/kiln/calldata-kiln-fee-splitter-factory.json`  
**User Operation:** `createSplitterAndCall`  
**Purpose:** Allows a user to deploy a Fee Splitter contract and initiate staking in a single transaction.

**User verification on:**
```json
["#.operator", "#.data"]
```

*Notes:* Data leverage `calleePath` to target Kiln’s Batch Deposit V2 contract to stake ETHs.

---

### 2. Batch Deposit V2
**File:** `registry/kiln/calldata-kiln-batch-deposit-v2.json`  
**User Operation:** `batchDepositCustom`  
**Purpose:** Enables users to deposit 32 ETH or more into one or several validators.

**User verification on:**
```json
["#.publicKeys", "#.withdrawalCreds", "#.amountPerValidator"]
```

---

### 3. Batch Exit
**File:** `registry/kiln/calldata-kiln-batch-exit.json`  
**User Operation:** `requestExit`  
**Purpose:** Allows users to exit multiple validators simultaneously, without relying on EIP-7002.

**User verification on:**
```json
["#.validators_.[]"]
```