### PR TITLE
feat(Lido): add wstETH referral staker contract

### DIFF
--- a/registry/lido/calldata-WithdrawalQueueERC721.json
+++ b/registry/lido/calldata-WithdrawalQueueERC721.json
@@ -3,7 +3,12 @@
   "context": {
     "$id": "WithdrawalQueueERC721",
     "contract": {
-      "deployments": [{ "chainId": 1, "address": "0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1" }],
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1"
+        }
+      ],
       "abi": "https://github.com/LedgerHQ/ledger-asset-dapps/blob/2eb3482cb1311f828a88e417c5095b9bbbc43fee/ethereum/lido/abis/0x889edc2edab5f40e902b864ad4d7ade8e412f9b1.abi.json"
     }
   },
@@ -18,7 +23,7 @@
   "display": {
     "formats": {
       "requestWithdrawals(uint256[],address)": {
-        "intent": "request stETH withdrawal",
+        "intent": "Request stETH withdrawal",
         "fields": [
           {
             "label": "Amount to withdraw",
@@ -29,7 +34,10 @@
           {
             "label": "Beneficiary",
             "format": "addressName",
-            "params": { "types": ["eoa", "wallet"], "sources": ["local", "ens"] },
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens"]
+            },
             "path": "#._owner"
           }
         ],
@@ -37,7 +45,7 @@
         "excluded": []
       },
       "requestWithdrawalsWithPermit(uint256[],address,(uint256,uint256,uint8,bytes32,bytes32))": {
-        "intent": "request stETH withdrawal",
+        "intent": "Request stETH withdrawal",
         "fields": [
           {
             "label": "Amount to withdraw",
@@ -48,15 +56,24 @@
           {
             "label": "Beneficiary",
             "format": "addressName",
-            "params": { "types": ["eoa", "wallet"], "sources": ["local", "ens"] },
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens"]
+            },
             "path": "#._owner"
           }
         ],
         "required": ["#._amounts.[]", "#._owner"],
-        "excluded": ["#._permit.value", "#._permit.deadline", "#._permit.v", "#._permit.r", "#._permit.s"]
+        "excluded": [
+          "#._permit.value",
+          "#._permit.deadline",
+          "#._permit.v",
+          "#._permit.r",
+          "#._permit.s"
+        ]
       },
       "requestWithdrawalsWstETH(uint256[],address)": {
-        "intent": "request wstETH withdrawal",
+        "intent": "Request wstETH withdrawal",
         "fields": [
           {
             "label": "Amount to withdraw",
@@ -67,7 +84,10 @@
           {
             "label": "Beneficiary",
             "format": "addressName",
-            "params": { "types": ["eoa", "wallet"], "sources": ["local", "ens"] },
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens"]
+            },
             "path": "#._owner"
           }
         ],
@@ -75,7 +95,7 @@
         "excluded": []
       },
       "requestWithdrawalsWstETHWithPermit(uint256[],address,(uint256,uint256,uint8,bytes32,bytes32))": {
-        "intent": "request wstETH withdrawal",
+        "intent": "Request wstETH withdrawal",
         "fields": [
           {
             "label": "Amount to withdraw",
@@ -86,7 +106,10 @@
           {
             "label": "Beneficiary",
             "format": "addressName",
-            "params": { "types": ["eoa", "wallet"], "sources": ["local", "ens"] },
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens"]
+            },
             "path": "#._owner"
           }
         ],
@@ -94,25 +117,36 @@
         "excluded": ["#._permit"]
       },
       "claimWithdrawal(uint256)": {
-        "intent": "claim withdrawal request",
-        "fields": [{ "label": "Request ID", "format": "raw", "path": "#._requestId" }],
+        "intent": "Claim withdrawal request",
+        "fields": [
+          { "label": "Request ID", "format": "raw", "path": "#._requestId" }
+        ],
         "required": ["#._requestId"],
         "excluded": []
       },
       "claimWithdrawals(uint256[],uint256[])": {
-        "intent": "claim withdrawal requests",
-        "fields": [{ "label": "Request ID", "format": "raw", "path": "#._requestIds.[]" }],
+        "intent": "Claim withdrawal requests",
+        "fields": [
+          { "label": "Request ID", "format": "raw", "path": "#._requestIds.[]" }
+        ],
         "required": ["#._requestIds.[]"],
         "excluded": ["#._hints.[]"]
       },
       "claimWithdrawalsTo(uint256[],uint256[],address)": {
-        "intent": "claim withdrawal requests",
+        "intent": "Claim withdrawal requests",
         "fields": [
-          { "label": "Request IDs", "format": "raw", "path": "#._requestIds.[]" },
+          {
+            "label": "Request IDs",
+            "format": "raw",
+            "path": "#._requestIds.[]"
+          },
           {
             "label": "ETH recipient",
             "format": "addressName",
-            "params": { "types": ["eoa", "wallet"], "sources": ["local", "ens"] },
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens"]
+            },
             "path": "#._recipient"
           }
         ],
@@ -120,7 +154,7 @@
         "excluded": ["#._hints.[]"]
       },
       "approve(address,uint256)": {
-        "intent": "allow unstETH NFT transfer",
+        "intent": "Allow unstETH NFT transfer",
         "fields": [
           {
             "label": "Operator address",
@@ -132,18 +166,24 @@
         ]
       },
       "safeTransferFrom(address,address,uint256)": {
-        "intent": "transfer unstETH NFT",
+        "intent": "Transfer unstETH NFT",
         "fields": [
           {
             "label": "From",
             "format": "addressName",
-            "params": { "types": ["eoa", "wallet"], "sources": ["local", "ens"] },
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens"]
+            },
             "path": "#._from"
           },
           {
             "label": "To",
             "format": "addressName",
-            "params": { "types": ["eoa", "wallet"], "sources": ["local", "ens"] },
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens"]
+            },
             "path": "#._to"
           }
         ],
@@ -151,18 +191,24 @@
         "excluded": ["#._requestId"]
       },
       "transferFrom(address,address,uint256)": {
-        "intent": "transfer unstETH NFT",
+        "intent": "Transfer unstETH NFT",
         "fields": [
           {
             "label": "From",
             "format": "addressName",
-            "params": { "types": ["eoa", "wallet"], "sources": ["local", "ens"] },
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens"]
+            },
             "path": "#._from"
           },
           {
             "label": "To",
             "format": "addressName",
-            "params": { "types": ["eoa", "wallet"], "sources": ["local", "ens"] },
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens"]
+            },
             "path": "#._to"
           }
         ],
@@ -170,12 +216,15 @@
         "excluded": ["#._requestId"]
       },
       "setApprovalForAll(address, bool)": {
-        "intent": "approve all unstETH tokens",
+        "intent": "Approve all unstETH tokens",
         "fields": [
           {
             "label": "Operator",
             "format": "addressName",
-            "params": { "types": ["eoa", "wallet"], "sources": ["local", "ens"] },
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens"]
+            },
             "path": "#._operator"
           },
           { "label": "Approved", "format": "raw", "path": "#._approved" }

--- a/registry/lido/calldata-stETH.json
+++ b/registry/lido/calldata-stETH.json
@@ -3,19 +3,26 @@
   "context": {
     "$id": "stETH",
     "contract": {
-      "deployments": [{ "chainId": 1, "address": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84" }],
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"
+        }
+      ],
       "abi": "https://github.com/LedgerHQ/ledger-asset-dapps/blob/211e75ed27de3894f592ca73710fa0b72c3ceeae/ethereum/lido/abis/0xae7ab96520de3a18e5e111b5eaab095312d7fe84.abi.json"
     }
   },
   "metadata": {
     "owner": "Lido DAO",
     "info": { "legalName": "Lido DAO", "url": "https://lido.fi" },
-    "constants": { "stETHaddress": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84" }
+    "constants": {
+      "stETHaddress": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"
+    }
   },
   "display": {
     "formats": {
       "approve(address,uint256)": {
-        "intent": "authorize stETH spending",
+        "intent": "Authorize stETH spending",
         "fields": [
           {
             "label": "Spender",
@@ -34,18 +41,23 @@
         "excluded": []
       },
       "submit(address)": {
-        "intent": "stake ETH",
-        "fields": [{ "label": "Amount to stake", "format": "amount", "path": "@.value" }],
+        "intent": "Stake ETH",
+        "fields": [
+          { "label": "Amount to stake", "format": "amount", "path": "@.value" }
+        ],
         "required": [],
         "excluded": ["#._referral"]
       },
       "transfer(address,uint256)": {
-        "intent": "transfer stETH",
+        "intent": "Transfer stETH",
         "fields": [
           {
             "label": "Recipient",
             "format": "addressName",
-            "params": { "types": ["eoa", "wallet"], "sources": ["local", "ens"] },
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens"]
+            },
             "path": "#._recipient"
           },
           {

--- a/registry/lido/calldata-wstETH-referral-staker.json
+++ b/registry/lido/calldata-wstETH-referral-staker.json
@@ -85,7 +85,7 @@
   "display": {
     "formats": {
       "stakeETH(address)": {
-        "intent": "stake ETH",
+        "intent": "Stake ETH",
         "fields": [
           {
             "label": "Amount to stake",

--- a/registry/lido/calldata-wstETH.json
+++ b/registry/lido/calldata-wstETH.json
@@ -3,7 +3,12 @@
   "context": {
     "$id": "wstETH",
     "contract": {
-      "deployments": [{ "chainId": 1, "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0" }],
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0"
+        }
+      ],
       "abi": "https://github.com/LedgerHQ/ledger-asset-dapps/blob/211e75ed27de3894f592ca73710fa0b72c3ceeae/ethereum/lido/abis/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.abi.json"
     }
   },
@@ -18,7 +23,7 @@
   "display": {
     "formats": {
       "approve(address,uint256)": {
-        "intent": "authorize wstETH spending",
+        "intent": "Authorize wstETH spending",
         "fields": [
           {
             "label": "Spender",
@@ -37,7 +42,7 @@
         "excluded": []
       },
       "wrap(uint256)": {
-        "intent": "wrap stETH to wstETH",
+        "intent": "Wrap stETH to wstETH",
         "fields": [
           {
             "label": "stETH amount",
@@ -50,7 +55,7 @@
         "excluded": []
       },
       "unwrap(uint256)": {
-        "intent": "unwrap wstETH to stETH",
+        "intent": "Unwrap wstETH to stETH",
         "fields": [
           {
             "label": "wstETH amount",
@@ -63,12 +68,15 @@
         "excluded": []
       },
       "transfer(address,uint256)": {
-        "intent": "transfer wstETH",
+        "intent": "Transfer wstETH",
         "fields": [
           {
             "label": "Recipient",
             "format": "addressName",
-            "params": { "types": ["eoa", "wallet"], "sources": ["local", "ens"] },
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens"]
+            },
             "path": "#.recipient"
           },
           {


### PR DESCRIPTION
This PR adds ERC-7730 clear signing information for a new Lido contract: wstETH referral staker.
On etherscan: https://etherscan.io/address/0xa88f0329C2c4ce51ba3fc619BBf44efE7120Dd0d

The contract is mentioned here: https://docs.lido.fi/deployed-contracts/#core-protocol
