### PR TITLE
fix: align tally and smartcredit EIP-712 domains

### DIFF
--- a/registry/smartcredit/eip712-smartcredit.json
+++ b/registry/smartcredit/eip712-smartcredit.json
@@ -3,16 +3,16 @@
   "context": {
     "eip712": {
       "deployments": [{ "chainId": 1, "address": "0x72e9d9038ce484ee986fea183f8d8df93f9ada13" }],
-      "domain": { "name": "SmartCredit.io", "chainId": 1, "verifyingContract": "0x72e9d9038ce484ee986fea183f8d8df93f9ada13" },
+      "domain": { "name": "Credit Line", "version": "1.0.0" },
       "schemas": [
         {
           "primaryType": "LoanRequest",
           "types": {
             "EIP712Domain": [
-              { "name": "chainId", "type": "uint256" },
               { "name": "name", "type": "string" },
-              { "name": "verifyingContract", "type": "address" },
-              { "name": "version", "type": "string" }
+              { "name": "version", "type": "string" },
+              { "name": "chainId", "type": "uint256" },
+              { "name": "verifyingContract", "type": "address" }
             ],
             "LoanRequest": [
               { "name": "collateralAddress", "type": "address" },

--- a/registry/tally/eip712-tally-arbitrum-arb-token.json
+++ b/registry/tally/eip712-tally-arbitrum-arb-token.json
@@ -2,33 +2,80 @@
   "$schema": "../../specs/erc7730-v1.schema.json",
   "context": {
     "eip712": {
-      "deployments": [{ "chainId": 42161, "address": "0x912ce59144191c1204e64559fe8253a0e49e6548" }],
-      "domain": { "name": "Tally", "chainId": 42161, "verifyingContract": "0x912ce59144191c1204e64559fe8253a0e49e6548" },
+      "deployments": [
+        {
+          "chainId": 42161,
+          "address": "0x912ce59144191c1204e64559fe8253a0e49e6548"
+        }
+      ],
+      "domain": {
+        "name": "Arbitrum",
+        "version": "1"
+      },
       "schemas": [
         {
           "primaryType": "Delegation",
           "types": {
-            "Delegation": [{ "name": "delegatee", "type": "address" }, { "name": "nonce", "type": "uint256" }, { "name": "expiry", "type": "uint256" }],
+            "Delegation": [
+              {
+                "name": "delegatee",
+                "type": "address"
+              },
+              {
+                "name": "nonce",
+                "type": "uint256"
+              },
+              {
+                "name": "expiry",
+                "type": "uint256"
+              }
+            ],
             "EIP712Domain": [
-              { "name": "chainId", "type": "uint256" },
-              { "name": "name", "type": "string" },
-              { "name": "verifyingContract", "type": "address" },
-              { "name": "version", "type": "string" }
+              {
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "name": "version",
+                "type": "string"
+              },
+              {
+                "name": "chainId",
+                "type": "uint256"
+              },
+              {
+                "name": "verifyingContract",
+                "type": "address"
+              }
             ]
           }
         }
       ]
     }
   },
-  "metadata": { "owner": "Arbitrum" },
+  "metadata": {
+    "owner": "Arbitrum"
+  },
   "display": {
     "formats": {
       "Delegation": {
         "intent": "ARB token",
         "fields": [
-          { "path": "delegatee", "label": "Delegatee", "format": "raw" },
-          { "path": "nonce", "label": "Nonce", "format": "raw" },
-          { "path": "expiry", "label": "Expiry", "format": "raw" }
+          {
+            "path": "delegatee",
+            "label": "Delegatee",
+            "format": "raw"
+          },
+          {
+            "path": "nonce",
+            "label": "Nonce",
+            "format": "raw"
+          },
+          {
+            "path": "expiry",
+            "label": "Expiry",
+            "format": "raw"
+          }
         ]
       }
     }

--- a/registry/tally/eip712-tally-arbitrum-core-governor.json
+++ b/registry/tally/eip712-tally-arbitrum-core-governor.json
@@ -2,32 +2,71 @@
   "$schema": "../../specs/erc7730-v1.schema.json",
   "context": {
     "eip712": {
-      "deployments": [{ "chainId": 42161, "address": "0xf07ded9dc292157749b6fd268e37df6ea38395b9" }],
-      "domain": { "name": "Tally", "chainId": 42161, "verifyingContract": "0xf07ded9dc292157749b6fd268e37df6ea38395b9" },
+      "deployments": [
+        {
+          "chainId": 42161,
+          "address": "0xf07ded9dc292157749b6fd268e37df6ea38395b9"
+        }
+      ],
+      "domain": {
+        "name": "L2ArbitrumGovernor",
+        "version": "1"
+      },
       "schemas": [
         {
           "primaryType": "Ballot",
           "types": {
-            "Ballot": [{ "name": "proposalId", "type": "uint256" }, { "name": "support", "type": "uint8" }],
+            "Ballot": [
+              {
+                "name": "proposalId",
+                "type": "uint256"
+              },
+              {
+                "name": "support",
+                "type": "uint8"
+              }
+            ],
             "EIP712Domain": [
-              { "name": "chainId", "type": "uint256" },
-              { "name": "name", "type": "string" },
-              { "name": "verifyingContract", "type": "address" },
-              { "name": "version", "type": "string" }
+              {
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "name": "version",
+                "type": "string"
+              },
+              {
+                "name": "chainId",
+                "type": "uint256"
+              },
+              {
+                "name": "verifyingContract",
+                "type": "address"
+              }
             ]
           }
         }
       ]
     }
   },
-  "metadata": { "owner": "L2ArbitrumGovernor" },
+  "metadata": {
+    "owner": "L2ArbitrumGovernor"
+  },
   "display": {
     "formats": {
       "Ballot": {
         "intent": "Arbitrum Foundation: Core Governor",
         "fields": [
-          { "path": "proposalId", "label": "Proposal id", "format": "raw" },
-          { "path": "support", "label": "Support", "format": "raw" }
+          {
+            "path": "proposalId",
+            "label": "Proposal id",
+            "format": "raw"
+          },
+          {
+            "path": "support",
+            "label": "Support",
+            "format": "raw"
+          }
         ]
       }
     }

--- a/registry/tally/eip712-tally-arbitrum-treasury-governor.json
+++ b/registry/tally/eip712-tally-arbitrum-treasury-governor.json
@@ -2,32 +2,71 @@
   "$schema": "../../specs/erc7730-v1.schema.json",
   "context": {
     "eip712": {
-      "deployments": [{ "chainId": 42161, "address": "0x789fc99093b09ad01c34dc7251d0c89ce743e5a4" }],
-      "domain": { "name": "Tally", "chainId": 42161, "verifyingContract": "0x789fc99093b09ad01c34dc7251d0c89ce743e5a4" },
+      "deployments": [
+        {
+          "chainId": 42161,
+          "address": "0x789fc99093b09ad01c34dc7251d0c89ce743e5a4"
+        }
+      ],
+      "domain": {
+        "name": "L2ArbitrumGovernor",
+        "version": "1"
+      },
       "schemas": [
         {
           "primaryType": "Ballot",
           "types": {
-            "Ballot": [{ "name": "proposalId", "type": "uint256" }, { "name": "support", "type": "uint8" }],
+            "Ballot": [
+              {
+                "name": "proposalId",
+                "type": "uint256"
+              },
+              {
+                "name": "support",
+                "type": "uint8"
+              }
+            ],
             "EIP712Domain": [
-              { "name": "chainId", "type": "uint256" },
-              { "name": "name", "type": "string" },
-              { "name": "verifyingContract", "type": "address" },
-              { "name": "version", "type": "string" }
+              {
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "name": "version",
+                "type": "string"
+              },
+              {
+                "name": "chainId",
+                "type": "uint256"
+              },
+              {
+                "name": "verifyingContract",
+                "type": "address"
+              }
             ]
           }
         }
       ]
     }
   },
-  "metadata": { "owner": "L2ArbitrumGovernor" },
+  "metadata": {
+    "owner": "L2ArbitrumGovernor"
+  },
   "display": {
     "formats": {
       "Ballot": {
         "intent": "Arbitrum Foundation: Treasury Governor",
         "fields": [
-          { "path": "proposalId", "label": "Proposal id", "format": "raw" },
-          { "path": "support", "label": "Support", "format": "raw" }
+          {
+            "path": "proposalId",
+            "label": "Proposal id",
+            "format": "raw"
+          },
+          {
+            "path": "support",
+            "label": "Support",
+            "format": "raw"
+          }
         ]
       }
     }

--- a/registry/tally/eip712-tally-ethereum-bitcoin-governor.json
+++ b/registry/tally/eip712-tally-ethereum-bitcoin-governor.json
@@ -2,31 +2,66 @@
   "$schema": "../../specs/erc7730-v1.schema.json",
   "context": {
     "eip712": {
-      "deployments": [{ "chainId": 1, "address": "0xdbd27635a534a3d3169ef0498beb56fb9c937489" }],
-      "domain": { "name": "Tally", "chainId": 1, "verifyingContract": "0xdbd27635a534a3d3169ef0498beb56fb9c937489" },
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xdbd27635a534a3d3169ef0498beb56fb9c937489"
+        }
+      ],
+      "domain": {
+        "name": "GTC Governor Alpha"
+      },
       "schemas": [
         {
           "primaryType": "Ballot",
           "types": {
-            "Ballot": [{ "name": "proposalId", "type": "uint256" }, { "name": "support", "type": "uint8" }],
+            "Ballot": [
+              {
+                "name": "proposalId",
+                "type": "uint256"
+              },
+              {
+                "name": "support",
+                "type": "uint8"
+              }
+            ],
             "EIP712Domain": [
-              { "name": "chainId", "type": "uint256" },
-              { "name": "name", "type": "string" },
-              { "name": "verifyingContract", "type": "address" }
+              {
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "name": "chainId",
+                "type": "uint256"
+              },
+              {
+                "name": "verifyingContract",
+                "type": "address"
+              }
             ]
           }
         }
       ]
     }
   },
-  "metadata": { "owner": "GTC Governor Alpha" },
+  "metadata": {
+    "owner": "GTC Governor Alpha"
+  },
   "display": {
     "formats": {
       "Ballot": {
         "intent": "Gitcoin Governor",
         "fields": [
-          { "path": "proposalId", "label": "Proposal id", "format": "raw" },
-          { "path": "support", "label": "Support", "format": "raw" }
+          {
+            "path": "proposalId",
+            "label": "Proposal id",
+            "format": "raw"
+          },
+          {
+            "path": "support",
+            "label": "Support",
+            "format": "raw"
+          }
         ]
       }
     }

--- a/registry/tally/eip712-tally-ethereum-bravo-governor.json
+++ b/registry/tally/eip712-tally-ethereum-bravo-governor.json
@@ -2,31 +2,66 @@
   "$schema": "../../specs/erc7730-v1.schema.json",
   "context": {
     "eip712": {
-      "deployments": [{ "chainId": 1, "address": "0x408ed6354d4973f66138c91495f2f2fcbd8724c3" }],
-      "domain": { "name": "Tally", "chainId": 1, "verifyingContract": "0x408ed6354d4973f66138c91495f2f2fcbd8724c3" },
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x408ed6354d4973f66138c91495f2f2fcbd8724c3"
+        }
+      ],
+      "domain": {
+        "name": "Uniswap Governor Bravo"
+      },
       "schemas": [
         {
           "primaryType": "Ballot",
           "types": {
-            "Ballot": [{ "name": "proposalId", "type": "uint256" }, { "name": "support", "type": "uint8" }],
+            "Ballot": [
+              {
+                "name": "proposalId",
+                "type": "uint256"
+              },
+              {
+                "name": "support",
+                "type": "uint8"
+              }
+            ],
             "EIP712Domain": [
-              { "name": "chainId", "type": "uint256" },
-              { "name": "name", "type": "string" },
-              { "name": "verifyingContract", "type": "address" }
+              {
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "name": "chainId",
+                "type": "uint256"
+              },
+              {
+                "name": "verifyingContract",
+                "type": "address"
+              }
             ]
           }
         }
       ]
     }
   },
-  "metadata": { "owner": "Uniswap Governor Bravo" },
+  "metadata": {
+    "owner": "Uniswap Governor Bravo"
+  },
   "display": {
     "formats": {
       "Ballot": {
         "intent": "Uniswap Governor",
         "fields": [
-          { "path": "proposalId", "label": "Proposal id", "format": "raw" },
-          { "path": "support", "label": "Support", "format": "raw" }
+          {
+            "path": "proposalId",
+            "label": "Proposal id",
+            "format": "raw"
+          },
+          {
+            "path": "support",
+            "label": "Support",
+            "format": "raw"
+          }
         ]
       }
     }

--- a/registry/tally/eip712-tally-ethereum-ens-governor.json
+++ b/registry/tally/eip712-tally-ethereum-ens-governor.json
@@ -2,32 +2,71 @@
   "$schema": "../../specs/erc7730-v1.schema.json",
   "context": {
     "eip712": {
-      "deployments": [{ "chainId": 1, "address": "0x323a76393544d5ecca80cd6ef2a560c6a395b7e3" }],
-      "domain": { "name": "Tally", "chainId": 1, "verifyingContract": "0x323a76393544d5ecca80cd6ef2a560c6a395b7e3" },
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x323a76393544d5ecca80cd6ef2a560c6a395b7e3"
+        }
+      ],
+      "domain": {
+        "name": "ENS Governor",
+        "version": "1"
+      },
       "schemas": [
         {
           "primaryType": "Ballot",
           "types": {
-            "Ballot": [{ "name": "proposalId", "type": "uint256" }, { "name": "support", "type": "uint8" }],
+            "Ballot": [
+              {
+                "name": "proposalId",
+                "type": "uint256"
+              },
+              {
+                "name": "support",
+                "type": "uint8"
+              }
+            ],
             "EIP712Domain": [
-              { "name": "chainId", "type": "uint256" },
-              { "name": "name", "type": "string" },
-              { "name": "verifyingContract", "type": "address" },
-              { "name": "version", "type": "string" }
+              {
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "name": "version",
+                "type": "string"
+              },
+              {
+                "name": "chainId",
+                "type": "uint256"
+              },
+              {
+                "name": "verifyingContract",
+                "type": "address"
+              }
             ]
           }
         }
       ]
     }
   },
-  "metadata": { "owner": "ENS Governor" },
+  "metadata": {
+    "owner": "ENS Governor"
+  },
   "display": {
     "formats": {
       "Ballot": {
         "intent": "ENS Governor",
         "fields": [
-          { "path": "proposalId", "label": "Proposal id", "format": "raw" },
-          { "path": "support", "label": "Support", "format": "raw" }
+          {
+            "path": "proposalId",
+            "label": "Proposal id",
+            "format": "raw"
+          },
+          {
+            "path": "support",
+            "label": "Support",
+            "format": "raw"
+          }
         ]
       }
     }

--- a/registry/tally/eip712-tally-ethereum-ens-token.json
+++ b/registry/tally/eip712-tally-ethereum-ens-token.json
@@ -2,33 +2,80 @@
   "$schema": "../../specs/erc7730-v1.schema.json",
   "context": {
     "eip712": {
-      "deployments": [{ "chainId": 1, "address": "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72" }],
-      "domain": { "name": "Tally", "chainId": 1, "verifyingContract": "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72" },
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72"
+        }
+      ],
+      "domain": {
+        "name": "Ethereum Name Service",
+        "version": "1"
+      },
       "schemas": [
         {
           "primaryType": "Delegation",
           "types": {
-            "Delegation": [{ "name": "delegatee", "type": "address" }, { "name": "nonce", "type": "uint256" }, { "name": "expiry", "type": "uint256" }],
+            "Delegation": [
+              {
+                "name": "delegatee",
+                "type": "address"
+              },
+              {
+                "name": "nonce",
+                "type": "uint256"
+              },
+              {
+                "name": "expiry",
+                "type": "uint256"
+              }
+            ],
             "EIP712Domain": [
-              { "name": "chainId", "type": "uint256" },
-              { "name": "name", "type": "string" },
-              { "name": "verifyingContract", "type": "address" },
-              { "name": "version", "type": "string" }
+              {
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "name": "version",
+                "type": "string"
+              },
+              {
+                "name": "chainId",
+                "type": "uint256"
+              },
+              {
+                "name": "verifyingContract",
+                "type": "address"
+              }
             ]
           }
         }
       ]
     }
   },
-  "metadata": { "owner": "Ethereum Name Service" },
+  "metadata": {
+    "owner": "Ethereum Name Service"
+  },
   "display": {
     "formats": {
       "Delegation": {
         "intent": "ENS token",
         "fields": [
-          { "path": "delegatee", "label": "Delegatee", "format": "raw" },
-          { "path": "nonce", "label": "Nonce", "format": "raw" },
-          { "path": "expiry", "label": "Expiry", "format": "raw" }
+          {
+            "path": "delegatee",
+            "label": "Delegatee",
+            "format": "raw"
+          },
+          {
+            "path": "nonce",
+            "label": "Nonce",
+            "format": "raw"
+          },
+          {
+            "path": "expiry",
+            "label": "Expiry",
+            "format": "raw"
+          }
         ]
       }
     }

--- a/registry/tally/eip712-tally-ethereum-gtk-token.json
+++ b/registry/tally/eip712-tally-ethereum-gtk-token.json
@@ -2,32 +2,75 @@
   "$schema": "../../specs/erc7730-v1.schema.json",
   "context": {
     "eip712": {
-      "deployments": [{ "chainId": 1, "address": "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f" }],
-      "domain": { "name": "Tally", "chainId": 1, "verifyingContract": "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f" },
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f"
+        }
+      ],
+      "domain": {
+        "name": "Gitcoin"
+      },
       "schemas": [
         {
           "primaryType": "Delegation",
           "types": {
-            "Delegation": [{ "name": "delegatee", "type": "address" }, { "name": "nonce", "type": "uint256" }, { "name": "expiry", "type": "uint256" }],
+            "Delegation": [
+              {
+                "name": "delegatee",
+                "type": "address"
+              },
+              {
+                "name": "nonce",
+                "type": "uint256"
+              },
+              {
+                "name": "expiry",
+                "type": "uint256"
+              }
+            ],
             "EIP712Domain": [
-              { "name": "chainId", "type": "uint256" },
-              { "name": "name", "type": "string" },
-              { "name": "verifyingContract", "type": "address" }
+              {
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "name": "chainId",
+                "type": "uint256"
+              },
+              {
+                "name": "verifyingContract",
+                "type": "address"
+              }
             ]
           }
         }
       ]
     }
   },
-  "metadata": { "owner": "Gitcoin" },
+  "metadata": {
+    "owner": "Gitcoin"
+  },
   "display": {
     "formats": {
       "Delegation": {
         "intent": "GTK token",
         "fields": [
-          { "path": "delegatee", "label": "Delegatee", "format": "raw" },
-          { "path": "nonce", "label": "Nonce", "format": "raw" },
-          { "path": "expiry", "label": "Expiry", "format": "raw" }
+          {
+            "path": "delegatee",
+            "label": "Delegatee",
+            "format": "raw"
+          },
+          {
+            "path": "nonce",
+            "label": "Nonce",
+            "format": "raw"
+          },
+          {
+            "path": "expiry",
+            "label": "Expiry",
+            "format": "raw"
+          }
         ]
       }
     }

--- a/registry/tally/eip712-tally-ethereum-hop-governor.json
+++ b/registry/tally/eip712-tally-ethereum-hop-governor.json
@@ -2,31 +2,71 @@
   "$schema": "../../specs/erc7730-v1.schema.json",
   "context": {
     "eip712": {
-      "deployments": [{ "chainId": 1, "address": "0xed8bdb5895b8b7f9fdb3c087628fd8410e853d48" }],
-      "domain": { "name": "Tally", "chainId": 1, "verifyingContract": "0xed8bdb5895b8b7f9fdb3c087628fd8410e853d48" },
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xed8bdb5895b8b7f9fdb3c087628fd8410e853d48"
+        }
+      ],
+      "domain": {
+        "name": "HOP Governor",
+        "version": "1"
+      },
       "schemas": [
         {
           "primaryType": "Ballot",
           "types": {
-            "Ballot": [{ "name": "proposalId", "type": "uint256" }, { "name": "support", "type": "uint8" }],
+            "Ballot": [
+              {
+                "name": "proposalId",
+                "type": "uint256"
+              },
+              {
+                "name": "support",
+                "type": "uint8"
+              }
+            ],
             "EIP712Domain": [
-              { "name": "chainId", "type": "uint256" },
-              { "name": "name", "type": "string" },
-              { "name": "verifyingContract", "type": "address" }
+              {
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "name": "version",
+                "type": "string"
+              },
+              {
+                "name": "chainId",
+                "type": "uint256"
+              },
+              {
+                "name": "verifyingContract",
+                "type": "address"
+              }
             ]
           }
         }
       ]
     }
   },
-  "metadata": { "owner": "HOP Governor" },
+  "metadata": {
+    "owner": "HOP Governor"
+  },
   "display": {
     "formats": {
       "Ballot": {
         "intent": "Hop Governor",
         "fields": [
-          { "path": "proposalId", "label": "Proposal id", "format": "raw" },
-          { "path": "support", "label": "Support", "format": "raw" }
+          {
+            "path": "proposalId",
+            "label": "Proposal id",
+            "format": "raw"
+          },
+          {
+            "path": "support",
+            "label": "Support",
+            "format": "raw"
+          }
         ]
       }
     }

--- a/registry/tally/eip712-tally-ethereum-hop-token.json
+++ b/registry/tally/eip712-tally-ethereum-hop-token.json
@@ -2,32 +2,80 @@
   "$schema": "../../specs/erc7730-v1.schema.json",
   "context": {
     "eip712": {
-      "deployments": [{ "chainId": 1, "address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc" }],
-      "domain": { "name": "Tally", "chainId": 1, "verifyingContract": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc" },
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc"
+        }
+      ],
+      "domain": {
+        "name": "Hop",
+        "version": "1"
+      },
       "schemas": [
         {
           "primaryType": "Delegation",
           "types": {
-            "Delegation": [{ "name": "delegatee", "type": "address" }, { "name": "nonce", "type": "uint256" }, { "name": "expiry", "type": "uint256" }],
+            "Delegation": [
+              {
+                "name": "delegatee",
+                "type": "address"
+              },
+              {
+                "name": "nonce",
+                "type": "uint256"
+              },
+              {
+                "name": "expiry",
+                "type": "uint256"
+              }
+            ],
             "EIP712Domain": [
-              { "name": "chainId", "type": "uint256" },
-              { "name": "name", "type": "string" },
-              { "name": "verifyingContract", "type": "address" }
+              {
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "name": "version",
+                "type": "string"
+              },
+              {
+                "name": "chainId",
+                "type": "uint256"
+              },
+              {
+                "name": "verifyingContract",
+                "type": "address"
+              }
             ]
           }
         }
       ]
     }
   },
-  "metadata": { "owner": "Hop" },
+  "metadata": {
+    "owner": "Hop"
+  },
   "display": {
     "formats": {
       "Delegation": {
         "intent": "HOP token",
         "fields": [
-          { "path": "delegatee", "label": "Delegatee", "format": "raw" },
-          { "path": "nonce", "label": "Nonce", "format": "raw" },
-          { "path": "expiry", "label": "Expiry", "format": "raw" }
+          {
+            "path": "delegatee",
+            "label": "Delegatee",
+            "format": "raw"
+          },
+          {
+            "path": "nonce",
+            "label": "Nonce",
+            "format": "raw"
+          },
+          {
+            "path": "expiry",
+            "label": "Expiry",
+            "format": "raw"
+          }
         ]
       }
     }

--- a/registry/tally/eip712-tally-ethereum-pool-token.json
+++ b/registry/tally/eip712-tally-ethereum-pool-token.json
@@ -2,32 +2,75 @@
   "$schema": "../../specs/erc7730-v1.schema.json",
   "context": {
     "eip712": {
-      "deployments": [{ "chainId": 1, "address": "0x0cec1a9154ff802e7934fc916ed7ca50bde6844e" }],
-      "domain": { "name": "Tally", "chainId": 1, "verifyingContract": "0x0cec1a9154ff802e7934fc916ed7ca50bde6844e" },
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x0cec1a9154ff802e7934fc916ed7ca50bde6844e"
+        }
+      ],
+      "domain": {
+        "name": "PoolTogether"
+      },
       "schemas": [
         {
           "primaryType": "Delegation",
           "types": {
-            "Delegation": [{ "name": "delegatee", "type": "address" }, { "name": "nonce", "type": "uint256" }, { "name": "expiry", "type": "uint256" }],
+            "Delegation": [
+              {
+                "name": "delegatee",
+                "type": "address"
+              },
+              {
+                "name": "nonce",
+                "type": "uint256"
+              },
+              {
+                "name": "expiry",
+                "type": "uint256"
+              }
+            ],
             "EIP712Domain": [
-              { "name": "chainId", "type": "uint256" },
-              { "name": "name", "type": "string" },
-              { "name": "verifyingContract", "type": "address" }
+              {
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "name": "chainId",
+                "type": "uint256"
+              },
+              {
+                "name": "verifyingContract",
+                "type": "address"
+              }
             ]
           }
         }
       ]
     }
   },
-  "metadata": { "owner": "PoolTogether" },
+  "metadata": {
+    "owner": "PoolTogether"
+  },
   "display": {
     "formats": {
       "Delegation": {
         "intent": "POOL token",
         "fields": [
-          { "path": "delegatee", "label": "Delegatee", "format": "raw" },
-          { "path": "nonce", "label": "Nonce", "format": "raw" },
-          { "path": "expiry", "label": "Expiry", "format": "raw" }
+          {
+            "path": "delegatee",
+            "label": "Delegatee",
+            "format": "raw"
+          },
+          {
+            "path": "nonce",
+            "label": "Nonce",
+            "format": "raw"
+          },
+          {
+            "path": "expiry",
+            "label": "Expiry",
+            "format": "raw"
+          }
         ]
       }
     }

--- a/registry/tally/eip712-tally-ethereum-pooltogether-governor.json
+++ b/registry/tally/eip712-tally-ethereum-pooltogether-governor.json
@@ -2,31 +2,66 @@
   "$schema": "../../specs/erc7730-v1.schema.json",
   "context": {
     "eip712": {
-      "deployments": [{ "chainId": 1, "address": "0xb3a87172f555ae2a2ab79be60b336d2f7d0187f0" }],
-      "domain": { "name": "Tally", "chainId": 1, "verifyingContract": "0xb3a87172f555ae2a2ab79be60b336d2f7d0187f0" },
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xb3a87172f555ae2a2ab79be60b336d2f7d0187f0"
+        }
+      ],
+      "domain": {
+        "name": "PoolTogether Governor Alpha"
+      },
       "schemas": [
         {
           "primaryType": "Ballot",
           "types": {
-            "Ballot": [{ "name": "proposalId", "type": "uint256" }, { "name": "support", "type": "uint8" }],
+            "Ballot": [
+              {
+                "name": "proposalId",
+                "type": "uint256"
+              },
+              {
+                "name": "support",
+                "type": "uint8"
+              }
+            ],
             "EIP712Domain": [
-              { "name": "chainId", "type": "uint256" },
-              { "name": "name", "type": "string" },
-              { "name": "verifyingContract", "type": "address" }
+              {
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "name": "chainId",
+                "type": "uint256"
+              },
+              {
+                "name": "verifyingContract",
+                "type": "address"
+              }
             ]
           }
         }
       ]
     }
   },
-  "metadata": { "owner": "PoolTogether Governor Alpha" },
+  "metadata": {
+    "owner": "PoolTogether Governor Alpha"
+  },
   "display": {
     "formats": {
       "Ballot": {
         "intent": "PoolTogether Governor Alpha",
         "fields": [
-          { "path": "proposalId", "label": "Proposal id", "format": "raw" },
-          { "path": "support", "label": "Support", "format": "raw" }
+          {
+            "path": "proposalId",
+            "label": "Proposal id",
+            "format": "raw"
+          },
+          {
+            "path": "support",
+            "label": "Support",
+            "format": "raw"
+          }
         ]
       }
     }

--- a/registry/tally/eip712-tally-ethereum-uni-token.json
+++ b/registry/tally/eip712-tally-ethereum-uni-token.json
@@ -2,32 +2,75 @@
   "$schema": "../../specs/erc7730-v1.schema.json",
   "context": {
     "eip712": {
-      "deployments": [{ "chainId": 1, "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984" }],
-      "domain": { "name": "Tally", "chainId": 1, "verifyingContract": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984" },
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984"
+        }
+      ],
+      "domain": {
+        "name": "Uniswap"
+      },
       "schemas": [
         {
           "primaryType": "Delegation",
           "types": {
-            "Delegation": [{ "name": "delegatee", "type": "address" }, { "name": "nonce", "type": "uint256" }, { "name": "expiry", "type": "uint256" }],
+            "Delegation": [
+              {
+                "name": "delegatee",
+                "type": "address"
+              },
+              {
+                "name": "nonce",
+                "type": "uint256"
+              },
+              {
+                "name": "expiry",
+                "type": "uint256"
+              }
+            ],
             "EIP712Domain": [
-              { "name": "chainId", "type": "uint256" },
-              { "name": "name", "type": "string" },
-              { "name": "verifyingContract", "type": "address" }
+              {
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "name": "chainId",
+                "type": "uint256"
+              },
+              {
+                "name": "verifyingContract",
+                "type": "address"
+              }
             ]
           }
         }
       ]
     }
   },
-  "metadata": { "owner": "Uniswap" },
+  "metadata": {
+    "owner": "Uniswap"
+  },
   "display": {
     "formats": {
       "Delegation": {
         "intent": "UNI token",
         "fields": [
-          { "path": "delegatee", "label": "Delegatee", "format": "raw" },
-          { "path": "nonce", "label": "Nonce", "format": "raw" },
-          { "path": "expiry", "label": "Expiry", "format": "raw" }
+          {
+            "path": "delegatee",
+            "label": "Delegatee",
+            "format": "raw"
+          },
+          {
+            "path": "nonce",
+            "label": "Nonce",
+            "format": "raw"
+          },
+          {
+            "path": "expiry",
+            "label": "Expiry",
+            "format": "raw"
+          }
         ]
       }
     }


### PR DESCRIPTION
## Summary
- align Tally descriptors with on-chain EIP-712 domain definitions (domain names, version presence, and canonical `EIP712Domain` field ordering)
- remove redundant `chainId` and `verifyingContract` from `context.eip712.domain` in Tally files since these are already constrained by `deployments`
- update SmartCredit descriptor to match observed signing domain (`Credit Line`, version `1.0.0`) and canonical EIP-712 domain type ordering

## Test plan
- [x] validate JSON parses after edits
- [x] verify no linter diagnostics in modified descriptor files
- [x] manually confirm `verifyingContract` remains constrained through `context.eip712.deployments`