### PR TITLE
fix(figment): Issues fixes

### DIFF
--- a/registry/figment/calldata-figment-batch-deposit.json
+++ b/registry/figment/calldata-figment-batch-deposit.json
@@ -248,9 +248,9 @@
           {
             "$id": null,
             "label": "Withdraw Credentials",
-            "format": "raw",
+            "format": "addressName",
             "params": null,
-            "path": "#.withdrawal_credentials.[]",
+            "path": "#.withdrawal_credentials.[].[-20:]",
             "value": null
           },
           {


### PR DESCRIPTION
## figment
### `registry/figment/calldata-figment-batch-deposit.json`
- `deposit(bytes[],bytes[],bytes[],bytes32[],uint256[])`: Issue: `withdrawal_credentials` displayed as raw bytes, decoded transactions include `withdrawal_credentials` like "0x0200...<20-byte address>"; Fix: render last 20 bytes as an address (`addressName`).
