### PR TITLE
fix(swissborg): Issues fixes

### DIFF
--- a/registry/swissborg/calldata-NttManager.json
+++ b/registry/swissborg/calldata-NttManager.json
@@ -730,7 +730,7 @@
           { "$id": "destinationChain", "label": "Destination Chain", "format": "raw", "params": null, "path": "#.recipientChain" },
           {
             "$id": "encodedDestinationAddress",
-            "label": "Encoded Destination Address",
+            "label": "Destination Address",
             "format": "raw",
             "params": null,
             "path": "#.recipient"
@@ -752,7 +752,7 @@
           { "$id": "destinationChain", "label": "Destination Chain", "format": "raw", "params": null, "path": "#.recipientChain" },
           {
             "$id": "encodedDestinationAddress",
-            "label": "Encoded Destination Address",
+            "label": "Destination Address",
             "format": "raw",
             "params": null,
             "path": "#.recipient"
@@ -761,7 +761,7 @@
           { "$id": "shouldQueue", "label": "Should Queue", "format": "raw", "params": null, "path": "#.shouldQueue" },
           {
             "$id": "transceiverInstructions",
-            "label": "Transceiver Instructions",
+            "label": "Instructions",
             "format": "raw",
             "params": null,
             "path": "#.transceiverInstructions"


### PR DESCRIPTION
## swissborg
### `registry/swissborg/calldata-NttManager.json`
- `transfer(uint256,uint16,bytes32)`: Issue: label "Encoded Destination Address" exceeded 20 characters and was truncated on device; Fix: rename to "Destination Address".
- `transfer(uint256,uint16,bytes32,bytes32,bool,bytes)`:
  - Issue: label "Encoded Destination Address" exceeded 20 characters and was truncated on device. Fix: rename to "Destination Address".
  - Issue: label "Transceiver Instructions" exceeded 20 characters and was truncated on device. Fix: rename to "Instructions".
