### PR TITLE
[V2 migration] ercs - shared ERC descriptor schema migration

### DIFF
--- a/ercs/calldata-erc20-tokens.json
+++ b/ercs/calldata-erc20-tokens.json
@@ -1,51 +1,39 @@
 {
-  "$schema": "../specs/erc7730-v1.schema.json",
-  "context": {
-    "contract": {
-      "abi": [
-        {
-          "constant": false,
-          "inputs": [{ "name": "_spender", "type": "address" }, { "name": "_value", "type": "uint256" }],
-          "name": "approve",
-          "outputs": [{ "name": "", "type": "bool" }],
-          "payable": false,
-          "stateMutability": "nonpayable",
-          "type": "function"
-        },
-        {
-          "constant": false,
-          "inputs": [{ "name": "_to", "type": "address" }, { "name": "_value", "type": "uint256" }],
-          "name": "transfer",
-          "outputs": [{ "name": "", "type": "bool" }],
-          "payable": false,
-          "stateMutability": "nonpayable",
-          "type": "function"
-        }
-      ]
-    }
-  },
+  "$schema": "../specs/erc7730-v2.schema.json",
+  "context": { "contract": {} },
   "display": {
     "formats": {
-      "transfer(address,uint256)": {
+      "transfer(address _to, uint256 _value)": {
         "intent": "Send",
         "fields": [
-          { "path": "_value", "label": "Amount", "format": "tokenAmount", "params": { "tokenPath": "@.to" } },
-          { "path": "_to", "label": "To", "format": "addressName", "params": { "types": ["eoa"], "sources": ["local", "ens"] } }
-        ],
-        "required": ["_to", "_value"]
+          { "path": "_value", "label": "Amount", "format": "tokenAmount", "params": { "tokenPath": "@.to" }, "visible": "always" },
+          {
+            "path": "_to",
+            "label": "To",
+            "format": "addressName",
+            "params": { "types": ["eoa"], "sources": ["local", "ens"] },
+            "visible": "always"
+          }
+        ]
       },
-      "approve(address,uint256)": {
+      "approve(address _spender, uint256 _value)": {
         "intent": "Approve",
         "fields": [
-          { "path": "_spender", "label": "Spender", "format": "addressName", "params": { "types": ["eoa", "contract"] } },
+          {
+            "path": "_spender",
+            "label": "Spender",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
+          },
           {
             "path": "_value",
             "label": "Amount",
             "format": "tokenAmount",
-            "params": { "tokenPath": "@.to", "threshold": "0x8000000000000000000000000000000000000000000000000000000000000000" }
+            "params": { "tokenPath": "@.to", "threshold": "0x8000000000000000000000000000000000000000000000000000000000000000" },
+            "visible": "always"
           }
-        ],
-        "required": ["_spender", "_value"]
+        ]
       }
     }
   }

--- a/ercs/calldata-erc4626-vaults.json
+++ b/ercs/calldata-erc4626-vaults.json
@@ -1,31 +1,6 @@
 {
-  "$schema": "../specs/erc7730-v1.schema.json",
-  "context": {
-    "contract": {
-      "abi": [
-        {
-          "inputs": [{ "name": "assets", "type": "uint256" }, { "name": "receiver", "type": "address" }],
-          "name": "deposit",
-          "type": "function"
-        },
-        {
-          "inputs": [{ "name": "shares", "type": "uint256" }, { "name": "receiver", "type": "address" }],
-          "name": "mint",
-          "type": "function"
-        },
-        {
-          "inputs": [{ "name": "assets", "type": "uint256" }, { "name": "receiver", "type": "address" }, { "name": "owner", "type": "address" }],
-          "name": "withdraw",
-          "type": "function"
-        },
-        {
-          "inputs": [{ "name": "shares", "type": "uint256" }, { "name": "receiver", "type": "address" }, { "name": "owner", "type": "address" }],
-          "name": "redeem",
-          "type": "function"
-        }
-      ]
-    }
-  },
+  "$schema": "../specs/erc7730-v2.schema.json",
+  "context": { "contract": {} },
   "metadata": { "constants": { "underlyingToken": "0x0" } },
   "display": {
     "formats": {
@@ -36,44 +11,90 @@
             "path": "assets",
             "label": "Deposit asset",
             "format": "tokenAmount",
-            "params": { "token": "$.metadata.constants.underlyingToken" }
+            "params": { "token": "$.metadata.constants.underlyingToken" },
+            "visible": "always"
           },
           { "label": "Share ticker", "format": "raw", "value": "$.metadata.constants.vaultTicker" },
-          { "path": "receiver", "label": "Send shares to", "format": "addressName", "params": { "types": ["eoa", "contract"] } }
-        ],
-        "required": ["assets", "receiver"]
+          {
+            "path": "receiver",
+            "label": "Send shares to",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
+          }
+        ]
       },
       "mint(uint256 shares, address receiver)": {
         "intent": "Mint",
         "fields": [
           { "label": "Deposit asset", "format": "raw", "value": "$.metadata.constants.underlyingTicker" },
-          { "path": "shares", "label": "Minted shares", "format": "tokenAmount", "params": { "tokenPath": "@.to" } },
-          { "path": "receiver", "label": "Mint shares to", "format": "addressName", "params": { "types": ["eoa", "contract"] } }
-        ],
-        "required": ["shares", "receiver"]
+          {
+            "path": "shares",
+            "label": "Minted shares",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "@.to" },
+            "visible": "always"
+          },
+          {
+            "path": "receiver",
+            "label": "Mint shares to",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
+          }
+        ]
       },
-      "withdraw(uint256 assets,address receiver,address owner)": {
+      "withdraw(uint256 assets, address receiver, address owner)": {
         "intent": "Withdraw",
         "fields": [
           {
             "path": "assets",
             "label": "Withdraw exactly",
             "format": "tokenAmount",
-            "params": { "token": "$.metadata.constants.underlyingToken" }
+            "params": { "token": "$.metadata.constants.underlyingToken" },
+            "visible": "always"
           },
-          { "path": "receiver", "label": "To", "format": "addressName", "params": { "types": ["eoa", "contract"] } },
-          { "path": "owner", "label": "Owner", "format": "addressName", "params": { "types": ["eoa", "contract"] } }
-        ],
-        "required": ["assets", "receiver", "owner"]
+          {
+            "path": "receiver",
+            "label": "To",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
+          },
+          {
+            "path": "owner",
+            "label": "Owner",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
+          }
+        ]
       },
-      "redeem(uint256 shares,address receiver,address owner)": {
+      "redeem(uint256 shares, address receiver, address owner)": {
         "intent": "Redeem",
         "fields": [
-          { "path": "shares", "label": "Shares to redeem", "format": "tokenAmount", "params": { "tokenPath": "@.to" } },
-          { "path": "receiver", "label": "To", "format": "addressName", "params": { "types": ["eoa", "contract"] } },
-          { "path": "owner", "label": "Owner", "format": "addressName", "params": { "types": ["eoa", "contract"] } }
-        ],
-        "required": ["shares", "receiver", "owner"]
+          {
+            "path": "shares",
+            "label": "Shares to redeem",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "@.to" },
+            "visible": "always"
+          },
+          {
+            "path": "receiver",
+            "label": "To",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
+          },
+          {
+            "path": "owner",
+            "label": "Owner",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
+          }
+        ]
       }
     }
   }

--- a/ercs/calldata-erc721-nfts.json
+++ b/ercs/calldata-erc721-nfts.json
@@ -1,31 +1,6 @@
 {
-  "$schema": "../specs/erc7730-v1.schema.json",
-  "context": {
-    "contract": {
-      "abi": [
-        {
-          "inputs": [{ "name": "_from", "type": "address" }, { "name": "_to", "type": "address" }, { "name": "_tokenId", "type": "uint256" }],
-          "name": "transferFrom",
-          "type": "function"
-        },
-        {
-          "inputs": [{ "name": "_from", "type": "address" }, { "name": "_to", "type": "address" }, { "name": "_tokenId", "type": "uint256" }],
-          "name": "safeTransferFrom",
-          "type": "function"
-        },
-        {
-          "inputs": [{ "name": "_approved", "type": "address" }, { "name": "_tokenId", "type": "uint256" }],
-          "name": "approve",
-          "type": "function"
-        },
-        {
-          "inputs": [{ "name": "_operator", "type": "address" }, { "name": "_approved", "type": "bool" }],
-          "name": "setApprovalForAll",
-          "type": "function"
-        }
-      ]
-    }
-  },
+  "$schema": "../specs/erc7730-v2.schema.json",
+  "context": { "contract": {} },
   "metadata": { "enums": { "rights": { "True": "Grant all", "False": "Deny all" } } },
   "display": {
     "definitions": {
@@ -35,32 +10,30 @@
       "tokenId": { "label": "NFT", "format": "nftName", "params": { "collectionPath": "@.to" } }
     },
     "formats": {
-      "transferFrom(address,address,uint256)": {
+      "transferFrom(address _from, address _to, uint256 _tokenId)": {
+        "intent": "Send NFT",
+        "fields": [
+          { "path": "_from", "$ref": "$.display.definitions.from" },
+          { "path": "_to", "$ref": "$.display.definitions.to", "visible": "always" },
+          { "path": "_tokenId", "$ref": "$.display.definitions.tokenId", "visible": "always" }
+        ]
+      },
+      "safeTransferFrom(address _from, address _to, uint256 _tokenId)": {
         "intent": "Send NFT",
         "fields": [
           { "path": "_from", "$ref": "$.display.definitions.from" },
           { "path": "_to", "$ref": "$.display.definitions.to" },
           { "path": "_tokenId", "$ref": "$.display.definitions.tokenId" }
-        ],
-        "required": ["_to", "_tokenId"]
+        ]
       },
-      "safeTransferFrom(address,address,uint256)": {
-        "intent": "Send NFT",
-        "fields": [
-          { "path": "_from", "$ref": "$.display.definitions.from" },
-          { "path": "_to", "$ref": "$.display.definitions.to" },
-          { "path": "_tokenId", "$ref": "$.display.definitions.tokenId" }
-        ],
-        "required": ["_spender", "_value"]
-      },
-      "approve(address,uint256)": {
+      "approve(address _approved, uint256 _tokenId)": {
         "intent": "Approve operator for NFT",
         "fields": [
           { "path": "_approved", "$ref": "$.display.definitions.operator" },
           { "path": "_tokenId", "$ref": "$.display.definitions.tokenId" }
         ]
       },
-      "setApprovalForAll(address,bool)": {
+      "setApprovalForAll(address _operator, bool _approved)": {
         "$id": "setApprovalForAll",
         "intent": "Manage operator rights for",
         "fields": [

--- a/ercs/calldata-erc7540Deposit-vaults.json
+++ b/ercs/calldata-erc7540Deposit-vaults.json
@@ -1,41 +1,6 @@
 {
-  "$schema": "../specs/erc7730-v1.schema.json",
-  "context": {
-    "contract": {
-      "abi": [
-        {
-          "inputs": [
-            { "name": "assets", "type": "uint256" },
-            { "name": "receiver", "type": "address" },
-            { "name": "controller", "type": "address" }
-          ],
-          "name": "deposit",
-          "type": "function"
-        },
-        {
-          "inputs": [
-            { "name": "shares", "type": "uint256" },
-            { "name": "receiver", "type": "address" },
-            { "name": "controller", "type": "address" }
-          ],
-          "name": "mint",
-          "type": "function"
-        },
-        {
-          "inputs": [{ "name": "assets", "type": "uint256" }, { "name": "controller", "type": "address" }, { "name": "owner", "type": "address" }],
-          "type": "function",
-          "name": "requestDeposit"
-        },
-        {
-          "inputs": [{ "name": "operator", "type": "address" }, { "name": "approved", "type": "bool" }],
-          "stateMutability": "nonpayable",
-          "outputs": [{ "name": "success", "type": "bool" }],
-          "type": "function",
-          "name": "setOperator"
-        }
-      ]
-    }
-  },
+  "$schema": "../specs/erc7730-v2.schema.json",
+  "context": { "contract": {} },
   "metadata": { "constants": { "underlyingToken": "0x0" } },
   "display": {
     "formats": {
@@ -46,33 +11,52 @@
             "path": "assets",
             "label": "Amount of assets to finalize deposit for",
             "format": "tokenAmount",
-            "params": { "token": "$.metadata.constants.underlyingToken" }
+            "params": { "token": "$.metadata.constants.underlyingToken" },
+            "visible": "always"
           },
           { "label": "Receive shares", "format": "raw", "value": "$.metadata.constants.vaultTicker" },
-          { "path": "receiver", "label": "Send shares to", "format": "addressName", "params": { "types": ["eoa", "contract"] } },
+          {
+            "path": "receiver",
+            "label": "Send shares to",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
+          },
           {
             "path": "controller",
             "label": "Controller of the request",
             "format": "addressName",
-            "params": { "types": ["eoa", "contract"] }
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
           }
-        ],
-        "required": ["assets", "receiver", "controller"]
+        ]
       },
       "mint(uint256 shares, address receiver, address controller)": {
         "intent": "Mint",
         "fields": [
           { "label": "Claim deposit", "format": "raw", "value": "$.metadata.constants.underlyingTicker" },
-          { "path": "shares", "label": "Amount of shares to mint", "format": "tokenAmount", "params": { "tokenPath": "@.to" } },
-          { "path": "receiver", "label": "Send shares to", "format": "addressName", "params": { "types": ["eoa", "contract"] } },
+          {
+            "path": "shares",
+            "label": "Amount of shares to mint",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "@.to" },
+            "visible": "always"
+          },
+          {
+            "path": "receiver",
+            "label": "Send shares to",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
+          },
           {
             "path": "controller",
             "label": "Controller of the request",
             "format": "addressName",
-            "params": { "types": ["eoa", "contract"] }
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
           }
-        ],
-        "required": ["shares", "receiver", "controller"]
+        ]
       },
       "requestDeposit(uint256 assets, address controller, address owner)": {
         "intent": "Request deposit",
@@ -81,25 +65,37 @@
             "path": "assets",
             "label": "Amount of assets to request deposit for",
             "format": "tokenAmount",
-            "params": { "token": "$.metadata.constants.underlyingToken" }
+            "params": { "token": "$.metadata.constants.underlyingToken" },
+            "visible": "always"
           },
           {
             "path": "controller",
             "label": "Controller of the request",
             "format": "addressName",
-            "params": { "types": ["eoa", "contract"] }
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
           },
-          { "path": "owner", "label": "Owner of the shares", "format": "addressName", "params": { "types": ["eoa", "contract"] } }
-        ],
-        "required": ["assets", "controller", "owner"]
+          {
+            "path": "owner",
+            "label": "Owner of the shares",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
+          }
+        ]
       },
       "setOperator(address operator, bool approved)": {
         "intent": "Set operator",
         "fields": [
-          { "path": "operator", "label": "Operator", "format": "addressName", "params": { "types": ["eoa", "contract"] } },
-          { "path": "approved", "label": "Approved", "format": "raw" }
-        ],
-        "required": ["operator", "approved"]
+          {
+            "path": "operator",
+            "label": "Operator",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
+          },
+          { "path": "approved", "label": "Approved", "format": "raw", "visible": "always" }
+        ]
       }
     }
   }

--- a/ercs/calldata-erc7540Redeem-vaults.json
+++ b/ercs/calldata-erc7540Redeem-vaults.json
@@ -1,41 +1,6 @@
 {
-  "$schema": "../specs/erc7730-v1.schema.json",
-  "context": {
-    "contract": {
-      "abi": [
-        {
-          "name": "redeem",
-          "type": "function",
-          "inputs": [
-            { "name": "shares", "type": "uint256" },
-            { "name": "receiver", "type": "address" },
-            { "name": "controller", "type": "address" }
-          ]
-        },
-        {
-          "name": "withdraw",
-          "type": "function",
-          "inputs": [
-            { "name": "assets", "type": "uint256" },
-            { "name": "receiver", "type": "address" },
-            { "name": "controller", "type": "address" }
-          ]
-        },
-        {
-          "name": "requestRedeem",
-          "type": "function",
-          "inputs": [{ "name": "shares", "type": "uint256" }, { "name": "controller", "type": "address" }, { "name": "owner", "type": "address" }]
-        },
-        {
-          "name": "setOperator",
-          "type": "function",
-          "inputs": [{ "name": "operator", "type": "address" }, { "name": "approved", "type": "bool" }],
-          "stateMutability": "nonpayable",
-          "outputs": [{ "name": "success", "type": "bool" }]
-        }
-      ]
-    }
-  },
+  "$schema": "../specs/erc7730-v2.schema.json",
+  "context": { "contract": {} },
   "metadata": { "constants": { "underlyingToken": "0x0" } },
   "display": {
     "formats": {
@@ -46,17 +11,24 @@
             "path": "shares",
             "label": "Amount of shares to finalize redemption for",
             "format": "tokenAmount",
-            "params": { "tokenPath": "@.to" }
+            "params": { "tokenPath": "@.to" },
+            "visible": "always"
           },
-          { "path": "receiver", "label": "Send assets to", "format": "addressName", "params": { "types": ["eoa", "contract"] } },
+          {
+            "path": "receiver",
+            "label": "Send assets to",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
+          },
           {
             "path": "controller",
             "label": "Controller of the request",
             "format": "addressName",
-            "params": { "types": ["eoa", "contract"] }
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
           }
-        ],
-        "required": ["shares", "receiver", "controller"]
+        ]
       },
       "withdraw(uint256 assets, address receiver, address controller)": {
         "intent": "Withdraw",
@@ -66,17 +38,24 @@
             "path": "assets",
             "label": "Amount of assets to receive",
             "format": "tokenAmount",
-            "params": { "token": "$.metadata.constants.underlyingToken" }
+            "params": { "token": "$.metadata.constants.underlyingToken" },
+            "visible": "always"
           },
-          { "path": "receiver", "label": "Send assets to", "format": "addressName", "params": { "types": ["eoa", "contract"] } },
+          {
+            "path": "receiver",
+            "label": "Send assets to",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
+          },
           {
             "path": "controller",
             "label": "Controller of the request",
             "format": "addressName",
-            "params": { "types": ["eoa", "contract"] }
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
           }
-        ],
-        "required": ["assets", "receiver", "controller"]
+        ]
       },
       "requestRedeem(uint256 shares, address controller, address owner)": {
         "intent": "Request redemption",
@@ -85,25 +64,37 @@
             "path": "shares",
             "label": "Amount of shares to request redemption for",
             "format": "tokenAmount",
-            "params": { "tokenPath": "@.to" }
+            "params": { "tokenPath": "@.to" },
+            "visible": "always"
           },
           {
             "path": "controller",
             "label": "Controller of the request",
             "format": "addressName",
-            "params": { "types": ["eoa", "contract"] }
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
           },
-          { "path": "owner", "label": "Owner of the shares", "format": "addressName", "params": { "types": ["eoa", "contract"] } }
-        ],
-        "required": ["shares", "controller", "owner"]
+          {
+            "path": "owner",
+            "label": "Owner of the shares",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
+          }
+        ]
       },
       "setOperator(address operator, bool approved)": {
         "intent": "Set operator",
         "fields": [
-          { "path": "operator", "label": "Operator", "format": "addressName", "params": { "types": ["eoa", "contract"] } },
-          { "path": "approved", "label": "Approved", "format": "raw" }
-        ],
-        "required": ["operator", "approved"]
+          {
+            "path": "operator",
+            "label": "Operator",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
+          },
+          { "path": "approved", "label": "Approved", "format": "raw", "visible": "always" }
+        ]
       }
     }
   }

--- a/ercs/eip712-erc2612-permit.json
+++ b/ercs/eip712-erc2612-permit.json
@@ -1,41 +1,23 @@
 {
-  "$schema": "../specs/erc7730-v1.schema.json",
-  "context": {
-    "eip712": {
-      "schemas": [
-        {
-          "types": {
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ],
-            "Permit": [
-              { "name": "owner", "type": "address" },
-              { "name": "spender", "type": "address" },
-              { "name": "value", "type": "uint256" },
-              { "name": "nonce", "type": "uint256" },
-              { "name": "deadline", "type": "uint256" }
-            ]
-          },
-          "primaryType": "Permit"
-        }
-      ]
-    }
-  },
+  "$schema": "../specs/erc7730-v2.schema.json",
+  "context": { "eip712": {} },
   "display": {
     "formats": {
-      "Permit": {
+      "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)": {
         "intent": "Authorize spending of tokens",
         "fields": [
-          { "path": "spender", "label": "Spender", "format": "raw" },
-          { "path": "value", "label": "Max spending amount", "format": "tokenAmount", "params": { "tokenPath": "@.to" } },
-          { "path": "deadline", "label": "Valid until", "format": "date", "params": { "encoding": "timestamp" } }
-        ],
-        "required": ["spender", "value"],
-        "excluded": ["owner", "nonce"],
-        "screens": {}
+          { "path": "spender", "label": "Spender", "format": "raw", "visible": "always" },
+          {
+            "path": "value",
+            "label": "Max spending amount",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "@.to" },
+            "visible": "always"
+          },
+          { "path": "deadline", "label": "Valid until", "format": "date", "params": { "encoding": "timestamp" } },
+          { "label": "Owner", "path": "owner", "visible": "never" },
+          { "label": "Nonce", "path": "nonce", "visible": "never" }
+        ]
       }
     }
   }


### PR DESCRIPTION
## Summary

This PR migrates all 6 shared ERC descriptor include files under `ercs/` from ERC-7730 v1 to v2 schema.

### Changes Made

- **Schema Migration**: Migrated 6 files from ERC-7730 v1 to v2 schema
- **Test Generation**: N/A (shared include files have no deployments)

### Modified Files

- `ercs/calldata-erc20-tokens.json`
- `ercs/calldata-erc4626-vaults.json`
- `ercs/calldata-erc721-nfts.json`
- `ercs/calldata-erc7540Deposit-vaults.json`
- `ercs/calldata-erc7540Redeem-vaults.json`
- `ercs/eip712-erc2612-permit.json`

### V2 Transformations Applied

| Transformation | Count |
|-------|--------|
| Schema references updated | 6 |
| ABI sections removed | 5 |
| EIP-712 schemas removed | 1 |
| Format keys → human-readable | 3 |
| `required` → `visible: "always"` | multiple |
| `excluded` → `visible: "never"` | 2 (eip712-erc2612-permit) |
| `screens` removed | 1 |

### Validation Status

| Check | Status |
|-------|--------|
| Schema Migration | ✅ Passed |
| Standalone Linting | ⚠️ Expected errors (shared includes lack deployments) |
| Test Generation | ⏭️ N/A |

### Notes

- These are shared include files referenced by other descriptors via `includes`. They don't have `deployments` on their own, so they cannot be linted standalone — this is expected and unchanged from v1.
- Consumers of these files (tether, kiln, permit, makerdao) will need their own migration PRs.
- This PR was generated using `tools/scripts/migrate-v1-to-v2.js`

### Test Plan

- [ ] Review migrated schema files
- [ ] Verify consuming descriptors still work after merging
- [ ] Run CI checks


Made with [Cursor](https://cursor.com)