### PR TITLE
fix(lifi): Issues fixes

### DIFF
--- a/registry/lifi/calldata-LIFIDiamond.json
+++ b/registry/lifi/calldata-LIFIDiamond.json
@@ -5128,7 +5128,10 @@
   },
   "metadata": {
     "owner": "LI.FI Service GmbH",
-    "info": { "legalName": "LI.FI", "url": "https://li.fi" },
+    "info": {
+      "legalName": "LI.FI",
+      "url": "https://li.fi"
+    },
     "constants": {
       "addressAsEth": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
       "addressAsNull": "0x0000000000000000000000000000000000000000"
@@ -5139,12 +5142,22 @@
       "fromAmount": {
         "label": "Amount info",
         "format": "tokenAmount",
-        "params": { "nativeCurrencyAddress": ["$.metadata.constants.addressAsEth", "$.metadata.constants.addressAsNull"] }
+        "params": {
+          "nativeCurrencyAddress": [
+            "$.metadata.constants.addressAsEth",
+            "$.metadata.constants.addressAsNull"
+          ]
+        }
       },
       "_minAmountOut": {
-        "label": "Minimum Amount to receive",
+        "label": "Minimum Amount Out",
         "format": "tokenAmount",
-        "params": { "nativeCurrencyAddress": ["$.metadata.constants.addressAsEth", "$.metadata.constants.addressAsNull"] }
+        "params": {
+          "nativeCurrencyAddress": [
+            "$.metadata.constants.addressAsEth",
+            "$.metadata.constants.addressAsNull"
+          ]
+        }
       }
     },
     "formats": {
@@ -5156,22 +5169,40 @@
             "path": "_swapData.[0].fromAmount",
             "label": "Amount to Send",
             "format": "tokenAmount",
-            "params": { "tokenPath": "_swapData.[0].sendingAssetId" }
+            "params": {
+              "tokenPath": "_swapData.[0].sendingAssetId"
+            }
           },
           {
             "path": "_minAmountOut",
             "label": "Minimum to Receive",
             "format": "tokenAmount",
-            "params": { "tokenPath": "_swapData.[-1].receivingAssetId" }
+            "params": {
+              "tokenPath": "_swapData.[-1].receivingAssetId"
+            }
           },
           {
             "path": "_receiver",
             "label": "Recipient",
             "format": "addressName",
-            "params": { "types": ["eoa", "contract"], "sources": ["local", "ens"] }
+            "params": {
+              "types": [
+                "eoa",
+                "contract"
+              ],
+              "sources": [
+                "local",
+                "ens"
+              ]
+            }
           }
         ],
-        "required": ["_swapData.[0].fromAmount", "_swapData.[-1].receivingAssetId", "_minAmountOut", "_receiver"],
+        "required": [
+          "_swapData.[0].fromAmount",
+          "_swapData.[-1].receivingAssetId",
+          "_minAmountOut",
+          "_receiver"
+        ],
         "excluded": [
           "_transactionId",
           "_integrator",
@@ -5190,17 +5221,37 @@
             "path": "_swapData.[0].fromAmount",
             "label": "Amount to Send",
             "format": "tokenAmount",
-            "params": { "tokenPath": "_swapData.[0].sendingAssetId" }
+            "params": {
+              "tokenPath": "_swapData.[0].sendingAssetId"
+            }
           },
-          { "path": "_minAmountOut", "$ref": "$.display.definitions._minAmountOut" },
+          {
+            "path": "_minAmountOut",
+            "label": "Minimum to Receive",
+            "format": "amount"
+          },
           {
             "path": "_receiver",
             "label": "Receiver",
             "format": "addressName",
-            "params": { "types": ["eoa", "contract"], "sources": ["local", "ens"] }
+            "params": {
+              "types": [
+                "eoa",
+                "contract"
+              ],
+              "sources": [
+                "local",
+                "ens"
+              ]
+            }
           }
         ],
-        "required": ["_swapData.[0].fromAmount", "_swapData.[-1].receivingAssetId", "_minAmountOut", "_receiver"],
+        "required": [
+          "_swapData.[0].fromAmount",
+          "_swapData.[-1].receivingAssetId",
+          "_minAmountOut",
+          "_receiver"
+        ],
         "excluded": [
           "_transactionId",
           "_integrator",
@@ -5215,21 +5266,41 @@
         "$id": "swapTokensMultipleV3NativeToERC20",
         "intent": "Swap",
         "fields": [
-          { "path": "@.value", "label": "Amount to send", "format": "amount" },
+          {
+            "path": "@.value",
+            "label": "Amount to send",
+            "format": "amount"
+          },
           {
             "path": "_minAmountOut",
             "label": "Minimum to Receive",
             "format": "tokenAmount",
-            "params": { "tokenPath": "_swapData.[-1].receivingAssetId" }
+            "params": {
+              "tokenPath": "_swapData.[-1].receivingAssetId"
+            }
           },
           {
             "path": "_receiver",
             "label": "Recipient",
             "format": "addressName",
-            "params": { "types": ["eoa", "contract"], "sources": ["local", "ens"] }
+            "params": {
+              "types": [
+                "eoa",
+                "contract"
+              ],
+              "sources": [
+                "local",
+                "ens"
+              ]
+            }
           }
         ],
-        "required": ["_swapData.[0].fromAmount", "_swapData.[-1].receivingAssetId", "_minAmountOut", "_receiver"],
+        "required": [
+          "_swapData.[0].fromAmount",
+          "_swapData.[-1].receivingAssetId",
+          "_minAmountOut",
+          "_receiver"
+        ],
         "excluded": [
           "_transactionId",
           "_integrator",
@@ -5248,23 +5319,47 @@
             "path": "_swapData.fromAmount",
             "label": "Amount to Send",
             "format": "tokenAmount",
-            "params": { "tokenPath": "_swapData.sendingAssetId" }
+            "params": {
+              "tokenPath": "_swapData.sendingAssetId"
+            }
           },
           {
             "path": "_minAmountOut",
             "label": "Minimum to Receive",
             "format": "tokenAmount",
-            "params": { "tokenPath": "_swapData.receivingAssetId" }
+            "params": {
+              "tokenPath": "_swapData.receivingAssetId"
+            }
           },
           {
             "path": "_receiver",
             "label": "Recipient",
             "format": "addressName",
-            "params": { "types": ["eoa", "contract"], "sources": ["local", "ens"] }
+            "params": {
+              "types": [
+                "eoa",
+                "contract"
+              ],
+              "sources": [
+                "local",
+                "ens"
+              ]
+            }
           }
         ],
-        "required": ["_swapData.fromAmount", "_minAmountOut", "_receiver", "_swapData.receivingAssetId"],
-        "excluded": ["_transactionId", "_integrator", "_referrer", "_swapData.callData", "_swapData.requiresDeposit"]
+        "required": [
+          "_swapData.fromAmount",
+          "_minAmountOut",
+          "_receiver",
+          "_swapData.receivingAssetId"
+        ],
+        "excluded": [
+          "_transactionId",
+          "_integrator",
+          "_referrer",
+          "_swapData.callData",
+          "_swapData.requiresDeposit"
+        ]
       },
       "0x733214a3": {
         "$id": "swapTokensSingleV3ERC20ToNative",
@@ -5274,17 +5369,36 @@
             "path": "_swapData.fromAmount",
             "label": "Amount to Send",
             "format": "tokenAmount",
-            "params": { "tokenPath": "_swapData.sendingAssetId" }
+            "params": {
+              "tokenPath": "_swapData.sendingAssetId"
+            }
           },
-          { "path": "_minAmountOut", "$ref": "$.display.definitions._minAmountOut" },
+          {
+            "path": "_minAmountOut",
+            "label": "Minimum Amount Out",
+            "format": "amount"
+          },
           {
             "path": "_receiver",
             "label": "Receiver",
             "format": "addressName",
-            "params": { "types": ["eoa", "contract"], "sources": ["local", "ens"] }
+            "params": {
+              "types": [
+                "eoa",
+                "contract"
+              ],
+              "sources": [
+                "local",
+                "ens"
+              ]
+            }
           }
         ],
-        "required": ["_swapData.fromAmount", "_minAmountOut", "_receiver"],
+        "required": [
+          "_swapData.fromAmount",
+          "_minAmountOut",
+          "_receiver"
+        ],
         "excluded": [
           "_transactionId",
           "_integrator",
@@ -5299,22 +5413,48 @@
         "$id": "swapTokensSingleV3NativeToERC20",
         "intent": "Swap",
         "fields": [
-          { "path": "@.value", "label": "Amount to send", "format": "amount" },
+          {
+            "path": "@.value",
+            "label": "Amount to send",
+            "format": "amount"
+          },
           {
             "path": "_minAmountOut",
             "label": "Minimum to Receive",
             "format": "tokenAmount",
-            "params": { "tokenPath": "_swapData.receivingAssetId" }
+            "params": {
+              "tokenPath": "_swapData.receivingAssetId"
+            }
           },
           {
             "path": "_receiver",
             "label": "Recipient",
             "format": "addressName",
-            "params": { "types": ["eoa", "contract"], "sources": ["local", "ens"] }
+            "params": {
+              "types": [
+                "eoa",
+                "contract"
+              ],
+              "sources": [
+                "local",
+                "ens"
+              ]
+            }
           }
         ],
-        "required": ["_swapData.fromAmount", "_minAmountOut", "_receiver"],
-        "excluded": ["_transactionId", "_integrator", "_referrer", "_swapData.callData", "_swapData.requiresDeposit", "_swapData.approveTo"]
+        "required": [
+          "_swapData.fromAmount",
+          "_minAmountOut",
+          "_receiver"
+        ],
+        "excluded": [
+          "_transactionId",
+          "_integrator",
+          "_referrer",
+          "_swapData.callData",
+          "_swapData.requiresDeposit",
+          "_swapData.approveTo"
+        ]
       },
       "0x4630a0d8": {
         "$id": "swapTokensGeneric",
@@ -5323,21 +5463,38 @@
           {
             "path": "_swapData.[0].fromAmount",
             "$ref": "$.display.definitions.fromAmount",
-            "params": { "tokenPath": "_swapData.[0].sendingAssetId" }
+            "params": {
+              "tokenPath": "_swapData.[0].sendingAssetId"
+            }
           },
           {
             "path": "_minAmount",
             "$ref": "$.display.definitions._minAmountOut",
-            "params": { "tokenPath": "_swapData.[-1].receivingAssetId" }
+            "params": {
+              "tokenPath": "_swapData.[-1].receivingAssetId"
+            }
           },
           {
             "path": "_receiver",
             "label": "Recipient",
             "format": "addressName",
-            "params": { "types": ["eoa", "contract"], "sources": ["local", "ens"] }
+            "params": {
+              "types": [
+                "eoa",
+                "contract"
+              ],
+              "sources": [
+                "local",
+                "ens"
+              ]
+            }
           }
         ],
-        "required": ["_swapData.[0].fromAmount", "_minAmount", "_receiver"],
+        "required": [
+          "_swapData.[0].fromAmount",
+          "_minAmount",
+          "_receiver"
+        ],
         "excluded": [
           "_transactionId",
           "_integrator",


### PR DESCRIPTION
## lifi
### `registry/lifi/calldata-LIFIDiamond.json`
Definitions updated: `_minAmountOut` label now "Minimum Amount Out" and native address handling added to `fromAmount`/`_minAmountOut` for consistent native formatting.
- `0x2c57e884 (swapTokensMultipleV3ERC20ToNative)`:
  - Issue: `_minAmountOut` label exceeded 20 characters and was truncated on device. Fix: label "Minimum to Receive".
  - Issue: `_minAmountOut` was formatted as a token amount for native output. Fix: render `_minAmountOut` as native `amount`.
- `0x736eac0b (swapTokensMultipleV3NativeToERC20)`: Issue: ETH send amount was not displayed; Fix: add `@.value` "Amount to send" field.
- `0x733214a3 (swapTokensSingleV3ERC20ToNative)`:
  - Issue: `_minAmountOut` label exceeded 20 characters and was truncated on device. Fix: label "Minimum Amount Out".
  - Issue: `_minAmountOut` was formatted as a token amount for native output. Fix: render `_minAmountOut` as native `amount`.
- `0xaf7060fd (swapTokensSingleV3NativeToERC20)`: Issue: ETH send amount was not displayed; Fix: add `@.value` "Amount to send" field.
- `0x4630a0d8 (swapTokensGeneric)`:
  - Issue: min-out label exceeded 20 characters and was truncated on device. Fix: use `_minAmountOut` definition (label "Minimum Amount Out").
  - Issue: native formatting was inconsistent. Fix: apply native address handling in `fromAmount`/`_minAmountOut` definitions.
