### PR TITLE
Yield.xyz: add validators for POL staking on Ethereum

### DIFF
--- a/registry/yieldxyz/calldata-yieldxyz-pol-validator.json
+++ b/registry/yieldxyz/calldata-yieldxyz-pol-validator.json
@@ -1,0 +1,200 @@
+{
+  "$schema": "../../specs/erc7730-v1.schema.json",
+  "metadata": {
+    "owner": "Yield.xyz",
+    "info": {
+      "legalName": "Yield.xyz",
+      "url": "https://yield.xyz/"
+    },
+    "constants": {
+      "stakingTokenTicker": "POL"
+    }
+  },
+  "context": {
+    "$id": "YieldxyzPolValidator",
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xb929b89153fc2eed442e81e5a1add4e2fa39028f"
+        },
+        {
+          "chainId": 1,
+          "address": "0x56d783Ca8e0b998C57a428Bf1c26A8baca50524e"
+        },
+        {
+          "chainId": 1,
+          "address": "0x857679d69fe50e7b722f94acd2629d80c355163d"
+        },
+        {
+          "chainId": 1,
+          "address": "0xF30Cf4ed712D3734161fDAab5B1DBb49Fd2D0E5c"
+        },
+        {
+          "chainId": 1,
+          "address": "0x5A10DE50160126A5F936506BD342C541Ac44e943"
+        },
+        {
+          "chainId": 1,
+          "address": "0x35B1CA0F398905Cf752e6FE122b51c88022FCa32"
+        },
+        {
+          "chainId": 1,
+          "address": "0xD9E6987D77bf2c6d0647b8181fd68A259f838C36"
+        },
+        {
+          "chainId": 1,
+          "address": "0xD14a87025109013B0a2354a775cB335F926Af65A"
+        },
+        {
+          "chainId": 1,
+          "address": "0xa6e768fEf2D1aF36c0cfdb276422E7881a83e951"
+        },
+        {
+          "chainId": 1,
+          "address": "0x467585AaEa860F9D8B3B43bb994E4Da8A93788a7"
+        },
+        {
+          "chainId": 1,
+          "address": "0x06998Af8f39Ff8630d1FB515D22781DA4DC2CA71"
+        },
+        {
+          "chainId": 1,
+          "address": "0xC7757805B983eE1b6272c1840c18e66837dE858E"
+        },
+        {
+          "chainId": 1,
+          "address": "0xE3E9Ba8c8C696f8537cF16b23EDDf118bbD7f21F"
+        },
+        {
+          "chainId": 1,
+          "address": "0x875e901465A639f2E71fcfC10F426eD32F5A909a"
+        },
+        {
+          "chainId": 1,
+          "address": "0x2905B3387c9550Ea57fa3EE7d4b7E5Abf3acD3d2"
+        },
+        {
+          "chainId": 1,
+          "address": "0x15C2b3AdcA66E26B6F230b4023f52a285b7f9995"
+        },
+        {
+          "chainId": 1,
+          "address": "0x2EA3c215daeaCc1C90b51443aB5D08a9ad816138"
+        }
+      ],
+      "abi": [
+        {
+          "name": "buyVoucherPOL",
+          "type": "function",
+          "inputs": [
+            {
+              "name": "_amount",
+              "type": "uint256"
+            },
+            {
+              "name": "_minSharesToMint",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "name": "sellVoucher_newPOL",
+          "type": "function",
+          "inputs": [
+            {
+              "name": "claimAmount",
+              "type": "uint256"
+            },
+            {
+              "name": "maximumSharesToBurn",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "name": "unstakeClaimTokens_newPOL",
+          "type": "function",
+          "inputs": [
+            {
+              "name": "unbondNonce",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "name": "withdrawRewardsPOL",
+          "type": "function",
+          "inputs": []
+        }
+      ]
+    }
+  },
+  "display": {
+    "formats": {
+      "buyVoucherPOL(uint256,uint256)": {
+        "intent": "Stake POL",
+        "fields": [
+          {
+            "path": "#._amount",
+            "label": "Stake amount",
+            "format": "unit",
+            "params": {
+              "base": "$.metadata.constants.stakingTokenTicker",
+              "decimals": 18
+            }
+          },
+          {
+            "path": "#._minSharesToMint",
+            "label": "Min shares",
+            "format": "raw"
+          }
+        ],
+        "required": [
+          "#._amount",
+          "#._minSharesToMint"
+        ]
+      },
+      "sellVoucher_newPOL(uint256,uint256)": {
+        "intent": "Unstake POL",
+        "fields": [
+          {
+            "path": "#.claimAmount",
+            "label": "Claim amount",
+            "format": "unit",
+            "params": {
+              "base": "$.metadata.constants.stakingTokenTicker",
+              "decimals": 18
+            }
+          },
+          {
+            "path": "#.maximumSharesToBurn",
+            "label": "Max shares",
+            "format": "raw"
+          }
+        ],
+        "required": [
+          "#.claimAmount",
+          "#.maximumSharesToBurn"
+        ]
+      },
+      "unstakeClaimTokens_newPOL(uint256)": {
+        "intent": "Claim unstaked POL",
+        "fields": [
+          {
+            "path": "#.unbondNonce",
+            "label": "Unbond nonce",
+            "format": "raw"
+          }
+        ],
+        "required": [
+          "#.unbondNonce"
+        ]
+      },
+      "withdrawRewardsPOL()": {
+        "intent": "Withdraw POL rewards",
+        "fields": []
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Summary

This PR adds a new allowlist mapping of validator contracts to their corresponding provider identities.
The goal is to ensure these contract addresses are recognized and correctly attributed to the right ValidatorProviders enum values.

Added contract/provider mappings:

`0xb929b89153fc2eed442e81e5a1add4e2fa39028f` → Figment
`0x56d783Ca8e0b998C57a428Bf1c26A8baca50524e` → Chainflow
`0x857679d69fe50e7b722f94acd2629d80c355163d` → CoinbaseCloud
`0xF30Cf4ed712D3734161fDAab5B1DBb49Fd2D0E5c` → Everstake
`0x5A10DE50160126A5F936506BD342C541Ac44e943` → BwareLabs
`0x35B1CA0F398905Cf752e6FE122b51c88022FCa32` → InfStones
`0xD9E6987D77bf2c6d0647b8181fd68A259f838C36` → ChorusOne
`0xD14a87025109013B0a2354a775cB335F926Af65A` → Kiln
`0xa6e768fEf2D1aF36c0cfdb276422E7881a83e951` → Luganodes
`0x467585AaEa860F9D8B3B43bb994E4Da8A93788a7` → Meria
`0x06998Af8f39Ff8630d1FB515D22781DA4DC2CA71` → Staking4All
`0xC7757805B983eE1b6272c1840c18e66837dE858E` → Stakin
`0xE3E9Ba8c8C696f8537cF16b23EDDf118bbD7f21F` → PierTwo
`0x875e901465A639f2E71fcfC10F426eD32F5A909a` → Blockdaemon
`0x2905B3387c9550Ea57fa3EE7d4b7E5Abf3acD3d2` → SimplyStaking
`0x15C2b3AdcA66E26B6F230b4023f52a285b7f9995` → P2P
`0x2EA3c215daeaCc1C90b51443aB5D08a9ad816138` → LedgerByMeria