### PR TITLE
fix(swell): Issues fixes

### DIFF
--- a/registry/swell/calldata-swell.json
+++ b/registry/swell/calldata-swell.json
@@ -221,7 +221,6 @@
           { "label": "Amount", "format": "tokenAmount", "path": "amount", "params": { "token": "$.metadata.constants.swellToken" } }
         ]
       },
-      "balanceOf(address)": { "fields": [{ "label": "Account", "format": "addressName", "params": { "types": ["wallet", "eoa", "contract"] }, "path": "#.account" }] },
       "batchAddToWhitelist(address[])": {
         "intent": "Add to whitelist",
         "fields": [


### PR DESCRIPTION
## swell
### `registry/swell/calldata-swell.json`
Deployment updated to the proxy address`0xFAe103DC9cf190eD75350761e95403b7b8aFa6c0` instead of the implementation at `0x4796d939b22027c2876d5ce9fde52da9ec4e2362`.
- `addToWhitelist(address)`: Issue: intent exceeded 20 characters and was truncated on device; Fix: intent "Add to whitelist".
- `allowance(address,address)`:
  - Issue: intent exceeded 20 characters and was truncated on device. Fix: intent "Check Allowance".
  - Issue: address types were narrow. Fix: allow wallet/eoa/contract for owner.
- `approve(address,uint256)`:
  - Issue: intent exceeded 20 characters and was truncated on device. Fix: intent "Approve spender".
  - Issue: spender types were narrow. Fix: allow wallet/eoa/contract.
- `balanceOf(address)`: Issue: account types were narrow; Fix: allow wallet/eoa/contract.
- `batchAddToWhitelist(address[])`:
  - Issue: intent exceeded 20 characters and was truncated on device. Fix: intent "Add to whitelist".
  - Issue: address types were narrow. Fix: allow wallet/eoa/contract.
- `batchRemoveFromWhitelist(address[])`: Issue: intent exceeded 20 characters and was truncated on device; Fix: intent "Remove addresses".
- `burn(uint256)`: Issue: amount displayed as raw `amount`; Fix: use `tokenAmount` with `tokenPath @.to`.
- `decreaseAllowance(address,uint256)`:
  - Issue: spender types were narrow. Fix: allow wallet/eoa/contract.
  - Issue: amount was raw. Fix: use `tokenAmount` with `tokenPath @.to` for `subtractedValue`.
- `depositViaDepositManager(uint256,address,uint256)`:
  - Issue: intent exceeded 20 characters and was truncated on device. Fix: intent "Deposit via Manager".
  - Issue: `to` types were narrow. Fix: allow wallet/eoa/contract.
- `depositWithReferral(address)`:
  - Issue: intent exceeded 20 characters and was truncated on device. Fix: intent "Deposit".
  - Issue: payable amount hidden. Fix: add `@.value` "Amount".
- `increaseAllowance(address,uint256)`:
  - Issue: spender types were narrow. Fix: allow wallet/eoa/contract.
  - Issue: amount was raw. Fix: use `tokenAmount` with `tokenPath @.to` for `addedValue`.
- `removeFromWhitelist(address)`: Issue: intent exceeded 20 characters and was truncated on device; Fix: intent "Unwhitelist".
- `reprice(uint256,uint256,uint256)`: Issue: label "Pre Reward ETH Reserves" exceeded 20 characters and was truncated on device; Fix: rename to "Pre Reward Reserves".
- `transfer(address,uint256)`:
  - Issue: intent exceeded 20 characters and was truncated on device. Fix: intent "Transfer Tokens".
  - Issue: address types were narrow. Fix: allow wallet/eoa/contract for `to`.
  - Issue: amount display was pinned to the token constant. Fix: use `tokenAmount` with `tokenPath @.to`.
- `transferFrom(address,address,uint256)`:
  - Issue: intent exceeded 20 characters and was truncated on device. Fix: intent "Transfer From".
  - Issue: address types were narrow. Fix: allow wallet/eoa/contract for `from` and `to`.
  - Issue: amount display was pinned to the token constant. Fix: use `tokenAmount` with `tokenPath @.to`.
- `initialize(address)`: Issue: admin-only setup cluttered displays; Fix: remove the format entry.
- `setMaximumRepriceDifferencePercentage(uint256)`: Issue: admin-only setter cluttered displays; Fix: remove the format entry.
- `setMaximumRepriceRswETHDifferencePercentage(uint256)`: Issue: admin-only setter cluttered displays; Fix: remove the format entry.
- `setMinimumRepriceTime(uint256)`: Issue: admin-only setter cluttered displays; Fix: remove the format entry.
- `setNodeOperatorRewardPercentage(uint256)`: Issue: admin-only setter cluttered displays; Fix: remove the format entry.
- `setSwellTreasuryRewardPercentage(uint256)`: Issue: admin-only setter cluttered displays; Fix: remove the format entry.
