### PR TITLE
fix(benqi): Issues fixes

### DIFF
--- a/registry/benqi/calldata-sAVAX.json
+++ b/registry/benqi/calldata-sAVAX.json
@@ -54,7 +54,7 @@
         "excluded": []
       },
       "requestUnlock(uint256)": {
-        "intent": "Request unstaking sAVAX",
+        "intent": "Request unstaking",
         "fields": [
           {
             "label": "sAVAX amount",
@@ -73,9 +73,9 @@
         "required": ["#.unlockIndex"],
         "excluded": []
       },
-      "redeemOverdueShares()": { "intent": "Cancel overdue unlock request", "fields": [], "required": [], "excluded": [] },
+      "redeemOverdueShares()": { "intent": "Redeem Overdue", "fields": [], "required": [], "excluded": [] },
       "redeemOverdueShares(uint256)": {
-        "intent": "Cancel overdue unlock request",
+        "intent": "Redeem sAVAX",
         "fields": [{ "label": "Unlock index", "format": "raw", "path": "#.unlockIndex", "params": null }],
         "required": ["#.unlockIndex"],
         "excluded": []


### PR DESCRIPTION
## benqi
### `registry/benqi/calldata-sAVAX.json`
- `requestUnlock(uint256)`: Issue: intent exceeded 20 characters and was truncated on device; Fix: shorten to "Request unstaking".
- `redeemOverdueShares()`: Issue: intent said "Cancel overdue unlock request" even though this redeems; Fix: intent "Redeem Overdue".
- `redeemOverdueShares(uint256)`: Issue: intent said "Cancel overdue unlock request" which is misleading; Fix: intent "Redeem sAVAX".
