### PR TITLE
fix(midas): Issues fixes

### DIFF
--- a/registry/midas/calldata-MinterVault.json
+++ b/registry/midas/calldata-MinterVault.json
@@ -103,7 +103,7 @@
             "visible": "always"
           },
           {
-            "label": "Slippage",
+            "label": "Minimum to Receive",
             "format": "unit",
             "params": { "base": " ", "decimals": 18, "prefix": false },
             "path": "#.minReceiveAmount",
@@ -137,7 +137,7 @@
             "visible": "always"
           },
           {
-            "label": "Slippage",
+            "label": "Minimum to Receive",
             "format": "unit",
             "params": { "base": " ", "decimals": 18, "prefix": false },
             "path": "#.minReceiveAmount",
@@ -147,7 +147,7 @@
         ]
       },
       "depositRequest(address tokenIn, uint256 amountToken, bytes32 referrerId)": {
-        "intent": "request buying",
+        "intent": "Deposit Request",
         "fields": [
           {
             "label": "You pay with",
@@ -167,7 +167,7 @@
         ]
       },
       "depositRequest(address tokenIn, uint256 amountToken, bytes32 referrerId, address recipient)": {
-        "intent": "request buying",
+        "intent": "Deposit Request",
         "fields": [
           {
             "label": "You pay with",

--- a/registry/midas/calldata-RedemptionVault.json
+++ b/registry/midas/calldata-RedemptionVault.json
@@ -91,7 +91,7 @@
         "intent": "instantly redeem",
         "fields": [
           {
-            "label": "You receive",
+            "label": "Receive token",
             "format": "addressName",
             "params": { "types": ["token"] },
             "path": "#.tokenOut",
@@ -105,7 +105,7 @@
             "visible": "always"
           },
           {
-            "label": "Slippage",
+            "label": "Min receive amount",
             "format": "unit",
             "params": { "base": " ", "decimals": 18, "prefix": false },
             "path": "#.minReceiveAmount",
@@ -124,7 +124,7 @@
         "intent": "instantly redeem",
         "fields": [
           {
-            "label": "You receive",
+            "label": "Receive token",
             "format": "addressName",
             "params": { "types": ["token"] },
             "path": "#.tokenOut",
@@ -138,7 +138,7 @@
             "visible": "always"
           },
           {
-            "label": "Slippage",
+            "label": "Min receive amount",
             "format": "unit",
             "params": { "base": " ", "decimals": 18, "prefix": false },
             "path": "#.minReceiveAmount",
@@ -150,14 +150,14 @@
         "intent": "request a redemption",
         "fields": [
           {
-            "label": "You will receive",
+            "label": "Receive token",
             "format": "addressName",
             "params": { "types": ["token"] },
             "path": "#.tokenOut",
             "visible": "always"
           },
           {
-            "label": "Amount to redeem",
+            "label": "mToken Amount In",
             "format": "unit",
             "params": { "base": " ", "decimals": 18, "prefix": false },
             "path": "#.amountMTokenIn",
@@ -176,14 +176,14 @@
         "intent": "request a redemption",
         "fields": [
           {
-            "label": "You will receive",
+            "label": "Receive token",
             "format": "addressName",
             "params": { "types": ["token"] },
             "path": "#.tokenOut",
             "visible": "always"
           },
           {
-            "label": "Amount to redeem",
+            "label": "mToken Amount In",
             "format": "unit",
             "params": { "base": " ", "decimals": 18, "prefix": false },
             "path": "#.amountMTokenIn",
@@ -195,7 +195,7 @@
         "intent": "request a redemption",
         "fields": [
           {
-            "label": "Amount to redeem",
+            "label": "mToken Amount In",
             "format": "unit",
             "params": { "base": " ", "decimals": 18, "prefix": false },
             "path": "#.amountMTokenIn",


### PR DESCRIPTION
## midas
### `registry/midas/calldata-MinterVault.json`
- `depositInstant(address,uint256,uint256,bytes32,address)`: Issue: label "Slippage" is misleading and hid the min-out meaning; Fix: rename to "Minimum to Receive".
- `depositInstant(address,uint256,uint256,bytes32)`: Issue: label "Slippage" hid the min-out meaning; Fix: rename to "Minimum to Receive".
- `depositRequest(address,uint256,bytes32)`: Issue: intent "request buying" was unclear; Fix: intent "Deposit Request".
- `depositRequest(address,uint256,bytes32,address)`: Issue: intent "request buying" was unclear; Fix: intent "Deposit Request".

### `registry/midas/calldata-RedemptionVault.json`
- `redeemInstant(address,uint256,uint256,address)`:
  - Issue: label "You receive" was vague. Fix: rename to "Receive token".
  - Issue: label "Slippage" was misleading. Fix: rename to "Min receive amount".
  - Issue: `prefix` was a string. Fix: use boolean `prefix: false`.
- `redeemInstant(address,uint256,uint256)`:
  - Issue: label "You receive" was vague. Fix: rename to "Receive token".
  - Issue: label "Slippage" was misleading. Fix: rename to "Min receive amount".
  - Issue: `prefix` was a string. Fix: use boolean `prefix: false`.
- `redeemRequest(address,uint256,address)`:
  - Issue: label "You will receive" was unclear. Fix: rename to "Receive token".
  - Issue: label "Amount to redeem" was unclear: `#.amountMTokenIn` is the amount that the user sends. Fix: rename to "mToken Amount In".
- `redeemRequest(address,uint256)`:
  - Issue: label "You will receive" was unclear. Fix: rename to "Receive token".
  - Issue: label "Amount to redeem" was unclear: `#.amountMTokenIn` is the amount that the user sends. Fix: rename to "mToken Amount In".
- `redeemFiatRequest(uint256)`:
  - Issue: label "Amount to redeem" was unclear. Fix: rename to "mToken Amount In".
  - Issue: `prefix` was a string. Fix: use boolean `prefix: false`.
