### PR TITLE
Add BENQI sAVAX

### DIFF
--- a/registry/benqi/calldata-sAVAX.json
+++ b/registry/benqi/calldata-sAVAX.json
@@ -73,9 +73,9 @@
         "required": ["#.unlockIndex"],
         "excluded": []
       },
-      "redeemOverdueShares()": { "intent": "Restake after missed period", "fields": [], "required": [], "excluded": [] },
+      "redeemOverdueShares()": { "intent": "Cancel overdue unlock request", "fields": [], "required": [], "excluded": [] },
       "redeemOverdueShares(uint256)": {
-        "intent": "Restake after missed period",
+        "intent": "Cancel overdue unlock request",
         "fields": [{ "label": "Unlock index", "format": "raw", "path": "#.unlockIndex", "params": null }],
         "required": ["#.unlockIndex"],
         "excluded": []


### PR DESCRIPTION
This pull request adds clear signing for BENQI's sAVAX (Staked AVAX) staking contract.

BENQI sAVAX Contract Configuration (registry/benqi/calldata-sAVAX.json):

Contract deployed on Avalanche C-Chain (chain ID: 43114) at 0x2b2c81e08f1af8835a78bb2a90ae924ace0ea4be
Metadata and functions for:

- submit() - Stake AVAX
- requestUnlock(uint256) - Request unstaking sAVAX
- redeem() - Claim unstaked AVAX
- redeem(uint256) - Claim unstaked AVAX by unlock index
- redeemOverdueShares() - Cancel overdue unlock request
- redeemOverdueShares(uint256) - Cancel overdue unlock request by unlock index
