### PR TITLE
[V2 migration] ethena - schema migration and test generation

### DIFF
--- a/registry/ethena/calldata-ethena.json
+++ b/registry/ethena/calldata-ethena.json
@@ -1,101 +1,47 @@
 {
-  "$schema": "../../specs/erc7730-v1.schema.json",
+  "$schema": "../../specs/erc7730-v2.schema.json",
   "context": {
     "$id": "Staked USDe",
-    "contract": {
-      "deployments": [{ "chainId": 1, "address": "0x9D39A5DE30e57443BfF2A8307A4256c8797A3497" }],
-      "abi": [
-        {
-          "type": "function",
-          "name": "cooldownAssets",
-          "inputs": [{ "name": "assets", "type": "uint256", "internalType": "uint256" }],
-          "outputs": [{ "name": "shares", "type": "uint256", "internalType": "uint256" }],
-          "stateMutability": "nonpayable",
-          "constant": null,
-          "payable": null,
-          "gas": null,
-          "signature": null
-        },
-        {
-          "type": "function",
-          "name": "cooldownShares",
-          "inputs": [{ "name": "shares", "type": "uint256", "internalType": "uint256" }],
-          "outputs": [{ "name": "assets", "type": "uint256", "internalType": "uint256" }],
-          "stateMutability": "nonpayable",
-          "constant": null,
-          "payable": null,
-          "gas": null,
-          "signature": null
-        },
-        {
-          "type": "function",
-          "name": "unstake",
-          "inputs": [{ "name": "receiver", "type": "address", "internalType": "address" }],
-          "outputs": [],
-          "stateMutability": "nonpayable",
-          "constant": null,
-          "payable": null,
-          "gas": null,
-          "signature": null
-        }
-      ],
-      "addressMatcher": null,
-      "factory": null
-    }
+    "contract": { "deployments": [{ "chainId": 1, "address": "0x9D39A5DE30e57443BfF2A8307A4256c8797A3497" }] }
   },
-  "metadata": { "owner": "Ethena", "info": { "legalName": "Ethena", "url": "https://ethena.fi/" } },
+  "metadata": { "owner": "Ethena", "info": { "url": "https://ethena.fi/" }, "contractName": "Staked USDe" },
   "display": {
     "formats": {
-      "cooldownShares(uint256)": {
-        "$id": null,
+      "cooldownShares(uint256 shares)": {
         "intent": "Cooldown Shares",
-        "screens": null,
         "fields": [
           {
-            "$id": null,
             "label": "Amount",
             "format": "tokenAmount",
             "params": { "token": "0x9D39A5DE30e57443BfF2A8307A4256c8797A3497" },
             "path": "#.shares",
-            "value": null
+            "visible": "always"
           }
-        ],
-        "required": ["#.shares"],
-        "excluded": null
+        ]
       },
-      "cooldownAssets(uint256)": {
-        "$id": null,
+      "cooldownAssets(uint256 assets)": {
         "intent": "Cooldown Assets",
-        "screens": null,
         "fields": [
           {
-            "$id": null,
             "label": "Amount",
             "format": "tokenAmount",
             "params": { "token": "0x4c9EDD5852cd905f086C759E8383e09bff1E68B3" },
             "path": "#.assets",
-            "value": null
+            "visible": "always"
           }
-        ],
-        "required": ["#.assets"],
-        "excluded": null
+        ]
       },
-      "unstake(address)": {
-        "$id": null,
+      "unstake(address receiver)": {
         "intent": "Unstake",
-        "screens": null,
         "fields": [
           {
-            "$id": null,
             "label": "Receiver",
             "format": "addressName",
             "params": { "types": ["eoa", "wallet"], "sources": ["local", "ens"] },
             "path": "#.receiver",
-            "value": null
+            "visible": "always"
           }
-        ],
-        "required": ["#.receiver"],
-        "excluded": null
+        ]
       }
     }
   }

--- a/registry/ethena/tests/calldata-ethena.tests.json
+++ b/registry/ethena/tests/calldata-ethena.tests.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../../specs/erc7730-tests.schema.json",
+  "tests": [
+    {
+      "description": "Cooldown Shares - chain 1",
+      "rawTx": "0x02f84e018201e8841ff12f60841ff12f6083024728949d39a5de30e57443bff2a8307a4256c8797a349780a49343d9e10000000000000000000000000000000000000000000140dec2143dab35176404c0",
+      "txHash": "0xc34e8ee334d309e8b3658fcebcb4af2bc29ceb010141783b146d940ed4cdaca6",
+      "expectedTexts": [
+        "Interaction with",
+        "Ethena",
+        "Amount",
+        "1515266.436573198 420501508 sUSDe",
+        "Max fees",
+        "0.0000800034392 ETH"
+      ]
+    },
+    {
+      "description": "Unstake - chain 1",
+      "rawTx": "0x02f84d0182032283154938841b435ec0830174c8949d39a5de30e57443bff2a8307a4256c8797a349780a4f2888dbb0000000000000000000000000561e5b036ddcf2401c2b6b486f85451d75760a2c0",
+      "txHash": "0x97ea01b140a601124530ce6cee4c4ad87f4b8aaee9e4a0f8d2e99cf86faaba57",
+      "expectedTexts": [
+        "Interaction with",
+        "Ethena",
+        "Receiver",
+        "0x0561e5b036DdcF24 01c2B6b486f85451d75 760A2",
+        "Max fees",
+        "0.0000436505968 ETH"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Migrate Ethena calldata descriptor (`registry/ethena/calldata-ethena.json`) from v1 to v2 schema
- Add test file `registry/ethena/tests/calldata-ethena.tests.json`

## Test plan
- [ ] CI passes on the migrated descriptor
- [ ] Clear signing tester produces expected output for Ethena calldata