### PR TITLE
fix(aave): Issues fixes

### DIFF
--- a/registry/aave/calldata-WrappedTokenGatewayV3.json
+++ b/registry/aave/calldata-WrappedTokenGatewayV3.json
@@ -24,7 +24,7 @@
   "metadata": { "owner": "Aave", "info": { "url": "https://aave.com", "legalName": "Aave DAO", "deploymentDate": "2025-02-11T01:19:11Z" } },
   "display": {
     "formats": {
-      "depositETH(address undefined, address onBehalfOf, uint16 referralCode)": {
+      "depositETH(address , address onBehalfOf, uint16 referralCode)": {
         "$id": "depositETH",
         "intent": "Supply",
         "fields": [
@@ -37,9 +37,9 @@
           }
         ],
         "required": ["onBehalfOf"],
-        "excluded": ["undefined", "referralCode"]
+        "excluded": ["referralCode"]
       },
-      "repayETH(address undefined, uint256 amount, address onBehalfOf)": {
+      "repayETH(address , uint256 amount, address onBehalfOf)": {
         "$id": "repayETH",
         "intent": "Repay loan",
         "fields": [
@@ -52,13 +52,23 @@
           }
         ],
         "required": ["onBehalfOf", "amount"],
-        "excluded": ["undefined"]
+        "excluded": []
       },
-      "withdrawETH(address undefined, uint256 amount, address to)": {
+      "withdrawETH(address , uint256 amount, address to)": {
         "$id": "withdrawETH",
         "intent": "Withdraw",
         "fields": [
-          { "path": "amount", "format": "amount", "label": "Amount to withdraw" },
+          {
+            "path": "amount",
+            "format": "tokenAmount",
+            "label": "Amount to withdraw",
+            "params": {
+              "token": "0x0000000000000000000000000000000000000000",
+              "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000",
+              "threshold": "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+              "message": "All"
+            }
+          },
           {
             "path": "to",
             "format": "addressName",
@@ -67,13 +77,23 @@
           }
         ],
         "required": ["to", "amount"],
-        "excluded": ["undefined"]
+        "excluded": []
       },
-      "withdrawETHWithPermit(address undefined, uint256 amount, address to, uint256 deadline, uint8 permitV, bytes32 permitR, bytes32 permitS)": {
+      "withdrawETHWithPermit(address, uint256 amount, address to, uint256 deadline, uint8 permitV, bytes32 permitR, bytes32 permitS)": {
         "$id": "withdrawETHWithPermit",
         "intent": "Withdraw",
         "fields": [
-          { "path": "amount", "format": "amount", "label": "Amount to withdraw" },
+          {
+            "path": "amount",
+            "format": "tokenAmount",
+            "label": "Amount to withdraw",
+            "params": {
+              "token": "0x0000000000000000000000000000000000000000",
+              "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000",
+              "threshold": "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+              "message": "All"
+            }
+          },
           {
             "path": "to",
             "format": "addressName",
@@ -82,9 +102,9 @@
           }
         ],
         "required": ["to", "amount"],
-        "excluded": ["undefined", "deadline", "permitV", "permitR", "permitS"]
+        "excluded": ["deadline", "permitV", "permitR", "permitS"]
       },
-      "borrowETH(address undefined, uint256 amount, uint16 referralCode)": {
+      "borrowETH(address , uint256 amount, uint16 referralCode)": {
         "$id": "borrowETH",
         "intent": "Borrow",
         "fields": [
@@ -92,7 +112,7 @@
           { "path": "@.from", "format": "addressName", "label": "Debtor", "params": { "types": ["eoa"], "sources": ["local", "ens"] } }
         ],
         "required": ["amount"],
-        "excluded": ["undefined", "referralCode"]
+        "excluded": ["referralCode"]
       }
     }
   }

--- a/registry/aave/calldata-lpv2.json
+++ b/registry/aave/calldata-lpv2.json
@@ -53,7 +53,7 @@
             "label": "For asset",
             "params": { "types": ["token"], "sources": ["local", "ens"] }
           },
-          { "path": "useAsCollateral", "format": "raw", "label": "Enable use as collateral" }
+          { "path": "useAsCollateral", "format": "raw", "label": "Enable as collateral" }
         ],
         "required": ["asset", "useAsCollateral"]
       },
@@ -76,7 +76,7 @@
         "required": ["amount", "to"]
       },
       "swapBorrowRateMode(address,uint256)": {
-        "intent": "Swap interest rate mode",
+        "intent": "Swap to variable",
         "fields": [
           {
             "path": "asset",
@@ -87,7 +87,7 @@
           {
             "path": "rateMode",
             "format": "enum",
-            "label": "Set interest rate mode to",
+            "label": "Current rate mode",
             "params": { "$ref": "$.metadata.enums.interestRateMode" }
           }
         ],

--- a/registry/aave/calldata-lpv3.json
+++ b/registry/aave/calldata-lpv3.json
@@ -411,7 +411,7 @@
   "metadata": {
     "owner": "Aave",
     "info": { "url": "https://aave.com", "legalName": "Aave DAO", "deploymentDate": "2024-10-09T21:46:47Z" },
-    "enums": { "interestRateMode": { "1": "stable", "2": "variable" } },
+    "enums": { "interestRateMode": { "0": "none", "1": "deprecated", "2": "variable" } },
     "constants": { "max": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" }
   },
   "display": {
@@ -469,7 +469,7 @@
       },
       "repayWithATokens(address asset, uint256 amount, uint256 interestRateMode)": {
         "$id": "repayWithATokens",
-        "intent": "Repay loan",
+        "intent": "Repay with aTokens",
         "fields": [
           {
             "path": "amount",
@@ -610,7 +610,7 @@
       },
       "approvePositionManager(address positionManager, bool approve)": {
         "$id": "approvePositionManager",
-        "intent": "Approve position manager",
+        "intent": "Approve Manager",
         "fields": [
           { "path": "positionManager", "format": "addressName", "label": "Position manager", "params": { "types": ["eoa"] } },
           { "path": "approve", "format": "raw", "label": "Approve" }
@@ -620,8 +620,18 @@
       },
       "renouncePositionManagerRole(address user)": {
         "$id": "renouncePositionManagerRole",
-        "intent": "Renounce position manager",
-        "fields": [{ "path": "user", "format": "addressName", "label": "Position manager", "params": { "types": ["eoa"] } }],
+        "intent": "Revoke Manager Role",
+        "fields": [       {
+          "path": "@.from",
+          "format": "addressName",
+          "label": "Position manager",
+          "params": {
+            "types": [
+              "eoa"
+            ]
+          }
+        },
+        { "path": "user", "format": "addressName", "label": "User", "params": { "types": ["eoa"] } }],
         "required": ["user"],
         "excluded": []
       },


### PR DESCRIPTION
## aave
### `registry/aave/calldata-WrappedTokenGatewayV3.json`
- `depositETH(address,address,uint16)`: Issue: signature/exclusions referenced a bogus `undefined` parameter; Fix: remove `undefined` so parameters align.
- `repayETH(address,uint256,address)`: Issue: signature/exclusions referenced a bogus `undefined` parameter; Fix: remove `undefined` so required fields align.
- `withdrawETH(address,uint256,address)`:
  - Issue: amount was raw native. Fix: use native `tokenAmount` with All threshold.
  - Issue: `undefined` was excluded. Fix: remove `undefined`.
- `withdrawETHWithPermit(address,uint256,address,uint256,uint8,bytes32,bytes32)`:
  - Issue: amount was raw native. Fix: use native `tokenAmount` with All threshold.
  - Issue: `undefined` was excluded. Fix: remove `undefined`.
- `borrowETH(address,uint256,uint16)`: Issue: signature/exclusions referenced a bogus `undefined` parameter; Fix: remove `undefined` so parameters align.

### `registry/aave/calldata-lpv2.json`
- `setUserUseReserveAsCollateral(address,bool)`: Issue: label "Enable use as collateral" exceeded 20 characters and was truncated on device; Fix: shorten to "Enable as collateral".
- `swapBorrowRateMode(address,uint256)`:
  - Issue: intent implied an arbitrary swap. Fix: intent "Swap to variable".
  - Issue: label implied the target mode. Fix: label "Current rate mode".

### `registry/aave/calldata-lpv3.json`
- `repay(address,uint256,uint256,address)`: Issue: `interestRateMode` enum offered stable mode which is wrong and not consistent with source code; Fix: map enum to `0:none`, `1:deprecated`, `2:variable`.
- `repayWithPermit(address,uint256,uint256,address,uint256,uint8,bytes32,bytes32)`: Issue: `interestRateMode` enum offered stable mode; Fix: map enum to `0:none`, `1:deprecated`, `2:variable`.
- `repayWithATokens(address,uint256,uint256)`:
  - Issue: intent "Repay loan" hid aToken usage. Fix: intent "Repay with aTokens".
  - Issue: `interestRateMode` enum offered stable mode. Fix: map enum to `0:none`, `1:deprecated`, `2:variable`.
- `borrow(address,uint256,uint256,uint16,address)`: Issue: `interestRateMode` enum offered stable mode; Fix: map enum to `0:none`, `1:deprecated`, `2:variable`.
- `approvePositionManager(address,bool)`: Issue: intent "Approve position manager" exceeded 20 characters and was truncated on device; Fix: intent "Approve Manager".
- `renouncePositionManagerRole(address user)`:
  - Issue: The function removes the mapping `_positionManager[user][msg.sender]` and emits `PositionManagerRevoked(user, positionManager=msg.sender)`. The position manager being revoked is msg.sender (the caller), not the 'user' parameter. Fix: intent "Revoke Manager Role".
  - Issue: caller context and user labeling were missing. Fix: add `@.from` "Position manager" and label `user` as "User".
