### PR TITLE
fix(okx): Issues fixes

### DIFF
--- a/registry/okx/calldata-OkxDexRouterV1.0.7-multi-commission.json
+++ b/registry/okx/calldata-OkxDexRouterV1.0.7-multi-commission.json
@@ -511,7 +511,7 @@
           { "path": "baseRequest.deadLine", "$ref": "$.display.definitions.deadline" }
         ],
         "required": ["orderId", "baseRequest.fromToken", "baseRequest.toToken", "baseRequest.fromTokenAmount", "baseRequest.minReturnAmount"],
-        "excluded": ["batches", "batchesAmount", "extraData"]
+        "excluded": ["batches", "batchesAmount"]
       },
       "smartSwapTo(uint256 orderId,address receiver,(uint256,address,uint256,uint256,uint256) baseRequest,uint256[] batchesAmount,(address[],address[],uint256[],bytes[],uint256)[][] batches,(uint256,address,address,address,uint256,uint256,uint256,uint256,bool,bytes)[] extraData)": {
         "$id": "smartSwapTo",
@@ -539,7 +539,7 @@
           "baseRequest.fromTokenAmount",
           "baseRequest.minReturnAmount"
         ],
-        "excluded": ["batches", "batchesAmount", "extraData"]
+        "excluded": ["batches", "batchesAmount"]
       },
       "swapWrap(uint256 orderId,uint256 rawdata)": {
         "$id": "swapWrap",
@@ -713,7 +713,7 @@
           "to",
           "refundTo"
         ],
-        "excluded": ["batches", "batchesAmount", "extraData"]
+        "excluded": ["batches", "batchesAmount"]
       }
     }
   }


### PR DESCRIPTION
## okx
### `registry/okx/calldata-OkxDexRouterV1.0.6-dag.json`
- `swapWrap(uint256 orderId,uint256 rawdata)`: Issue: intent "Swap" was generic while this function only handles wrap/unwrap logic; Fix: intent "Wrap/Unwrap".
- `swapWrapToWithBaseRequest(uint256 orderId,address receiver,(uint256,address,uint256,uint256,uint256) baseRequest)`:
  - Issue: wrap amount was obscured by min-return labeling. Fix: show `baseRequest.fromTokenAmount` as "Wrap/Unwrap Amount" with native token handling. As this function only wraps/unwraps exactly the same amount, displaying the min return amount is not needed.
  - Issue: `$id` was still "swapWrapToWithBaseRequest". Fix: set `$id` to "Wrap/Unwrap".
