### PR TITLE
fix(quickswap): Issues fixes

### DIFF
--- a/registry/quickswap/calldata-QuickSwap.json
+++ b/registry/quickswap/calldata-QuickSwap.json
@@ -17,7 +17,7 @@
         "intent": "Swap",
         "fields": [
           { "path": "amountIn", "label": "Amount to Send", "format": "tokenAmount", "params": { "tokenPath": "path.[0]" } },
-          { "path": "amountOutMin", "label": "Minimum to Receive", "format": "tokenAmount", "params": { "tokenPath": "path.[1]" } },
+          { "path": "amountOutMin", "label": "Minimum to Receive", "format": "tokenAmount", "params": { "tokenPath": "path.[-1]" } },
           { "path": "to", "label": "Beneficiary", "format": "addressName", "params": { "types": ["eoa"], "sources": ["local", "ens"] } },
           { "path": "deadline", "label": "Deadline", "format": "date", "params": { "encoding": "timestamp" } }
         ],
@@ -38,7 +38,8 @@
         "$id": "swapExactETHForTokens",
         "intent": "Swap",
         "fields": [
-          { "path": "amountOutMin", "label": "Minimum to Receive", "format": "tokenAmount", "params": { "tokenPath": "path.[1]" } },
+          { "path": "@.value", "label": "Amount to Send", "format": "amount" },
+          { "path": "amountOutMin", "label": "Minimum to Receive", "format": "tokenAmount", "params": { "tokenPath": "path.[-1]" } },
           { "path": "to", "label": "Beneficiary", "format": "addressName", "params": { "types": ["eoa"], "sources": ["local", "ens"] } },
           { "path": "deadline", "label": "Deadline", "format": "date", "params": { "encoding": "timestamp" } }
         ],
@@ -48,7 +49,7 @@
         "$id": "swapTokensForExactTokens",
         "intent": "Swap",
         "fields": [
-          { "path": "amountOut", "label": "Amount to Receive", "format": "tokenAmount", "params": { "tokenPath": "path.[1]" } },
+          { "path": "amountOut", "label": "Amount to Receive", "format": "tokenAmount", "params": { "tokenPath": "path.[-1]" } },
           { "path": "amountInMax", "label": "Maximum to Send", "format": "tokenAmount", "params": { "tokenPath": "path.[0]" } },
           { "path": "to", "label": "Beneficiary", "format": "addressName", "params": { "types": ["eoa"], "sources": ["local", "ens"] } },
           { "path": "deadline", "label": "Deadline", "format": "date", "params": { "encoding": "timestamp" } }
@@ -60,7 +61,7 @@
         "intent": "Swap",
         "fields": [
           { "path": "amountIn", "label": "Amount to Send", "format": "tokenAmount", "params": { "tokenPath": "path.[0]" } },
-          { "path": "amountOutMin", "label": "Minimum to Receive", "format": "tokenAmount", "params": { "tokenPath": "path.[1]" } },
+          { "path": "amountOutMin", "label": "Minimum to Receive", "format": "tokenAmount", "params": { "tokenPath": "path.[-1]" } },
           { "path": "to", "label": "Beneficiary", "format": "addressName", "params": { "types": ["eoa"], "sources": ["local", "ens"] } },
           { "path": "deadline", "label": "Deadline", "format": "date", "params": { "encoding": "timestamp" } }
         ],
@@ -81,7 +82,8 @@
         "$id": "swapExactETHForTokensSupportingFeeOnTransferTokens",
         "intent": "Swap",
         "fields": [
-          { "path": "amountOutMin", "label": "Minimum to Receive", "format": "tokenAmount", "params": { "tokenPath": "path.[1]" } },
+          { "path": "@.value", "label": "Amount to Send", "format": "amount" },
+          { "path": "amountOutMin", "label": "Minimum to Receive", "format": "tokenAmount", "params": { "tokenPath": "path.[-1]" } },
           { "path": "to", "label": "Beneficiary", "format": "addressName", "params": { "types": ["eoa"], "sources": ["local", "ens"] } },
           { "path": "deadline", "label": "Deadline", "format": "date", "params": { "encoding": "timestamp" } }
         ],
@@ -128,7 +130,7 @@
         "intent": "Remove Liquidity",
         "fields": [
           { "path": "amountTokenMin", "label": "Minimum amount", "format": "tokenAmount", "params": { "tokenPath": "token" } },
-          { "path": "amountETHMin", "label": "Minimum amount", "format": "tokenAmount" },
+          { "path": "amountETHMin", "label": "Minimum amount", "format": "amount" },
           { "path": "to", "label": "Beneficiary", "format": "addressName", "params": { "types": ["eoa"], "sources": ["local", "ens"] } },
           { "path": "deadline", "label": "Deadline", "format": "date", "params": { "encoding": "timestamp" } }
         ],
@@ -150,7 +152,7 @@
         "intent": "Remove Liquidity",
         "fields": [
           { "path": "amountTokenMin", "label": "Minimum amount", "format": "tokenAmount", "params": { "tokenPath": "token" } },
-          { "path": "amountETHMin", "label": "Minimum amount", "format": "tokenAmount" },
+          { "path": "amountETHMin", "label": "Minimum amount", "format": "amount" },
           { "path": "to", "label": "Beneficiary", "format": "addressName", "params": { "types": ["eoa"], "sources": ["local", "ens"] } },
           { "path": "deadline", "label": "Deadline", "format": "date", "params": { "encoding": "timestamp" } }
         ],


### PR DESCRIPTION
## quickswap
### `registry/quickswap/calldata-QuickSwap.json`
- `0x38ed1739 (swapExactTokensForTokens)`: Issue: incorrect path slicing used `path.[1]`; Fix: use `path.[-1]` for `amountOutMin` token.
- `0x7ff36ab5 (swapExactETHForTokens)`:
  - Issue: ETH send amount was hidden. Fix: add `@.value` "Amount to Send" since it can only swap native.
  - Issue: incorrect path slicing used `path.[1]`; Fix: use `path.[-1]` for `amountOutMin` token.
- `0x8803dbee (swapTokensForExactTokens)`: Issue: incorrect path slicing used `path.[1]`; Fix: use `path.[-1]` for `amountOutMin` token.
- `0x5c11d795 (swapExactTokensForTokensSupportingFeeOnTransferTokens)`: Issue: incorrect path slicing used `path.[1]`; Fix: use `path.[-1]` for `amountOutMin` token.
- `0xb6f9de95 (swapExactETHForTokensSupportingFeeOnTransferTokens)`:
  - Issue: ETH send amount was hidden. Fix: add `@.value` "Amount to Send" since it can only swap native.
  - Issue: incorrect path slicing used `path.[1]`; Fix: use `path.[-1]` for `amountOutMin` token.
- `0x02751cec (removeLiquidityETH)`: Issue: `amountETHMin` formatted as `tokenAmount`; Fix: render as native `amount`.
- `0xded9382a (removeLiquidityETHWithPermit)`: Issue: `amountETHMin` formatted as `tokenAmount`; Fix: render as native `amount`.
