### PR TITLE
fix(p2p): Issues fixes

### DIFF
--- a/registry/p2p/calldata-NativeTokenVault.json
+++ b/registry/p2p/calldata-NativeTokenVault.json
@@ -527,7 +527,8 @@
         "intent": "Exit funds",
         "screens": null,
         "fields": [
-          { "$id": null, "label": "Amount to exit", "format": "amount", "params": null, "path": "#.shares", "value": null },
+          { "$id": null, "label": "Shares to exit", "format": "tokenAmount", "params": {
+      "tokenPath": "@.to"}, "path": "#.shares", "value": null },
           {
             "$id": null,
             "label": "Client address",

--- a/registry/p2p/calldata-P2pMessageSender.json
+++ b/registry/p2p/calldata-P2pMessageSender.json
@@ -30,7 +30,7 @@
     "formats": {
       "send(string)": {
         "$id": null,
-        "intent": "Withdraw validators",
+        "intent": "Withdrawal message",
         "screens": null,
         "fields": [{ "$id": null, "label": "Public keys", "format": "raw", "params": null, "path": "#.text", "value": null }],
         "required": ["#.text"],

--- a/registry/p2p/calldata-P2pSsvProxyFactory.json
+++ b/registry/p2p/calldata-P2pSsvProxyFactory.json
@@ -1245,13 +1245,30 @@
             "path": "#._ethAmountPerValidatorInWei",
             "value": null
           },
-          { "$id": null, "label": "Amount to deposit", "format": "amount", "params": null, "path": "@.value", "value": null }
+          { "$id": null, "label": "Amount to deposit", "format": "amount", "params": null, "path": "@.value", "value": null },
+             {
+          "path": "#._clientConfig.recipient",
+          "label": "Client recipient",
+          "format": "addressName",
+          "params": {
+            "senderAddress": [
+              "0x0000000000000000000000000000000000000000"
+            ]
+          }
+        },
+        {
+        "path": "#._clientConfig.basisPoints",
+        "label": "Client fee (bps)",
+        "format": "unit",
+        "params": {
+          "base": "bps",
+          "decimals": 0
+        }
+      }
         ],
-        "required": ["#._eth2WithdrawalCredentials", "#._ethAmountPerValidatorInWei", "@.value"],
+        "required": ["#._eth2WithdrawalCredentials", "#._ethAmountPerValidatorInWei", "@.value", "#._clientConfig.basisPoints","#._clientConfig.recipient"],
         "excluded": [
           "#._clientConfig",
-          "#._clientConfig.basisPoints",
-          "#._clientConfig.recipient",
           "#._referrerConfig",
           "#._referrerConfig.basisPoints",
           "#._referrerConfig.recipient",


### PR DESCRIPTION
## p2p
### `registry/p2p/calldata-NativeTokenVault.json`
- `enterExitQueue(uint256,address)`: Issue: share amount displayed as a raw amount; Fix: show "Shares to exit" as `tokenAmount` with `tokenPath @.to`.

### `registry/p2p/calldata-P2pMessageSender.json`
- `send(string)`: Issue: intent "Withdraw validators" was unclear; Fix: intent "Withdrawal message".

### `registry/p2p/calldata-P2pSsvProxyFactory.json`
- `addEth(bytes32,uint96,(uint96,address),(uint96,address),bytes)`: Issue: client fee recipient/bps were hidden; Fix: add `#._clientConfig.recipient` and `#._clientConfig.basisPoints` fields and require them.
