### PR TITLE
fix(migrate): expand tuple types for selector computation and fail on unconverted selectors

### DIFF
--- a/tools/scripts/migrate-v1-to-v2.js
+++ b/tools/scripts/migrate-v1-to-v2.js
@@ -1122,13 +1122,32 @@ function canonicalizeSignature(signatureLike) {
 }
 
 /**
+ * Recursively expand an ABI parameter type, replacing tuple types with their
+ * component types in parenthesised form (e.g. `tuple[]` with components
+ * becomes `(uint256,address)[]`). Required for correct keccak256 selector
+ * computation.
+ */
+function expandAbiType(param) {
+  if (!param) return "";
+  const type = param.type || "";
+  const isTuple = type === "tuple" || type.startsWith("tuple[");
+  if (isTuple && Array.isArray(param.components)) {
+    const inner = param.components.map(expandAbiType).join(",");
+    const suffix = type.slice("tuple".length);
+    return `(${inner})${suffix}`;
+  }
+  return type;
+}
+
+/**
  * Return canonical name(types) signature for ABI function entry.
+ * Tuple types are expanded to their component types for correct selector computation.
  */
 function abiCanonicalSignature(abiEntry) {
   if (!abiEntry || abiEntry.type !== "function") return null;
   const name = abiEntry.name;
   const inputs = Array.isArray(abiEntry.inputs) ? abiEntry.inputs : [];
-  const types = inputs.map((input) => extractParamType(input?.type || ""));
+  const types = inputs.map((input) => expandAbiType(input));
   return `${name}(${types.join(",")})`;
 }
 
@@ -1460,6 +1479,19 @@ function migrateFile(filePath) {
 
     // 5. Transform format keys before removing abi/schemas
     const keyMapping = transformFormatKeys(json);
+
+    // Fail if any hex selector format keys could not be converted
+    if (json.display?.formats) {
+      const unconvertedSelectors = Object.keys(json.display.formats)
+        .filter((key) => isHexSelector(key) && !keyMapping[key]);
+      if (unconvertedSelectors.length > 0) {
+        const selectorList = unconvertedSelectors.join(", ");
+        throw new Error(
+          `Failed to convert selector(s) to human-readable ABI: ${selectorList}. ` +
+          `Ensure the contract ABI contains matching function entries.`
+        );
+      }
+    }
 
     // Apply key mapping to formats
     if (Object.keys(keyMapping).length > 0 && json.display?.formats) {


### PR DESCRIPTION
## Summary

- **Fix tuple expansion in selector computation**: `abiCanonicalSignature()` was using raw `input.type` (e.g. `"tuple[]"`) instead of expanding tuple parameters to their component types (e.g. `(bytes32[],(uint24,bytes20,uint120,uint8))[]`). This produced incorrect keccak256 selectors for any function with struct parameters, so `findAbiEntry()` could never match hex selector keys against those ABI entries.
- **Fail on unconverted selectors**: The migration previously silently removed the ABI and wrote the file with raw hex selectors as format keys while reporting success. Now it fails with a clear error when hex selector format keys cannot be converted to human-readable ABI signatures.

## Affected files

Discovered on `registry/flare/calldata-RewardManager-Songbird.json` where selectors `0x3ce7522a` and `0x15f253fb` were left unconverted because the corresponding ABI functions (`initialiseWeightBasedClaims`, `autoClaim`) have tuple parameters.

## Test plan

- [x] Verified migration of `calldata-RewardManager-Songbird.json` now correctly converts both selectors to human-readable signatures
- [x] Verified migration fails with clear error when a hex selector has no matching ABI entry
- [x] Existing non-tuple selector conversions are unaffected

Made with [Cursor](https://cursor.com)