### PR TITLE
temp: revert Lifi descriptor

### DIFF
--- a/registry/lifi/calldata-LIFIDiamond.json
+++ b/registry/lifi/calldata-LIFIDiamond.json
@@ -1,0 +1,14038 @@
+{
+  "$schema": "https://github.com/LedgerHQ/clear-signing-erc7730-registry/blob/master/specs/erc7730-v1.schema.json",
+  "context": {
+    "$id": "LI.FI Service GmbH",
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 137,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 42161,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 10,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 56,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 43114,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 100,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 250,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 324,
+          "address": "0x341e94069f53234fE6DabeF707aD424830525715"
+        },
+        {
+          "chainId": 8453,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 59144,
+          "address": "0xDE1E598b81620773454588B85D6b5D4eEC32573e"
+        },
+        {
+          "chainId": 5000,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 534352,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 42220,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 1284,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 1285,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 1313161554,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 1088,
+          "address": "0x24ca98fB6972F5eE05f0dB00595c7f68D9FaFd68"
+        },
+        {
+          "chainId": 25,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 1666600000,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 122,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 288,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 106,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 9001,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 42170,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 167004,
+          "address": "0x3A9A5dBa8FE1C4Da98187cE4755701BCA182f63b"
+        },
+        {
+          "chainId": 204,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 81457,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 252,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 34443,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        }
+      ],
+      "abi": [
+        {
+          "type": "function",
+          "name": "setApprovalForBridges",
+          "inputs": [
+            {
+              "name": "bridges",
+              "type": "address[]",
+              "internalType": "address[]"
+            },
+            {
+              "name": "tokensToApprove",
+              "type": "address[]",
+              "internalType": "address[]"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaHopL1ERC20",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_hopData",
+              "type": "tuple",
+              "internalType": "struct HopFacetOptimized.HopData",
+              "components": [
+                {
+                  "name": "bonderFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "amountOutMin",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "deadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationAmountOutMin",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationDeadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hopBridge",
+                  "type": "address",
+                  "internalType": "contract IHopBridge"
+                },
+                {
+                  "name": "relayer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "relayerFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "nativeFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaHopL1Native",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_hopData",
+              "type": "tuple",
+              "internalType": "struct HopFacetOptimized.HopData",
+              "components": [
+                {
+                  "name": "bonderFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "amountOutMin",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "deadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationAmountOutMin",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationDeadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hopBridge",
+                  "type": "address",
+                  "internalType": "contract IHopBridge"
+                },
+                {
+                  "name": "relayer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "relayerFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "nativeFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaHopL2ERC20",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_hopData",
+              "type": "tuple",
+              "internalType": "struct HopFacetOptimized.HopData",
+              "components": [
+                {
+                  "name": "bonderFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "amountOutMin",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "deadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationAmountOutMin",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationDeadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hopBridge",
+                  "type": "address",
+                  "internalType": "contract IHopBridge"
+                },
+                {
+                  "name": "relayer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "relayerFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "nativeFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaHopL2Native",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_hopData",
+              "type": "tuple",
+              "internalType": "struct HopFacetOptimized.HopData",
+              "components": [
+                {
+                  "name": "bonderFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "amountOutMin",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "deadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationAmountOutMin",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationDeadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hopBridge",
+                  "type": "address",
+                  "internalType": "contract IHopBridge"
+                },
+                {
+                  "name": "relayer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "relayerFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "nativeFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaHopL1ERC20",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_hopData",
+              "type": "tuple",
+              "internalType": "struct HopFacetOptimized.HopData",
+              "components": [
+                {
+                  "name": "bonderFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "amountOutMin",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "deadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationAmountOutMin",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationDeadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hopBridge",
+                  "type": "address",
+                  "internalType": "contract IHopBridge"
+                },
+                {
+                  "name": "relayer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "relayerFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "nativeFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaHopL1Native",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_hopData",
+              "type": "tuple",
+              "internalType": "struct HopFacetOptimized.HopData",
+              "components": [
+                {
+                  "name": "bonderFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "amountOutMin",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "deadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationAmountOutMin",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationDeadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hopBridge",
+                  "type": "address",
+                  "internalType": "contract IHopBridge"
+                },
+                {
+                  "name": "relayer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "relayerFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "nativeFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaHopL2ERC20",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_hopData",
+              "type": "tuple",
+              "internalType": "struct HopFacetOptimized.HopData",
+              "components": [
+                {
+                  "name": "bonderFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "amountOutMin",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "deadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationAmountOutMin",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationDeadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hopBridge",
+                  "type": "address",
+                  "internalType": "contract IHopBridge"
+                },
+                {
+                  "name": "relayer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "relayerFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "nativeFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaHopL2Native",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_hopData",
+              "type": "tuple",
+              "internalType": "struct HopFacetOptimized.HopData",
+              "components": [
+                {
+                  "name": "bonderFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "amountOutMin",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "deadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationAmountOutMin",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationDeadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hopBridge",
+                  "type": "address",
+                  "internalType": "contract IHopBridge"
+                },
+                {
+                  "name": "relayer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "relayerFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "nativeFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "event",
+          "name": "AssetSwapped",
+          "inputs": [
+            {
+              "name": "transactionId",
+              "type": "bytes32",
+              "indexed": false,
+              "internalType": "bytes32"
+            },
+            {
+              "name": "dex",
+              "type": "address",
+              "indexed": false,
+              "internalType": "address"
+            },
+            {
+              "name": "fromAssetId",
+              "type": "address",
+              "indexed": false,
+              "internalType": "address"
+            },
+            {
+              "name": "toAssetId",
+              "type": "address",
+              "indexed": false,
+              "internalType": "address"
+            },
+            {
+              "name": "fromAmount",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            },
+            {
+              "name": "toAmount",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            },
+            {
+              "name": "timestamp",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "BridgeToNonEVMChain",
+          "inputs": [
+            {
+              "name": "transactionId",
+              "type": "bytes32",
+              "indexed": true,
+              "internalType": "bytes32"
+            },
+            {
+              "name": "destinationChainId",
+              "type": "uint256",
+              "indexed": true,
+              "internalType": "uint256"
+            },
+            {
+              "name": "receiver",
+              "type": "bytes",
+              "indexed": false,
+              "internalType": "bytes"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "BridgeToNonEVMChainBytes32",
+          "inputs": [
+            {
+              "name": "transactionId",
+              "type": "bytes32",
+              "indexed": true,
+              "internalType": "bytes32"
+            },
+            {
+              "name": "destinationChainId",
+              "type": "uint256",
+              "indexed": true,
+              "internalType": "uint256"
+            },
+            {
+              "name": "receiver",
+              "type": "bytes32",
+              "indexed": false,
+              "internalType": "bytes32"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "LiFiGenericSwapCompleted",
+          "inputs": [
+            {
+              "name": "transactionId",
+              "type": "bytes32",
+              "indexed": true,
+              "internalType": "bytes32"
+            },
+            {
+              "name": "integrator",
+              "type": "string",
+              "indexed": false,
+              "internalType": "string"
+            },
+            {
+              "name": "referrer",
+              "type": "string",
+              "indexed": false,
+              "internalType": "string"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "indexed": false,
+              "internalType": "address"
+            },
+            {
+              "name": "fromAssetId",
+              "type": "address",
+              "indexed": false,
+              "internalType": "address"
+            },
+            {
+              "name": "toAssetId",
+              "type": "address",
+              "indexed": false,
+              "internalType": "address"
+            },
+            {
+              "name": "fromAmount",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            },
+            {
+              "name": "toAmount",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "LiFiSwappedGeneric",
+          "inputs": [
+            {
+              "name": "transactionId",
+              "type": "bytes32",
+              "indexed": true,
+              "internalType": "bytes32"
+            },
+            {
+              "name": "integrator",
+              "type": "string",
+              "indexed": false,
+              "internalType": "string"
+            },
+            {
+              "name": "referrer",
+              "type": "string",
+              "indexed": false,
+              "internalType": "string"
+            },
+            {
+              "name": "fromAssetId",
+              "type": "address",
+              "indexed": false,
+              "internalType": "address"
+            },
+            {
+              "name": "toAssetId",
+              "type": "address",
+              "indexed": false,
+              "internalType": "address"
+            },
+            {
+              "name": "fromAmount",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            },
+            {
+              "name": "toAmount",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "LiFiTransferCompleted",
+          "inputs": [
+            {
+              "name": "transactionId",
+              "type": "bytes32",
+              "indexed": true,
+              "internalType": "bytes32"
+            },
+            {
+              "name": "receivingAssetId",
+              "type": "address",
+              "indexed": false,
+              "internalType": "address"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "indexed": false,
+              "internalType": "address"
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            },
+            {
+              "name": "timestamp",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "LiFiTransferRecovered",
+          "inputs": [
+            {
+              "name": "transactionId",
+              "type": "bytes32",
+              "indexed": true,
+              "internalType": "bytes32"
+            },
+            {
+              "name": "receivingAssetId",
+              "type": "address",
+              "indexed": false,
+              "internalType": "address"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "indexed": false,
+              "internalType": "address"
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            },
+            {
+              "name": "timestamp",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "LiFiTransferStarted",
+          "inputs": [
+            {
+              "name": "bridgeData",
+              "type": "tuple",
+              "indexed": false,
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "error",
+          "name": "ContractCallNotAllowed",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "CumulativeSlippageTooHigh",
+          "inputs": [
+            {
+              "name": "minAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "receivedAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "error",
+          "name": "InvalidAmount",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "InvalidContract",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "InvalidReceiver",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "NoSwapDataProvided",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "NoSwapFromZeroBalance",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "NullAddrIsNotAValidSpender",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "NullAddrIsNotAnERC20Token",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "OnlyContractOwner",
+          "inputs": []
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaStargate",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_stargateData",
+              "type": "tuple",
+              "internalType": "struct StargateFacetV2.StargateData",
+              "components": [
+                {
+                  "name": "assetId",
+                  "type": "uint16",
+                  "internalType": "uint16"
+                },
+                {
+                  "name": "sendParams",
+                  "type": "tuple",
+                  "internalType": "struct IStargate.SendParam",
+                  "components": [
+                    {
+                      "name": "dstEid",
+                      "type": "uint32",
+                      "internalType": "uint32"
+                    },
+                    {
+                      "name": "to",
+                      "type": "bytes32",
+                      "internalType": "bytes32"
+                    },
+                    {
+                      "name": "amountLD",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "minAmountLD",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "extraOptions",
+                      "type": "bytes",
+                      "internalType": "bytes"
+                    },
+                    {
+                      "name": "composeMsg",
+                      "type": "bytes",
+                      "internalType": "bytes"
+                    },
+                    {
+                      "name": "oftCmd",
+                      "type": "bytes",
+                      "internalType": "bytes"
+                    }
+                  ]
+                },
+                {
+                  "name": "fee",
+                  "type": "tuple",
+                  "internalType": "struct IStargate.MessagingFee",
+                  "components": [
+                    {
+                      "name": "nativeFee",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "lzTokenFee",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    }
+                  ]
+                },
+                {
+                  "name": "refundAddress",
+                  "type": "address",
+                  "internalType": "address payable"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaStargate",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_stargateData",
+              "type": "tuple",
+              "internalType": "struct StargateFacetV2.StargateData",
+              "components": [
+                {
+                  "name": "assetId",
+                  "type": "uint16",
+                  "internalType": "uint16"
+                },
+                {
+                  "name": "sendParams",
+                  "type": "tuple",
+                  "internalType": "struct IStargate.SendParam",
+                  "components": [
+                    {
+                      "name": "dstEid",
+                      "type": "uint32",
+                      "internalType": "uint32"
+                    },
+                    {
+                      "name": "to",
+                      "type": "bytes32",
+                      "internalType": "bytes32"
+                    },
+                    {
+                      "name": "amountLD",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "minAmountLD",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "extraOptions",
+                      "type": "bytes",
+                      "internalType": "bytes"
+                    },
+                    {
+                      "name": "composeMsg",
+                      "type": "bytes",
+                      "internalType": "bytes"
+                    },
+                    {
+                      "name": "oftCmd",
+                      "type": "bytes",
+                      "internalType": "bytes"
+                    }
+                  ]
+                },
+                {
+                  "name": "fee",
+                  "type": "tuple",
+                  "internalType": "struct IStargate.MessagingFee",
+                  "components": [
+                    {
+                      "name": "nativeFee",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "lzTokenFee",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    }
+                  ]
+                },
+                {
+                  "name": "refundAddress",
+                  "type": "address",
+                  "internalType": "address payable"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "tokenMessaging",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "contract ITokenMessaging"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "error",
+          "name": "CannotBridgeToSameNetwork",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "InformationMismatch",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "InvalidAssetId",
+          "inputs": [
+            {
+              "name": "invalidAssetId",
+              "type": "uint16",
+              "internalType": "uint16"
+            }
+          ]
+        },
+        {
+          "type": "error",
+          "name": "ReentrancyError",
+          "inputs": []
+        },
+        {
+          "type": "function",
+          "name": "swapTokensGeneric",
+          "inputs": [
+            {
+              "name": "_transactionId",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "_integrator",
+              "type": "string",
+              "internalType": "string"
+            },
+            {
+              "name": "_referrer",
+              "type": "string",
+              "internalType": "string"
+            },
+            {
+              "name": "_receiver",
+              "type": "address",
+              "internalType": "address payable"
+            },
+            {
+              "name": "_minAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaArbitrumBridge",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_arbitrumData",
+              "type": "tuple",
+              "internalType": "struct ArbitrumBridgeFacet.ArbitrumData",
+              "components": [
+                {
+                  "name": "maxSubmissionCost",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "maxGas",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "maxGasPrice",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaArbitrumBridge",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_arbitrumData",
+              "type": "tuple",
+              "internalType": "struct ArbitrumBridgeFacet.ArbitrumData",
+              "components": [
+                {
+                  "name": "maxSubmissionCost",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "maxGas",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "maxGasPrice",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "getPeripheryContract",
+          "inputs": [
+            {
+              "name": "_name",
+              "type": "string",
+              "internalType": "string"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "registerPeripheryContract",
+          "inputs": [
+            {
+              "name": "_name",
+              "type": "string",
+              "internalType": "string"
+            },
+            {
+              "name": "_contractAddress",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "event",
+          "name": "PeripheryContractRegistered",
+          "inputs": [
+            {
+              "name": "name",
+              "type": "string",
+              "indexed": false,
+              "internalType": "string"
+            },
+            {
+              "name": "contractAddress",
+              "type": "address",
+              "indexed": false,
+              "internalType": "address"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "function",
+          "name": "MAYAN",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "contract IMayan"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaMayan",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_mayanData",
+              "type": "tuple",
+              "internalType": "struct MayanFacet.MayanData",
+              "components": [
+                {
+                  "name": "nonEVMReceiver",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "mayanProtocol",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "protocolData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaMayan",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_mayanData",
+              "type": "tuple",
+              "internalType": "struct MayanFacet.MayanData",
+              "components": [
+                {
+                  "name": "nonEVMReceiver",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "mayanProtocol",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "protocolData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "error",
+          "name": "InvalidConfig",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "InvalidNonEVMReceiver",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "ProtocolDataTooShort",
+          "inputs": []
+        },
+        {
+          "type": "function",
+          "name": "RELAY_DEPOSITORY",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaRelayDepository",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_relayDepositoryData",
+              "type": "tuple",
+              "internalType": "struct RelayDepositoryFacet.RelayDepositoryData",
+              "components": [
+                {
+                  "name": "orderId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "depositorAddress",
+                  "type": "address",
+                  "internalType": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaRelayDepository",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_relayDepositoryData",
+              "type": "tuple",
+              "internalType": "struct RelayDepositoryFacet.RelayDepositoryData",
+              "components": [
+                {
+                  "name": "orderId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "depositorAddress",
+                  "type": "address",
+                  "internalType": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "error",
+          "name": "InvalidCallData",
+          "inputs": []
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaSymbiosis",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_symbiosisData",
+              "type": "tuple",
+              "internalType": "struct SymbiosisFacet.SymbiosisData",
+              "components": [
+                {
+                  "name": "firstSwapCalldata",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "secondSwapCalldata",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "intermediateToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "firstDexRouter",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "secondDexRouter",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approvedTokens",
+                  "type": "address[]",
+                  "internalType": "address[]"
+                },
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaSymbiosis",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_symbiosisData",
+              "type": "tuple",
+              "internalType": "struct SymbiosisFacet.SymbiosisData",
+              "components": [
+                {
+                  "name": "firstSwapCalldata",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "secondSwapCalldata",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "intermediateToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "firstDexRouter",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "secondDexRouter",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approvedTokens",
+                  "type": "address[]",
+                  "internalType": "address[]"
+                },
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "ACROSS_REFERRER_DELIMITER",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "cancelOwnershipTransfer",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "confirmOwnershipTransfer",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "decode_startBridgeTokensViaAcrossERC20Packed",
+          "inputs": [
+            {
+              "name": "data",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "acrossData",
+              "type": "tuple",
+              "internalType": "struct AcrossFacet.AcrossData",
+              "components": [
+                {
+                  "name": "relayerFeePct",
+                  "type": "int64",
+                  "internalType": "int64"
+                },
+                {
+                  "name": "quoteTimestamp",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "message",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "maxCount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "decode_startBridgeTokensViaAcrossNativePacked",
+          "inputs": [
+            {
+              "name": "data",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "acrossData",
+              "type": "tuple",
+              "internalType": "struct AcrossFacet.AcrossData",
+              "components": [
+                {
+                  "name": "relayerFeePct",
+                  "type": "int64",
+                  "internalType": "int64"
+                },
+                {
+                  "name": "quoteTimestamp",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "message",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "maxCount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "encode_startBridgeTokensViaAcrossERC20Packed",
+          "inputs": [
+            {
+              "name": "transactionId",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "sendingAssetId",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "minAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "destinationChainId",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "relayerFeePct",
+              "type": "int64",
+              "internalType": "int64"
+            },
+            {
+              "name": "quoteTimestamp",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "message",
+              "type": "bytes",
+              "internalType": "bytes"
+            },
+            {
+              "name": "maxCount",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "encode_startBridgeTokensViaAcrossNativePacked",
+          "inputs": [
+            {
+              "name": "transactionId",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "destinationChainId",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "relayerFeePct",
+              "type": "int64",
+              "internalType": "int64"
+            },
+            {
+              "name": "quoteTimestamp",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "maxCount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "message",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "executeCallAndWithdraw",
+          "inputs": [
+            {
+              "name": "_callTo",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "_callData",
+              "type": "bytes",
+              "internalType": "bytes"
+            },
+            {
+              "name": "_assetAddress",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "_to",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "_amount",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "owner",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "pendingOwner",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "setApprovalForBridge",
+          "inputs": [
+            {
+              "name": "tokensToApprove",
+              "type": "address[]",
+              "internalType": "address[]"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaAcrossERC20Min",
+          "inputs": [
+            {
+              "name": "transactionId",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "sendingAssetId",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "minAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "destinationChainId",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "relayerFeePct",
+              "type": "int64",
+              "internalType": "int64"
+            },
+            {
+              "name": "quoteTimestamp",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "message",
+              "type": "bytes",
+              "internalType": "bytes"
+            },
+            {
+              "name": "maxCount",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaAcrossERC20Packed",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaAcrossNativeMin",
+          "inputs": [
+            {
+              "name": "transactionId",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "destinationChainId",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "relayerFeePct",
+              "type": "int64",
+              "internalType": "int64"
+            },
+            {
+              "name": "quoteTimestamp",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "message",
+              "type": "bytes",
+              "internalType": "bytes"
+            },
+            {
+              "name": "maxCount",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaAcrossNativePacked",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "transferOwnership",
+          "inputs": [
+            {
+              "name": "_newOwner",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "event",
+          "name": "CallExecutedAndFundsWithdrawn",
+          "inputs": [],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "LiFiAcrossTransfer",
+          "inputs": [
+            {
+              "name": "_transactionId",
+              "type": "bytes8",
+              "indexed": false,
+              "internalType": "bytes8"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "OwnershipTransferRequested",
+          "inputs": [
+            {
+              "name": "_from",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "_to",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "OwnershipTransferred",
+          "inputs": [
+            {
+              "name": "previousOwner",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "newOwner",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "error",
+          "name": "NewOwnerMustNotBeSelf",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "NoNullOwner",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "NoPendingOwnershipTransfer",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "NotPendingOwner",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "UnAuthorized",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "WithdrawFailed",
+          "inputs": []
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaSquid",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_squidData",
+              "type": "tuple",
+              "internalType": "struct SquidFacet.SquidData",
+              "components": [
+                {
+                  "name": "routeType",
+                  "type": "uint8",
+                  "internalType": "enum SquidFacet.RouteType"
+                },
+                {
+                  "name": "destinationChain",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "destinationAddress",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "bridgedTokenSymbol",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "depositAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sourceCalls",
+                  "type": "tuple[]",
+                  "internalType": "struct ISquidMulticall.Call[]",
+                  "components": [
+                    {
+                      "name": "callType",
+                      "type": "uint8",
+                      "internalType": "enum ISquidMulticall.CallType"
+                    },
+                    {
+                      "name": "target",
+                      "type": "address",
+                      "internalType": "address"
+                    },
+                    {
+                      "name": "value",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "callData",
+                      "type": "bytes",
+                      "internalType": "bytes"
+                    },
+                    {
+                      "name": "payload",
+                      "type": "bytes",
+                      "internalType": "bytes"
+                    }
+                  ]
+                },
+                {
+                  "name": "payload",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "fee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "enableExpress",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaSquid",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_squidData",
+              "type": "tuple",
+              "internalType": "struct SquidFacet.SquidData",
+              "components": [
+                {
+                  "name": "routeType",
+                  "type": "uint8",
+                  "internalType": "enum SquidFacet.RouteType"
+                },
+                {
+                  "name": "destinationChain",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "destinationAddress",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "bridgedTokenSymbol",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "depositAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sourceCalls",
+                  "type": "tuple[]",
+                  "internalType": "struct ISquidMulticall.Call[]",
+                  "components": [
+                    {
+                      "name": "callType",
+                      "type": "uint8",
+                      "internalType": "enum ISquidMulticall.CallType"
+                    },
+                    {
+                      "name": "target",
+                      "type": "address",
+                      "internalType": "address"
+                    },
+                    {
+                      "name": "value",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "callData",
+                      "type": "bytes",
+                      "internalType": "bytes"
+                    },
+                    {
+                      "name": "payload",
+                      "type": "bytes",
+                      "internalType": "bytes"
+                    }
+                  ]
+                },
+                {
+                  "name": "payload",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "fee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "enableExpress",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "error",
+          "name": "InvalidRouteType",
+          "inputs": []
+        },
+        {
+          "type": "function",
+          "name": "ACROSS_CHAIN_ID_SOLANA",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "MULTIPLIER_BASE",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "SPOKEPOOL",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "contract IAcrossSpokePoolV4"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "WRAPPED_NATIVE",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaAcrossV4",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_acrossData",
+              "type": "tuple",
+              "internalType": "struct AcrossFacetV4.AcrossV4Data",
+              "components": [
+                {
+                  "name": "receiverAddress",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "refundAddress",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "outputAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "outputAmountMultiplier",
+                  "type": "uint128",
+                  "internalType": "uint128"
+                },
+                {
+                  "name": "exclusiveRelayer",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "quoteTimestamp",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "fillDeadline",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "exclusivityParameter",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "message",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaAcrossV4",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_acrossData",
+              "type": "tuple",
+              "internalType": "struct AcrossFacetV4.AcrossV4Data",
+              "components": [
+                {
+                  "name": "receiverAddress",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "refundAddress",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "outputAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "outputAmountMultiplier",
+                  "type": "uint128",
+                  "internalType": "uint128"
+                },
+                {
+                  "name": "exclusiveRelayer",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "quoteTimestamp",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "fillDeadline",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "exclusivityParameter",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "message",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "receive",
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "decode_startBridgeTokensViaCBridgeERC20Packed",
+          "inputs": [
+            {
+              "name": "_data",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "",
+              "type": "tuple",
+              "internalType": "struct CBridgeFacet.CBridgeData",
+              "components": [
+                {
+                  "name": "maxSlippage",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "nonce",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "decode_startBridgeTokensViaCBridgeNativePacked",
+          "inputs": [
+            {
+              "name": "_data",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "",
+              "type": "tuple",
+              "internalType": "struct CBridgeFacet.CBridgeData",
+              "components": [
+                {
+                  "name": "maxSlippage",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "nonce",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "encode_startBridgeTokensViaCBridgeERC20Packed",
+          "inputs": [
+            {
+              "name": "transactionId",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "destinationChainId",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "sendingAssetId",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "minAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "nonce",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "maxSlippage",
+              "type": "uint32",
+              "internalType": "uint32"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "encode_startBridgeTokensViaCBridgeNativePacked",
+          "inputs": [
+            {
+              "name": "transactionId",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "destinationChainId",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "nonce",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "maxSlippage",
+              "type": "uint32",
+              "internalType": "uint32"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaCBridgeERC20Min",
+          "inputs": [
+            {
+              "name": "transactionId",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "destinationChainId",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "sendingAssetId",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "nonce",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "maxSlippage",
+              "type": "uint32",
+              "internalType": "uint32"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaCBridgeERC20Packed",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaCBridgeNativeMin",
+          "inputs": [
+            {
+              "name": "transactionId",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "destinationChainId",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "nonce",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "maxSlippage",
+              "type": "uint32",
+              "internalType": "uint32"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaCBridgeNativePacked",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "triggerRefund",
+          "inputs": [
+            {
+              "name": "_callTo",
+              "type": "address",
+              "internalType": "address payable"
+            },
+            {
+              "name": "_callData",
+              "type": "bytes",
+              "internalType": "bytes"
+            },
+            {
+              "name": "_assetAddress",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "_to",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "_amount",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "event",
+          "name": "CBridgeRefund",
+          "inputs": [
+            {
+              "name": "_assetAddress",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "_to",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "LiFiCBridgeTransfer",
+          "inputs": [
+            {
+              "name": "_transactionId",
+              "type": "bytes8",
+              "indexed": false,
+              "internalType": "bytes8"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "error",
+          "name": "ExternalCallFailed",
+          "inputs": []
+        },
+        {
+          "type": "fallback",
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "pauseDiamond",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "pauserWallet",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "removeFacet",
+          "inputs": [
+            {
+              "name": "_facetAddress",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "unpauseDiamond",
+          "inputs": [
+            {
+              "name": "_blacklist",
+              "type": "address[]",
+              "internalType": "address[]"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "event",
+          "name": "DiamondCut",
+          "inputs": [
+            {
+              "name": "_diamondCut",
+              "type": "tuple[]",
+              "indexed": false,
+              "internalType": "struct LibDiamond.FacetCut[]",
+              "components": [
+                {
+                  "name": "facetAddress",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "action",
+                  "type": "uint8",
+                  "internalType": "enum LibDiamond.FacetCutAction"
+                },
+                {
+                  "name": "functionSelectors",
+                  "type": "bytes4[]",
+                  "internalType": "bytes4[]"
+                }
+              ]
+            },
+            {
+              "name": "_init",
+              "type": "address",
+              "indexed": false,
+              "internalType": "address"
+            },
+            {
+              "name": "_calldata",
+              "type": "bytes",
+              "indexed": false,
+              "internalType": "bytes"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "EmergencyFacetRemoved",
+          "inputs": [
+            {
+              "name": "facetAddress",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "msgSender",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "EmergencyPaused",
+          "inputs": [
+            {
+              "name": "msgSender",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "EmergencyUnpaused",
+          "inputs": [
+            {
+              "name": "msgSender",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "error",
+          "name": "CalldataEmptyButInitNotZero",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "DiamondIsPaused",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "FacetAddressIsNotZero",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "FacetAddressIsZero",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "FacetContainsNoCode",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "FacetIsNotRegistered",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "FunctionAlreadyExists",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "FunctionDoesNotExist",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "FunctionIsImmutable",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "IncorrectFacetCutAction",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "InitReverted",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "InitZeroButCalldataNotEmpty",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "NoFacetToPause",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "NoSelectorsInFace",
+          "inputs": []
+        },
+        {
+          "type": "function",
+          "name": "decode_startBridgeTokensViaHopL1ERC20Packed",
+          "inputs": [
+            {
+              "name": "_data",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "",
+              "type": "tuple",
+              "internalType": "struct HopFacetOptimized.HopData",
+              "components": [
+                {
+                  "name": "bonderFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "amountOutMin",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "deadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationAmountOutMin",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationDeadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hopBridge",
+                  "type": "address",
+                  "internalType": "contract IHopBridge"
+                },
+                {
+                  "name": "relayer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "relayerFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "nativeFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "decode_startBridgeTokensViaHopL1NativePacked",
+          "inputs": [
+            {
+              "name": "_data",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "",
+              "type": "tuple",
+              "internalType": "struct HopFacetOptimized.HopData",
+              "components": [
+                {
+                  "name": "bonderFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "amountOutMin",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "deadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationAmountOutMin",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationDeadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hopBridge",
+                  "type": "address",
+                  "internalType": "contract IHopBridge"
+                },
+                {
+                  "name": "relayer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "relayerFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "nativeFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "decode_startBridgeTokensViaHopL2ERC20Packed",
+          "inputs": [
+            {
+              "name": "_data",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "",
+              "type": "tuple",
+              "internalType": "struct HopFacetOptimized.HopData",
+              "components": [
+                {
+                  "name": "bonderFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "amountOutMin",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "deadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationAmountOutMin",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationDeadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hopBridge",
+                  "type": "address",
+                  "internalType": "contract IHopBridge"
+                },
+                {
+                  "name": "relayer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "relayerFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "nativeFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "decode_startBridgeTokensViaHopL2NativePacked",
+          "inputs": [
+            {
+              "name": "_data",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "",
+              "type": "tuple",
+              "internalType": "struct HopFacetOptimized.HopData",
+              "components": [
+                {
+                  "name": "bonderFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "amountOutMin",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "deadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationAmountOutMin",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationDeadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hopBridge",
+                  "type": "address",
+                  "internalType": "contract IHopBridge"
+                },
+                {
+                  "name": "relayer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "relayerFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "nativeFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "encode_startBridgeTokensViaHopL1ERC20Packed",
+          "inputs": [
+            {
+              "name": "transactionId",
+              "type": "bytes8",
+              "internalType": "bytes8"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "destinationChainId",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "sendingAssetId",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "minAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "destinationAmountOutMin",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "relayer",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "relayerFee",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "hopBridge",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "encode_startBridgeTokensViaHopL1NativePacked",
+          "inputs": [
+            {
+              "name": "transactionId",
+              "type": "bytes8",
+              "internalType": "bytes8"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "destinationChainId",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "destinationAmountOutMin",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "relayer",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "relayerFee",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "hopBridge",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "encode_startBridgeTokensViaHopL2ERC20Packed",
+          "inputs": [
+            {
+              "name": "transactionId",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "destinationChainId",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "sendingAssetId",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "minAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "bonderFee",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "amountOutMin",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "destinationAmountOutMin",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "destinationDeadline",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "wrapper",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "encode_startBridgeTokensViaHopL2NativePacked",
+          "inputs": [
+            {
+              "name": "transactionId",
+              "type": "bytes8",
+              "internalType": "bytes8"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "destinationChainId",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "bonderFee",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "amountOutMin",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "nativeBridge",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "nativeExchangeAddress",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "nativeHToken",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "nativeL2CanonicalToken",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "setApprovalForHopBridges",
+          "inputs": [
+            {
+              "name": "bridges",
+              "type": "address[]",
+              "internalType": "address[]"
+            },
+            {
+              "name": "tokensToApprove",
+              "type": "address[]",
+              "internalType": "address[]"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaHopL1ERC20Min",
+          "inputs": [
+            {
+              "name": "transactionId",
+              "type": "bytes8",
+              "internalType": "bytes8"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "destinationChainId",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "sendingAssetId",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "minAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "destinationAmountOutMin",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "relayer",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "relayerFee",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "hopBridge",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaHopL1ERC20Packed",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaHopL1NativeMin",
+          "inputs": [
+            {
+              "name": "transactionId",
+              "type": "bytes8",
+              "internalType": "bytes8"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "destinationChainId",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "destinationAmountOutMin",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "relayer",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "relayerFee",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "hopBridge",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaHopL1NativePacked",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaHopL2ERC20Min",
+          "inputs": [
+            {
+              "name": "transactionId",
+              "type": "bytes8",
+              "internalType": "bytes8"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "destinationChainId",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "sendingAssetId",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "minAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "bonderFee",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "amountOutMin",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "destinationAmountOutMin",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "destinationDeadline",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "hopBridge",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaHopL2ERC20Packed",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaHopL2NativeMin",
+          "inputs": [
+            {
+              "name": "transactionId",
+              "type": "bytes8",
+              "internalType": "bytes8"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "destinationChainId",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "bonderFee",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "amountOutMin",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "destinationAmountOutMin",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "destinationDeadline",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "hopBridge",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaHopL2NativePacked",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "event",
+          "name": "LiFiHopTransfer",
+          "inputs": [
+            {
+              "name": "_transactionId",
+              "type": "bytes8",
+              "indexed": false,
+              "internalType": "bytes8"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "error",
+          "name": "Invalid",
+          "inputs": []
+        },
+        {
+          "type": "function",
+          "name": "NATIVE_ADDRESS",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "swapTokensMultipleV3ERC20ToERC20",
+          "inputs": [
+            {
+              "name": "_transactionId",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "_integrator",
+              "type": "string",
+              "internalType": "string"
+            },
+            {
+              "name": "_referrer",
+              "type": "string",
+              "internalType": "string"
+            },
+            {
+              "name": "_receiver",
+              "type": "address",
+              "internalType": "address payable"
+            },
+            {
+              "name": "_minAmountOut",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "swapTokensMultipleV3ERC20ToNative",
+          "inputs": [
+            {
+              "name": "_transactionId",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "_integrator",
+              "type": "string",
+              "internalType": "string"
+            },
+            {
+              "name": "_referrer",
+              "type": "string",
+              "internalType": "string"
+            },
+            {
+              "name": "_receiver",
+              "type": "address",
+              "internalType": "address payable"
+            },
+            {
+              "name": "_minAmountOut",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "swapTokensMultipleV3NativeToERC20",
+          "inputs": [
+            {
+              "name": "_transactionId",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "_integrator",
+              "type": "string",
+              "internalType": "string"
+            },
+            {
+              "name": "_referrer",
+              "type": "string",
+              "internalType": "string"
+            },
+            {
+              "name": "_receiver",
+              "type": "address",
+              "internalType": "address payable"
+            },
+            {
+              "name": "_minAmountOut",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapTokensSingleV3ERC20ToERC20",
+          "inputs": [
+            {
+              "name": "_transactionId",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "_integrator",
+              "type": "string",
+              "internalType": "string"
+            },
+            {
+              "name": "_referrer",
+              "type": "string",
+              "internalType": "string"
+            },
+            {
+              "name": "_receiver",
+              "type": "address",
+              "internalType": "address payable"
+            },
+            {
+              "name": "_minAmountOut",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple",
+              "internalType": "struct LibSwap.SwapData",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "swapTokensSingleV3ERC20ToNative",
+          "inputs": [
+            {
+              "name": "_transactionId",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "_integrator",
+              "type": "string",
+              "internalType": "string"
+            },
+            {
+              "name": "_referrer",
+              "type": "string",
+              "internalType": "string"
+            },
+            {
+              "name": "_receiver",
+              "type": "address",
+              "internalType": "address payable"
+            },
+            {
+              "name": "_minAmountOut",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple",
+              "internalType": "struct LibSwap.SwapData",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "swapTokensSingleV3NativeToERC20",
+          "inputs": [
+            {
+              "name": "_transactionId",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "_integrator",
+              "type": "string",
+              "internalType": "string"
+            },
+            {
+              "name": "_referrer",
+              "type": "string",
+              "internalType": "string"
+            },
+            {
+              "name": "_receiver",
+              "type": "address",
+              "internalType": "address payable"
+            },
+            {
+              "name": "_minAmountOut",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple",
+              "internalType": "struct LibSwap.SwapData",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "error",
+          "name": "NativeAssetTransferFailed",
+          "inputs": []
+        },
+        {
+          "type": "function",
+          "name": "spokePool",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "contract IAcrossSpokePool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaAcrossV3",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_acrossData",
+              "type": "tuple",
+              "internalType": "struct AcrossFacetV3.AcrossV3Data",
+              "components": [
+                {
+                  "name": "receiverAddress",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "refundAddress",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "outputAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "outputAmountPercent",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "exclusiveRelayer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "quoteTimestamp",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "fillDeadline",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "exclusivityDeadline",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "message",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaAcrossV3",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_acrossData",
+              "type": "tuple",
+              "internalType": "struct AcrossFacetV3.AcrossV3Data",
+              "components": [
+                {
+                  "name": "receiverAddress",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "refundAddress",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "outputAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "outputAmountPercent",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "exclusiveRelayer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "quoteTimestamp",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "fillDeadline",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "exclusivityDeadline",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "message",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "wrappedNative",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "PIONEER_ADDRESS",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address payable"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaPioneer",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_pioneerData",
+              "type": "tuple",
+              "internalType": "struct PioneerFacet.PioneerData",
+              "components": [
+                {
+                  "name": "refundAddress",
+                  "type": "address",
+                  "internalType": "address payable"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaPioneer",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_pioneerData",
+              "type": "tuple",
+              "internalType": "struct PioneerFacet.PioneerData",
+              "components": [
+                {
+                  "name": "refundAddress",
+                  "type": "address",
+                  "internalType": "address payable"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "event",
+          "name": "PioneerRefundAddressRegistered",
+          "inputs": [
+            {
+              "name": "refundTo",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaUnit",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_unitData",
+              "type": "tuple",
+              "internalType": "struct UnitFacet.UnitData",
+              "components": [
+                {
+                  "name": "depositAddress",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "signature",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "deadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaUnit",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_unitData",
+              "type": "tuple",
+              "internalType": "struct UnitFacet.UnitData",
+              "components": [
+                {
+                  "name": "depositAddress",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "signature",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "deadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "error",
+          "name": "InvalidDestinationChain",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "InvalidSendingToken",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "InvalidSignature",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "SignatureExpired",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "TransactionAlreadyProcessed",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "UnsupportedChain",
+          "inputs": []
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaGarden",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_gardenData",
+              "type": "tuple",
+              "internalType": "struct GardenFacet.GardenData",
+              "components": [
+                {
+                  "name": "redeemer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "refundAddress",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "timelock",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "secretHash",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "nonEvmReceiver",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaGarden",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_gardenData",
+              "type": "tuple",
+              "internalType": "struct GardenFacet.GardenData",
+              "components": [
+                {
+                  "name": "redeemer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "refundAddress",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "timelock",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "secretHash",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "nonEvmReceiver",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "error",
+          "name": "AssetNotSupported",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "InvalidGardenData",
+          "inputs": []
+        },
+        {
+          "type": "function",
+          "name": "GAS_ZIP_ROUTER",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "contract IGasZip"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "getDestinationChainsValue",
+          "inputs": [
+            {
+              "name": "_chainIds",
+              "type": "uint8[]",
+              "internalType": "uint8[]"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "destinationChains",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaGasZip",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_gasZipData",
+              "type": "tuple",
+              "internalType": "struct IGasZip.GasZipData",
+              "components": [
+                {
+                  "name": "receiverAddress",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "destinationChains",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaGasZip",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_gasZipData",
+              "type": "tuple",
+              "internalType": "struct IGasZip.GasZipData",
+              "components": [
+                {
+                  "name": "receiverAddress",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "destinationChains",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "error",
+          "name": "OnlyNativeAllowed",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "TooManyChainIds",
+          "inputs": []
+        },
+        {
+          "type": "function",
+          "name": "consumedIds",
+          "inputs": [
+            {
+              "name": "",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "relayReceiver",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "relaySolver",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaRelay",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_relayData",
+              "type": "tuple",
+              "internalType": "struct RelayFacet.RelayData",
+              "components": [
+                {
+                  "name": "requestId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "nonEVMReceiver",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "signature",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaRelay",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_relayData",
+              "type": "tuple",
+              "internalType": "struct RelayFacet.RelayData",
+              "components": [
+                {
+                  "name": "requestId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "nonEVMReceiver",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "signature",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "error",
+          "name": "InvalidQuote",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "SliceOutOfBounds",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "SliceOverflow",
+          "inputs": []
+        },
+        {
+          "type": "function",
+          "name": "diamondCut",
+          "inputs": [
+            {
+              "name": "_diamondCut",
+              "type": "tuple[]",
+              "internalType": "struct LibDiamond.FacetCut[]",
+              "components": [
+                {
+                  "name": "facetAddress",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "action",
+                  "type": "uint8",
+                  "internalType": "enum LibDiamond.FacetCutAction"
+                },
+                {
+                  "name": "functionSelectors",
+                  "type": "bytes4[]",
+                  "internalType": "bytes4[]"
+                }
+              ]
+            },
+            {
+              "name": "_init",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "_calldata",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "initOptimism",
+          "inputs": [
+            {
+              "name": "configs",
+              "type": "tuple[]",
+              "internalType": "struct OptimismBridgeFacet.Config[]",
+              "components": [
+                {
+                  "name": "assetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "bridge",
+                  "type": "address",
+                  "internalType": "address"
+                }
+              ]
+            },
+            {
+              "name": "standardBridge",
+              "type": "address",
+              "internalType": "contract IL1StandardBridge"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "registerOptimismBridge",
+          "inputs": [
+            {
+              "name": "assetId",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "bridge",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaOptimismBridge",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_optimismData",
+              "type": "tuple",
+              "internalType": "struct OptimismBridgeFacet.OptimismData",
+              "components": [
+                {
+                  "name": "assetIdOnL2",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "l2Gas",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "isSynthetix",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaOptimismBridge",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_optimismData",
+              "type": "tuple",
+              "internalType": "struct OptimismBridgeFacet.OptimismData",
+              "components": [
+                {
+                  "name": "assetIdOnL2",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "l2Gas",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "isSynthetix",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "event",
+          "name": "OptimismBridgeRegistered",
+          "inputs": [
+            {
+              "name": "assetId",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "bridge",
+              "type": "address",
+              "indexed": false,
+              "internalType": "address"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "OptimismInitialized",
+          "inputs": [
+            {
+              "name": "configs",
+              "type": "tuple[]",
+              "indexed": false,
+              "internalType": "struct OptimismBridgeFacet.Config[]",
+              "components": [
+                {
+                  "name": "assetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "bridge",
+                  "type": "address",
+                  "internalType": "address"
+                }
+              ]
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "error",
+          "name": "AlreadyInitialized",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "NotInitialized",
+          "inputs": []
+        },
+        {
+          "type": "function",
+          "name": "withdraw",
+          "inputs": [
+            {
+              "name": "_assetAddress",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "_to",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "_amount",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "event",
+          "name": "LogWithdraw",
+          "inputs": [
+            {
+              "name": "_assetAddress",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "_to",
+              "type": "address",
+              "indexed": false,
+              "internalType": "address"
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "error",
+          "name": "NotAContract",
+          "inputs": []
+        },
+        {
+          "type": "function",
+          "name": "addressCanExecuteMethod",
+          "inputs": [
+            {
+              "name": "_selector",
+              "type": "bytes4",
+              "internalType": "bytes4"
+            },
+            {
+              "name": "_executor",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "setCanExecute",
+          "inputs": [
+            {
+              "name": "_selector",
+              "type": "bytes4",
+              "internalType": "bytes4"
+            },
+            {
+              "name": "_executor",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "_canExecute",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "event",
+          "name": "AccessGranted",
+          "inputs": [
+            {
+              "name": "account",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "method",
+              "type": "bytes4",
+              "indexed": true,
+              "internalType": "bytes4"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "AccessRevoked",
+          "inputs": [
+            {
+              "name": "account",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "method",
+              "type": "bytes4",
+              "indexed": true,
+              "internalType": "bytes4"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "ExecutionAllowed",
+          "inputs": [
+            {
+              "name": "account",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "method",
+              "type": "bytes4",
+              "indexed": true,
+              "internalType": "bytes4"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "ExecutionDenied",
+          "inputs": [
+            {
+              "name": "account",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "method",
+              "type": "bytes4",
+              "indexed": true,
+              "internalType": "bytes4"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "error",
+          "name": "CannotAuthoriseSelf",
+          "inputs": []
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaGnosisBridge",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaGnosisBridge",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaCelerCircleBridge",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaCelerCircleBridge",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "decode_startBridgeTokensViaAcrossV3ERC20Packed",
+          "inputs": [
+            {
+              "name": "data",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "acrossData",
+              "type": "tuple",
+              "internalType": "struct AcrossFacetV3.AcrossV3Data",
+              "components": [
+                {
+                  "name": "receiverAddress",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "refundAddress",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "outputAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "outputAmountPercent",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "exclusiveRelayer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "quoteTimestamp",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "fillDeadline",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "exclusivityDeadline",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "message",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "decode_startBridgeTokensViaAcrossV3NativePacked",
+          "inputs": [
+            {
+              "name": "data",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "acrossData",
+              "type": "tuple",
+              "internalType": "struct AcrossFacetV3.AcrossV3Data",
+              "components": [
+                {
+                  "name": "receiverAddress",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "refundAddress",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "outputAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "outputAmountPercent",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "exclusiveRelayer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "quoteTimestamp",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "fillDeadline",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "exclusivityDeadline",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "message",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "encode_startBridgeTokensViaAcrossV3ERC20Packed",
+          "inputs": [
+            {
+              "name": "_parameters",
+              "type": "tuple",
+              "internalType": "struct AcrossFacetPackedV3.PackedParameters",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "depositor",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "outputAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "exclusiveRelayer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "quoteTimestamp",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "fillDeadline",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "exclusivityDeadline",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "message",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                }
+              ]
+            },
+            {
+              "name": "sendingAssetId",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "inputAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "encode_startBridgeTokensViaAcrossV3NativePacked",
+          "inputs": [
+            {
+              "name": "_parameters",
+              "type": "tuple",
+              "internalType": "struct AcrossFacetPackedV3.PackedParameters",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "depositor",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "outputAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "exclusiveRelayer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "quoteTimestamp",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "fillDeadline",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "exclusivityDeadline",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "message",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaAcrossV3ERC20Min",
+          "inputs": [
+            {
+              "name": "_parameters",
+              "type": "tuple",
+              "internalType": "struct AcrossFacetPackedV3.PackedParameters",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "depositor",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "outputAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "exclusiveRelayer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "quoteTimestamp",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "fillDeadline",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "exclusivityDeadline",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "message",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                }
+              ]
+            },
+            {
+              "name": "sendingAssetId",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "inputAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaAcrossV3ERC20Packed",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaAcrossV3NativeMin",
+          "inputs": [
+            {
+              "name": "_parameters",
+              "type": "tuple",
+              "internalType": "struct AcrossFacetPackedV3.PackedParameters",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "depositor",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "outputAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "exclusiveRelayer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "quoteTimestamp",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "fillDeadline",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "exclusivityDeadline",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "message",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaAcrossV3NativePacked",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "initHop",
+          "inputs": [
+            {
+              "name": "configs",
+              "type": "tuple[]",
+              "internalType": "struct HopFacet.Config[]",
+              "components": [
+                {
+                  "name": "assetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "bridge",
+                  "type": "address",
+                  "internalType": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "registerBridge",
+          "inputs": [
+            {
+              "name": "assetId",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "bridge",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaHop",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_hopData",
+              "type": "tuple",
+              "internalType": "struct HopFacet.HopData",
+              "components": [
+                {
+                  "name": "bonderFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "amountOutMin",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "deadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationAmountOutMin",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationDeadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "relayer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "relayerFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "nativeFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaHop",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_hopData",
+              "type": "tuple",
+              "internalType": "struct HopFacet.HopData",
+              "components": [
+                {
+                  "name": "bonderFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "amountOutMin",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "deadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationAmountOutMin",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationDeadline",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "relayer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "relayerFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "nativeFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "event",
+          "name": "HopBridgeRegistered",
+          "inputs": [
+            {
+              "name": "assetId",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "bridge",
+              "type": "address",
+              "indexed": false,
+              "internalType": "address"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "HopInitialized",
+          "inputs": [
+            {
+              "name": "configs",
+              "type": "tuple[]",
+              "indexed": false,
+              "internalType": "struct HopFacet.Config[]",
+              "components": [
+                {
+                  "name": "assetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "bridge",
+                  "type": "address",
+                  "internalType": "address"
+                }
+              ]
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaOmniBridge",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaOmniBridge",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaPolygonBridge",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaPolygonBridge",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaAllBridge",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_allBridgeData",
+              "type": "tuple",
+              "internalType": "struct AllBridgeFacet.AllBridgeData",
+              "components": [
+                {
+                  "name": "recipient",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "fees",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "receiveToken",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "nonce",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "messenger",
+                  "type": "uint8",
+                  "internalType": "enum IAllBridge.MessengerProtocol"
+                },
+                {
+                  "name": "payFeeWithSendingAsset",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaAllBridge",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_allBridgeData",
+              "type": "tuple",
+              "internalType": "struct AllBridgeFacet.AllBridgeData",
+              "components": [
+                {
+                  "name": "recipient",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "fees",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "receiveToken",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "nonce",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "messenger",
+                  "type": "uint8",
+                  "internalType": "enum IAllBridge.MessengerProtocol"
+                },
+                {
+                  "name": "payFeeWithSendingAsset",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "error",
+          "name": "UnsupportedAllBridgeChainId",
+          "inputs": []
+        },
+        {
+          "type": "function",
+          "name": "PORTAL",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "contract IEcoPortal"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaEco",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_ecoData",
+              "type": "tuple",
+              "internalType": "struct EcoFacet.EcoData",
+              "components": [
+                {
+                  "name": "nonEVMReceiver",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "prover",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "rewardDeadline",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "encodedRoute",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "solanaATA",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "refundRecipient",
+                  "type": "address",
+                  "internalType": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaEco",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_ecoData",
+              "type": "tuple",
+              "internalType": "struct EcoFacet.EcoData",
+              "components": [
+                {
+                  "name": "nonEVMReceiver",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "prover",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "rewardDeadline",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "encodedRoute",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "solanaATA",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "refundRecipient",
+                  "type": "address",
+                  "internalType": "address"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "error",
+          "name": "IntentAlreadyFunded",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "NativeAssetNotSupported",
+          "inputs": []
+        },
+        {
+          "type": "function",
+          "name": "decode_startBridgeTokensViaAcrossV4ERC20Packed",
+          "inputs": [
+            {
+              "name": "data",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "acrossData",
+              "type": "tuple",
+              "internalType": "struct AcrossFacetV4.AcrossV4Data",
+              "components": [
+                {
+                  "name": "receiverAddress",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "refundAddress",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "outputAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "outputAmountMultiplier",
+                  "type": "uint128",
+                  "internalType": "uint128"
+                },
+                {
+                  "name": "exclusiveRelayer",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "quoteTimestamp",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "fillDeadline",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "exclusivityParameter",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "message",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "decode_startBridgeTokensViaAcrossV4NativePacked",
+          "inputs": [
+            {
+              "name": "data",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "acrossData",
+              "type": "tuple",
+              "internalType": "struct AcrossFacetV4.AcrossV4Data",
+              "components": [
+                {
+                  "name": "receiverAddress",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "refundAddress",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "outputAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "outputAmountMultiplier",
+                  "type": "uint128",
+                  "internalType": "uint128"
+                },
+                {
+                  "name": "exclusiveRelayer",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "quoteTimestamp",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "fillDeadline",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "exclusivityParameter",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "message",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "encode_startBridgeTokensViaAcrossV4ERC20Packed",
+          "inputs": [
+            {
+              "name": "_parameters",
+              "type": "tuple",
+              "internalType": "struct AcrossFacetPackedV4.PackedParameters",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes8",
+                  "internalType": "bytes8"
+                },
+                {
+                  "name": "receiver",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "depositor",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "outputAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "exclusiveRelayer",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "quoteTimestamp",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "fillDeadline",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "exclusivityParameter",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "message",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                }
+              ]
+            },
+            {
+              "name": "sendingAssetId",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "inputAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "encode_startBridgeTokensViaAcrossV4NativePacked",
+          "inputs": [
+            {
+              "name": "_parameters",
+              "type": "tuple",
+              "internalType": "struct AcrossFacetPackedV4.PackedParameters",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes8",
+                  "internalType": "bytes8"
+                },
+                {
+                  "name": "receiver",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "depositor",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "outputAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "exclusiveRelayer",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "quoteTimestamp",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "fillDeadline",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "exclusivityParameter",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "message",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaAcrossV4ERC20Min",
+          "inputs": [
+            {
+              "name": "_parameters",
+              "type": "tuple",
+              "internalType": "struct AcrossFacetPackedV4.PackedParameters",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes8",
+                  "internalType": "bytes8"
+                },
+                {
+                  "name": "receiver",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "depositor",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "outputAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "exclusiveRelayer",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "quoteTimestamp",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "fillDeadline",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "exclusivityParameter",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "message",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                }
+              ]
+            },
+            {
+              "name": "sendingAssetId",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "inputAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaAcrossV4ERC20Packed",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaAcrossV4NativeMin",
+          "inputs": [
+            {
+              "name": "_parameters",
+              "type": "tuple",
+              "internalType": "struct AcrossFacetPackedV4.PackedParameters",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes8",
+                  "internalType": "bytes8"
+                },
+                {
+                  "name": "receiver",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "depositor",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "outputAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "exclusiveRelayer",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "quoteTimestamp",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "fillDeadline",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "exclusivityParameter",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "message",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaAcrossV4NativePacked",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "error",
+          "name": "InvalidCalldataLength",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "InvalidInputAmount",
+          "inputs": []
+        },
+        {
+          "type": "function",
+          "name": "CHAINFLIP_VAULT",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "contract IChainflipVault"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaChainflip",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_chainflipData",
+              "type": "tuple",
+              "internalType": "struct ChainflipFacet.ChainflipData",
+              "components": [
+                {
+                  "name": "nonEVMReceiver",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "dstToken",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "dstCallReceiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "dstCallSwapData",
+                  "type": "tuple[]",
+                  "internalType": "struct LibSwap.SwapData[]",
+                  "components": [
+                    {
+                      "name": "callTo",
+                      "type": "address",
+                      "internalType": "address"
+                    },
+                    {
+                      "name": "approveTo",
+                      "type": "address",
+                      "internalType": "address"
+                    },
+                    {
+                      "name": "sendingAssetId",
+                      "type": "address",
+                      "internalType": "address"
+                    },
+                    {
+                      "name": "receivingAssetId",
+                      "type": "address",
+                      "internalType": "address"
+                    },
+                    {
+                      "name": "fromAmount",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "callData",
+                      "type": "bytes",
+                      "internalType": "bytes"
+                    },
+                    {
+                      "name": "requiresDeposit",
+                      "type": "bool",
+                      "internalType": "bool"
+                    }
+                  ]
+                },
+                {
+                  "name": "gasAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "cfParameters",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaChainflip",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_chainflipData",
+              "type": "tuple",
+              "internalType": "struct ChainflipFacet.ChainflipData",
+              "components": [
+                {
+                  "name": "nonEVMReceiver",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "dstToken",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "dstCallReceiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "dstCallSwapData",
+                  "type": "tuple[]",
+                  "internalType": "struct LibSwap.SwapData[]",
+                  "components": [
+                    {
+                      "name": "callTo",
+                      "type": "address",
+                      "internalType": "address"
+                    },
+                    {
+                      "name": "approveTo",
+                      "type": "address",
+                      "internalType": "address"
+                    },
+                    {
+                      "name": "sendingAssetId",
+                      "type": "address",
+                      "internalType": "address"
+                    },
+                    {
+                      "name": "receivingAssetId",
+                      "type": "address",
+                      "internalType": "address"
+                    },
+                    {
+                      "name": "fromAmount",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "callData",
+                      "type": "bytes",
+                      "internalType": "bytes"
+                    },
+                    {
+                      "name": "requiresDeposit",
+                      "type": "bool",
+                      "internalType": "bool"
+                    }
+                  ]
+                },
+                {
+                  "name": "gasAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "cfParameters",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "error",
+          "name": "EmptyNonEvmAddress",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "UnsupportedChainflipChainId",
+          "inputs": []
+        },
+        {
+          "type": "function",
+          "name": "AIRLIFT",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "contract IGlacisAirlift"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaGlacis",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_glacisData",
+              "type": "tuple",
+              "internalType": "struct GlacisFacet.GlacisData",
+              "components": [
+                {
+                  "name": "receiverAddress",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "refundAddress",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "nativeFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaGlacis",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_glacisData",
+              "type": "tuple",
+              "internalType": "struct GlacisFacet.GlacisData",
+              "components": [
+                {
+                  "name": "receiverAddress",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "refundAddress",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "nativeFee",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "addDex",
+          "inputs": [
+            {
+              "name": "_dex",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "approvedDexs",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "addresses",
+              "type": "address[]",
+              "internalType": "address[]"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "batchAddDex",
+          "inputs": [
+            {
+              "name": "_dexs",
+              "type": "address[]",
+              "internalType": "address[]"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "batchRemoveDex",
+          "inputs": [
+            {
+              "name": "_dexs",
+              "type": "address[]",
+              "internalType": "address[]"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "batchSetFunctionApprovalBySignature",
+          "inputs": [
+            {
+              "name": "_signatures",
+              "type": "bytes4[]",
+              "internalType": "bytes4[]"
+            },
+            {
+              "name": "_approval",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "isFunctionApproved",
+          "inputs": [
+            {
+              "name": "_signature",
+              "type": "bytes4",
+              "internalType": "bytes4"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "approved",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "removeDex",
+          "inputs": [
+            {
+              "name": "_dex",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "setFunctionApprovalBySignature",
+          "inputs": [
+            {
+              "name": "_signature",
+              "type": "bytes4",
+              "internalType": "bytes4"
+            },
+            {
+              "name": "_approval",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "event",
+          "name": "DexAdded",
+          "inputs": [
+            {
+              "name": "dexAddress",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "DexRemoved",
+          "inputs": [
+            {
+              "name": "dexAddress",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "FunctionSignatureApprovalChanged",
+          "inputs": [
+            {
+              "name": "functionSignature",
+              "type": "bytes4",
+              "indexed": true,
+              "internalType": "bytes4"
+            },
+            {
+              "name": "approved",
+              "type": "bool",
+              "indexed": true,
+              "internalType": "bool"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "function",
+          "name": "facetAddress",
+          "inputs": [
+            {
+              "name": "_functionSelector",
+              "type": "bytes4",
+              "internalType": "bytes4"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "facetAddress_",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "facetAddresses",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "facetAddresses_",
+              "type": "address[]",
+              "internalType": "address[]"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "facetFunctionSelectors",
+          "inputs": [
+            {
+              "name": "_facet",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "facetFunctionSelectors_",
+              "type": "bytes4[]",
+              "internalType": "bytes4[]"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "facets",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "facets_",
+              "type": "tuple[]",
+              "internalType": "struct IDiamondLoupe.Facet[]",
+              "components": [
+                {
+                  "name": "facetAddress",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "functionSelectors",
+                  "type": "bytes4[]",
+                  "internalType": "bytes4[]"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "supportsInterface",
+          "inputs": [
+            {
+              "name": "_interfaceId",
+              "type": "bytes4",
+              "internalType": "bytes4"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaCBridge",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_cBridgeData",
+              "type": "tuple",
+              "internalType": "struct CBridgeFacet.CBridgeData",
+              "components": [
+                {
+                  "name": "maxSlippage",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "nonce",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaCBridge",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_cBridgeData",
+              "type": "tuple",
+              "internalType": "struct CBridgeFacet.CBridgeData",
+              "components": [
+                {
+                  "name": "maxSlippage",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "nonce",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "DLN_SOURCE",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "contract IDlnSource"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "getDeBridgeChainId",
+          "inputs": [
+            {
+              "name": "_chainId",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "initDeBridgeDln",
+          "inputs": [
+            {
+              "name": "chainIdConfigs",
+              "type": "tuple[]",
+              "internalType": "struct DeBridgeDlnFacet.ChainIdConfig[]",
+              "components": [
+                {
+                  "name": "chainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "deBridgeChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "setDeBridgeChainId",
+          "inputs": [
+            {
+              "name": "_chainId",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "_deBridgeChainId",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaDeBridgeDln",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_deBridgeData",
+              "type": "tuple",
+              "internalType": "struct DeBridgeDlnFacet.DeBridgeDlnData",
+              "components": [
+                {
+                  "name": "receivingAssetId",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "receiver",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "orderAuthorityDst",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "minAmountOut",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaDeBridgeDln",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_deBridgeData",
+              "type": "tuple",
+              "internalType": "struct DeBridgeDlnFacet.DeBridgeDlnData",
+              "components": [
+                {
+                  "name": "receivingAssetId",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "receiver",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "orderAuthorityDst",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "minAmountOut",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "event",
+          "name": "DeBridgeChainIdSet",
+          "inputs": [
+            {
+              "name": "chainId",
+              "type": "uint256",
+              "indexed": true,
+              "internalType": "uint256"
+            },
+            {
+              "name": "deBridgeChainId",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "DeBridgeInitialized",
+          "inputs": [
+            {
+              "name": "chainIdConfigs",
+              "type": "tuple[]",
+              "indexed": false,
+              "internalType": "struct DeBridgeDlnFacet.ChainIdConfig[]",
+              "components": [
+                {
+                  "name": "chainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "deBridgeChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "DlnOrderCreated",
+          "inputs": [
+            {
+              "name": "orderId",
+              "type": "bytes32",
+              "indexed": true,
+              "internalType": "bytes32"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "error",
+          "name": "EmptyNonEVMAddress",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "UnknownDeBridgeChain",
+          "inputs": []
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaAcross",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_acrossData",
+              "type": "tuple",
+              "internalType": "struct AcrossFacet.AcrossData",
+              "components": [
+                {
+                  "name": "relayerFeePct",
+                  "type": "int64",
+                  "internalType": "int64"
+                },
+                {
+                  "name": "quoteTimestamp",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "message",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "maxCount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaAcross",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_acrossData",
+              "type": "tuple",
+              "internalType": "struct AcrossFacet.AcrossData",
+              "components": [
+                {
+                  "name": "relayerFeePct",
+                  "type": "int64",
+                  "internalType": "int64"
+                },
+                {
+                  "name": "quoteTimestamp",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "message",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "maxCount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "extractBridgeData",
+          "inputs": [
+            {
+              "name": "data",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "extractData",
+          "inputs": [
+            {
+              "name": "data",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "extractGenericSwapParameters",
+          "inputs": [
+            {
+              "name": "data",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "sendingAssetId",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "receivingAssetId",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "receivingAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "extractMainParameters",
+          "inputs": [
+            {
+              "name": "data",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "bridge",
+              "type": "string",
+              "internalType": "string"
+            },
+            {
+              "name": "sendingAssetId",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "destinationChainId",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "hasSourceSwaps",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "hasDestinationCall",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "extractNonEVMAddress",
+          "inputs": [
+            {
+              "name": "data",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "nonEVMAddress",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "extractSwapData",
+          "inputs": [
+            {
+              "name": "data",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "validateCalldata",
+          "inputs": [
+            {
+              "name": "data",
+              "type": "bytes",
+              "internalType": "bytes"
+            },
+            {
+              "name": "bridge",
+              "type": "string",
+              "internalType": "string"
+            },
+            {
+              "name": "sendingAssetId",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "destinationChainId",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "hasSourceSwaps",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "hasDestinationCall",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "isValid",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "validateDestinationCalldata",
+          "inputs": [
+            {
+              "name": "data",
+              "type": "bytes",
+              "internalType": "bytes"
+            },
+            {
+              "name": "callTo",
+              "type": "bytes",
+              "internalType": "bytes"
+            },
+            {
+              "name": "dstCalldata",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "isValid",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "startBridgeTokensViaThorSwap",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_thorSwapData",
+              "type": "tuple",
+              "internalType": "struct ThorSwapFacet.ThorSwapData",
+              "components": [
+                {
+                  "name": "vault",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "memo",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "expiration",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "swapAndStartBridgeTokensViaThorSwap",
+          "inputs": [
+            {
+              "name": "_bridgeData",
+              "type": "tuple",
+              "internalType": "struct ILiFi.BridgeData",
+              "components": [
+                {
+                  "name": "transactionId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "bridge",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "integrator",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "referrer",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "minAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "destinationChainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "hasSourceSwaps",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "hasDestinationCall",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_swapData",
+              "type": "tuple[]",
+              "internalType": "struct LibSwap.SwapData[]",
+              "components": [
+                {
+                  "name": "callTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "approveTo",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "sendingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receivingAssetId",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "fromAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "requiresDeposit",
+                  "type": "bool",
+                  "internalType": "bool"
+                }
+              ]
+            },
+            {
+              "name": "_thorSwapData",
+              "type": "tuple",
+              "internalType": "struct ThorSwapFacet.ThorSwapData",
+              "components": [
+                {
+                  "name": "vault",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "memo",
+                  "type": "string",
+                  "internalType": "string"
+                },
+                {
+                  "name": "expiration",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "error",
+          "name": "DeprecatedToken",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "AddressOutOfBounds",
+          "inputs": []
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "LI.FI Service GmbH",
+    "info": {
+      "legalName": "LI.FI",
+      "url": "https://li.fi"
+    },
+    "constants": {
+      "addressAsEth": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+      "addressAsNull": "0x0000000000000000000000000000000000000000"
+    }
+  },
+  "display": {
+    "definitions": {
+      "fromAmount": {
+        "label": "Amount info",
+        "format": "tokenAmount",
+        "params": {
+          "nativeCurrencyAddress": [
+            "$.metadata.constants.addressAsEth",
+            "$.metadata.constants.addressAsNull"
+          ]
+        }
+      },
+      "_minAmountOut": {
+        "label": "Minimum Amount to receive",
+        "format": "tokenAmount",
+        "params": {
+          "nativeCurrencyAddress": [
+            "$.metadata.constants.addressAsEth",
+            "$.metadata.constants.addressAsNull"
+          ]
+        }
+      }
+    },
+    "formats": {
+      "0x5fd9ae2e": {
+        "$id": "swapTokensMultipleV3ERC20ToERC20",
+        "intent": "Swap",
+        "fields": [
+          {
+            "path": "_swapData.[0].fromAmount",
+            "label": "Amount to Send",
+            "format": "tokenAmount",
+            "params": {
+              "tokenPath": "_swapData.[0].sendingAssetId"
+            }
+          },
+          {
+            "path": "_minAmountOut",
+            "label": "Minimum to Receive",
+            "format": "tokenAmount",
+            "params": {
+              "tokenPath": "_swapData.[-1].receivingAssetId"
+            }
+          },
+          {
+            "path": "_receiver",
+            "label": "Recipient",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "eoa",
+                "contract"
+              ],
+              "sources": [
+                "local",
+                "ens"
+              ]
+            }
+          }
+        ],
+        "required": [
+          "_swapData.[0].fromAmount",
+          "_swapData.[-1].receivingAssetId",
+          "_minAmountOut",
+          "_receiver"
+        ],
+        "excluded": [
+          "_transactionId",
+          "_integrator",
+          "_referrer",
+          "_swapData.[].callData",
+          "_swapData.[].callTo",
+          "_swapData.[].approveTo",
+          "_swapData.[].requiresDeposit"
+        ]
+      },
+      "0x2c57e884": {
+        "$id": "swapTokensMultipleV3ERC20ToNative",
+        "intent": "Swap",
+        "fields": [
+          {
+            "path": "_swapData.[0].fromAmount",
+            "label": "Amount to Send",
+            "format": "tokenAmount",
+            "params": {
+              "tokenPath": "_swapData.[0].sendingAssetId"
+            }
+          },
+          {
+            "path": "_minAmountOut",
+            "$ref": "$.display.definitions._minAmountOut"
+          },
+          {
+            "path": "_receiver",
+            "label": "Receiver",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "eoa",
+                "contract"
+              ],
+              "sources": [
+                "local",
+                "ens"
+              ]
+            }
+          }
+        ],
+        "required": [
+          "_swapData.[0].fromAmount",
+          "_swapData.[-1].receivingAssetId",
+          "_minAmountOut",
+          "_receiver"
+        ],
+        "excluded": [
+          "_transactionId",
+          "_integrator",
+          "_referrer",
+          "_swapData.[].callData",
+          "_swapData.[].requiresDeposit",
+          "_swapData.[].approveTo",
+          "_swapData.[].callTo"
+        ]
+      },
+      "0x736eac0b": {
+        "$id": "swapTokensMultipleV3NativeToERC20",
+        "intent": "Swap",
+        "fields": [
+          {
+            "path": "@.value",
+            "label": "Amount to send",
+            "format": "amount"
+          },
+          {
+            "path": "_minAmountOut",
+            "label": "Minimum to Receive",
+            "format": "tokenAmount",
+            "params": {
+              "tokenPath": "_swapData.[-1].receivingAssetId"
+            }
+          },
+          {
+            "path": "_receiver",
+            "label": "Recipient",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "eoa",
+                "contract"
+              ],
+              "sources": [
+                "local",
+                "ens"
+              ]
+            }
+          }
+        ],
+        "required": [
+          "_swapData.[0].fromAmount",
+          "_swapData.[-1].receivingAssetId",
+          "_minAmountOut",
+          "_receiver"
+        ],
+        "excluded": [
+          "_transactionId",
+          "_integrator",
+          "_referrer",
+          "_swapData.[0].callData",
+          "_swapData.[0].requiresDeposit",
+          "_swapData.[0].callTo",
+          "_swapData.[0].approveTo"
+        ]
+      },
+      "0x4666fc80": {
+        "$id": "swapTokensSingleV3ERC20ToERC20",
+        "intent": "Swap",
+        "fields": [
+          {
+            "path": "_swapData.fromAmount",
+            "label": "Amount to Send",
+            "format": "tokenAmount",
+            "params": {
+              "tokenPath": "_swapData.sendingAssetId"
+            }
+          },
+          {
+            "path": "_minAmountOut",
+            "label": "Minimum to Receive",
+            "format": "tokenAmount",
+            "params": {
+              "tokenPath": "_swapData.receivingAssetId"
+            }
+          },
+          {
+            "path": "_receiver",
+            "label": "Recipient",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "eoa",
+                "contract"
+              ],
+              "sources": [
+                "local",
+                "ens"
+              ]
+            }
+          }
+        ],
+        "required": [
+          "_swapData.fromAmount",
+          "_minAmountOut",
+          "_receiver",
+          "_swapData.receivingAssetId"
+        ],
+        "excluded": [
+          "_transactionId",
+          "_integrator",
+          "_referrer",
+          "_swapData.callData",
+          "_swapData.requiresDeposit"
+        ]
+      },
+      "0x733214a3": {
+        "$id": "swapTokensSingleV3ERC20ToNative",
+        "intent": "Swap",
+        "fields": [
+          {
+            "path": "_swapData.fromAmount",
+            "label": "Amount to Send",
+            "format": "tokenAmount",
+            "params": {
+              "tokenPath": "_swapData.sendingAssetId"
+            }
+          },
+          {
+            "path": "_minAmountOut",
+            "$ref": "$.display.definitions._minAmountOut"
+          },
+          {
+            "path": "_receiver",
+            "label": "Receiver",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "eoa",
+                "contract"
+              ],
+              "sources": [
+                "local",
+                "ens"
+              ]
+            }
+          }
+        ],
+        "required": [
+          "_swapData.fromAmount",
+          "_minAmountOut",
+          "_receiver"
+        ],
+        "excluded": [
+          "_transactionId",
+          "_integrator",
+          "_referrer",
+          "_swapData.callData",
+          "_swapData.callTo",
+          "_swapData.approveTo",
+          "_swapData.requiresDeposit"
+        ]
+      },
+      "0xaf7060fd": {
+        "$id": "swapTokensSingleV3NativeToERC20",
+        "intent": "Swap",
+        "fields": [
+          {
+            "path": "@.value",
+            "label": "Amount to send",
+            "format": "amount"
+          },
+          {
+            "path": "_minAmountOut",
+            "label": "Minimum to Receive",
+            "format": "tokenAmount",
+            "params": {
+              "tokenPath": "_swapData.receivingAssetId"
+            }
+          },
+          {
+            "path": "_receiver",
+            "label": "Recipient",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "eoa",
+                "contract"
+              ],
+              "sources": [
+                "local",
+                "ens"
+              ]
+            }
+          }
+        ],
+        "required": [
+          "_swapData.fromAmount",
+          "_minAmountOut",
+          "_receiver"
+        ],
+        "excluded": [
+          "_transactionId",
+          "_integrator",
+          "_referrer",
+          "_swapData.callData",
+          "_swapData.requiresDeposit",
+          "_swapData.approveTo"
+        ]
+      },
+      "0x4630a0d8": {
+        "$id": "swapTokensGeneric",
+        "intent": "Swap",
+        "fields": [
+          {
+            "path": "_swapData.[0].fromAmount",
+            "$ref": "$.display.definitions.fromAmount",
+            "params": {
+              "tokenPath": "_swapData.[0].sendingAssetId"
+            }
+          },
+          {
+            "path": "_minAmount",
+            "$ref": "$.display.definitions._minAmountOut",
+            "params": {
+              "tokenPath": "_swapData.[-1].receivingAssetId"
+            }
+          },
+          {
+            "path": "_receiver",
+            "label": "Recipient",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "eoa",
+                "contract"
+              ],
+              "sources": [
+                "local",
+                "ens"
+              ]
+            }
+          }
+        ],
+        "required": [
+          "_swapData.[0].fromAmount",
+          "_minAmount",
+          "_receiver"
+        ],
+        "excluded": [
+          "_transactionId",
+          "_integrator",
+          "_referrer",
+          "_swapData.[].callData",
+          "_swapData.[].callTo",
+          "_swapData.[].approveTo",
+          "_swapData.[].requiresDeposit"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Latest version was exhaustive and it creates a lot of performance issues on several steps of the process.
This PR temporary reverts to the previous version to unlock current situation while performance improvements are done asynchronously. The objective remains to be able to add the full descriptor back in the registry