### PR TITLE
[V2 migration] tether - schema migration and test generation

### DIFF
--- a/registry/tether/calldata-usdt.json
+++ b/registry/tether/calldata-usdt.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../specs/erc7730-v1.schema.json",
+  "$schema": "../../specs/erc7730-v2.schema.json",
   "context": {
     "$id": "Tether USD",
     "contract": {
@@ -9,10 +9,33 @@
       ]
     }
   },
-  "includes": "../../ercs/calldata-erc20-tokens.json",
   "metadata": {
-    "owner": "Tether",
-    "info": { "legalName": "Tether Limited", "url": "https://tether.to/", "deploymentDate": "2017-11-28T12:41:21Z" },
-    "token": { "ticker": "USDT", "name": "Tether USD", "decimals": 6 }
+    "owner": "Tether Limited",
+    "info": { "url": "https://tether.to/", "deploymentDate": "2017-11-28T12:41:21Z" },
+    "token": { "ticker": "USDT", "name": "Tether USD", "decimals": 6 },
+    "contractName": "Tether USD"
+  },
+  "display": {
+    "formats": {
+      "transfer(address _to, uint256 _value)": {
+        "intent": "Send",
+        "fields": [
+          { "path": "#._value", "label": "Amount", "format": "tokenAmount", "params": { "tokenPath": "@.to" } },
+          { "path": "#._to", "label": "To", "format": "addressName", "params": { "types": ["eoa"], "sources": ["local", "ens"] } }
+        ]
+      },
+      "approve(address _spender, uint256 _value)": {
+        "intent": "Approve",
+        "fields": [
+          { "path": "#._spender", "label": "Spender", "format": "addressName", "params": { "types": ["eoa", "contract"] } },
+          {
+            "path": "#._value",
+            "label": "Amount",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "@.to", "threshold": "0x8000000000000000000000000000000000000000000000000000000000000000" }
+          }
+        ]
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

This PR contains the V2 migration for `tether` in the registry.

### Changes Made

- **Schema Migration**: Migrated `calldata-usdt.json` from ERC-7730 v1 to v2 schema
- **Inlined includes**: Replaced `includes` reference to shared `ercs/calldata-erc20-tokens.json` (v1) with inlined v2-compatible display formats
- Converted v1 function keys to v2 human-readable ABI format (`transfer(address _to, uint256 _value)`)
- Converted v1 field paths to v2 format (`#._value` instead of `_value`)
- Removed `required` arrays (v1) — fields are visible by default in v2
- Removed `legalName` from metadata info (deprecated in v2)
- Added `contractName` to metadata

### Modified Files

- `registry/tether/calldata-usdt.json`

### Validation Status

| Check | Status |
|-------|--------|
| Schema Migration | ✅ Passed |
| v2 Linting | ✅ Passed (warnings only — missing admin functions, same as v1) |
| Test Generation | ⏭️ Skipped |

### Notes

- This PR was generated with `tools/scripts/batch-process.js` and then manually fixed to handle the `includes` → inline conversion
- Please review the changes before merging

### Test Plan

- [ ] Review migrated schema file
- [ ] Run CI checks
- [ ] Generate tests when ready