### PR TITLE
[V2 migration] lens - schema migration and test generation

### DIFF
--- a/registry/lens/eip712-lens-lenshub.json
+++ b/registry/lens/eip712-lens-lenshub.json
@@ -1,453 +1,28 @@
 {
-  "$schema": "../../specs/erc7730-v1.schema.json",
+  "$schema": "../../specs/erc7730-v2.schema.json",
   "context": {
     "eip712": {
       "deployments": [{ "chainId": 137, "address": "0xdb46d1dc155634fbc732f92e853b10b288ad5a1d" }],
-      "domain": { "name": "Lens Protocol Profiles", "version": "2" },
-      "schemas": [
-        {
-          "primaryType": "act",
-          "types": {
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ],
-            "act": [
-              { "name": "publicationActedProfileId", "type": "uint256" },
-              { "name": "publicationActedId", "type": "uint256" },
-              { "name": "actorProfileId", "type": "uint256" },
-              { "name": "referrerProfileIds", "type": "uint256[]" },
-              { "name": "referrerPubIds", "type": "uint256[]" },
-              { "name": "actionModuleAddress", "type": "address" },
-              { "name": "actionModuleData", "type": "bytes" },
-              { "name": "nonce", "type": "uint256" },
-              { "name": "deadline", "type": "uint256" }
-            ]
-          }
-        },
-        {
-          "primaryType": "burn",
-          "types": {
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ],
-            "burn": [{ "name": "tokenId", "type": "uint256" }]
-          }
-        },
-        {
-          "primaryType": "ChangeDelegatedExecutorsConfig",
-          "types": {
-            "ChangeDelegatedExecutorsConfig": [
-              { "name": "delegatorProfileId", "type": "uint256" },
-              { "name": "delegatedExecutors", "type": "address[]" },
-              { "name": "approvals", "type": "bool[]" },
-              { "name": "configNumber", "type": "uint64" },
-              { "name": "switchToGivenConfig", "type": "bool" },
-              { "name": "nonce", "type": "uint256" },
-              { "name": "deadline", "type": "uint256" }
-            ],
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ]
-          }
-        },
-        {
-          "primaryType": "collect",
-          "types": {
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ],
-            "collect": [
-              { "name": "publicationCollectedProfileId", "type": "uint256" },
-              { "name": "publicationCollectedId", "type": "uint256" },
-              { "name": "collectorProfileId", "type": "uint256" }
-            ]
-          }
-        },
-        {
-          "primaryType": "collect_with_sign",
-          "types": {
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ],
-            "collect_with_sign": [
-              { "name": "publicationCollectedProfileId", "type": "uint256" },
-              { "name": "publicationCollectedId", "type": "uint256" },
-              { "name": "collectorProfileId", "type": "uint256" },
-              { "name": "signatureDeadline", "type": "uint256" }
-            ]
-          }
-        },
-        {
-          "primaryType": "Comment",
-          "types": {
-            "Comment": [
-              { "name": "profileId", "type": "uint256" },
-              { "name": "contentURI", "type": "string" },
-              { "name": "pointedProfileId", "type": "uint256" },
-              { "name": "pointedPubId", "type": "uint256" },
-              { "name": "referrerProfileIds", "type": "uint256[]" },
-              { "name": "referrerPubIds", "type": "uint256[]" },
-              { "name": "referenceModuleData", "type": "bytes" },
-              { "name": "actionModules", "type": "address[]" },
-              { "name": "actionModulesInitDatas", "type": "bytes[]" },
-              { "name": "referenceModule", "type": "address" },
-              { "name": "referenceModuleInitData", "type": "bytes" },
-              { "name": "nonce", "type": "uint256" },
-              { "name": "deadline", "type": "uint256" }
-            ],
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ]
-          }
-        },
-        {
-          "primaryType": "comment_with_sign",
-          "types": {
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ],
-            "comment_with_sign": [
-              { "name": "profile_id", "type": "uint256" },
-              { "name": "profile_id_pointed", "type": "uint256" },
-              { "name": "pubid_pointed", "type": "uint256" },
-              { "name": "signatureDeadline", "type": "uint256" }
-            ]
-          }
-        },
-        {
-          "primaryType": "create_profile",
-          "types": {
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ],
-            "create_profile": [{ "name": "to", "type": "address" }, { "name": "followModule", "type": "address" }]
-          }
-        },
-        {
-          "primaryType": "Follow",
-          "types": {
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ],
-            "Follow": [
-              { "name": "followerProfileId", "type": "uint256" },
-              { "name": "idsOfProfilesToFollow", "type": "uint256[]" },
-              { "name": "followTokenIds", "type": "uint256[]" },
-              { "name": "datas", "type": "bytes[]" },
-              { "name": "nonce", "type": "uint256" },
-              { "name": "deadline", "type": "uint256" }
-            ]
-          }
-        },
-        {
-          "primaryType": "follow_with_sign",
-          "types": {
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ],
-            "follow_with_sign": [{ "name": "followerProfileId", "type": "uint256" }, { "name": "signatureDeadline", "type": "uint256" }]
-          }
-        },
-        {
-          "primaryType": "link",
-          "types": {
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ],
-            "link": [{ "name": "handle_id", "type": "uint256" }, { "name": "profile_id", "type": "uint256" }]
-          }
-        },
-        {
-          "primaryType": "link_with_sig",
-          "types": {
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ],
-            "link_with_sig": [
-              { "name": "handle_id", "type": "uint256" },
-              { "name": "profile_id", "type": "uint256" },
-              { "name": "signatureDeadline", "type": "uint256" }
-            ]
-          }
-        },
-        {
-          "primaryType": "mint",
-          "types": {
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ],
-            "mint": [
-              { "name": "to", "type": "uint256" },
-              { "name": "profile_id", "type": "uint256" },
-              { "name": "profile_id_pointed", "type": "uint256" },
-              { "name": "pubid_pointed", "type": "uint256" }
-            ]
-          }
-        },
-        {
-          "primaryType": "Mirror",
-          "types": {
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ],
-            "Mirror": [
-              { "name": "profileId", "type": "uint256" },
-              { "name": "metadataURI", "type": "string" },
-              { "name": "pointedProfileId", "type": "uint256" },
-              { "name": "pointedPubId", "type": "uint256" },
-              { "name": "referrerProfileIds", "type": "uint256[]" },
-              { "name": "referrerPubIds", "type": "uint256[]" },
-              { "name": "referenceModuleData", "type": "bytes" },
-              { "name": "nonce", "type": "uint256" },
-              { "name": "deadline", "type": "uint256" }
-            ]
-          }
-        },
-        {
-          "primaryType": "mirror_with_sig",
-          "types": {
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ],
-            "mirror_with_sig": [
-              { "name": "profile_id", "type": "uint256" },
-              { "name": "profile_id_pointed", "type": "uint256" },
-              { "name": "pubid_pointed", "type": "uint256" },
-              { "name": "signatureDeadline", "type": "uint256" }
-            ]
-          }
-        },
-        {
-          "primaryType": "Post",
-          "types": {
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ],
-            "Post": [
-              { "name": "profileId", "type": "uint256" },
-              { "name": "contentURI", "type": "string" },
-              { "name": "actionModules", "type": "address[]" },
-              { "name": "actionModulesInitDatas", "type": "bytes[]" },
-              { "name": "referenceModule", "type": "address" },
-              { "name": "referenceModuleInitData", "type": "bytes" },
-              { "name": "nonce", "type": "uint256" },
-              { "name": "deadline", "type": "uint256" }
-            ]
-          }
-        },
-        {
-          "primaryType": "post_with_sign",
-          "types": {
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ],
-            "post_with_sign": [{ "name": "profile_id", "type": "uint256" }, { "name": "signatureDeadline", "type": "uint256" }]
-          }
-        },
-        {
-          "primaryType": "Quote",
-          "types": {
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ],
-            "Quote": [
-              { "name": "profileId", "type": "uint256" },
-              { "name": "contentURI", "type": "string" },
-              { "name": "pointedProfileId", "type": "uint256" },
-              { "name": "pointedPubId", "type": "uint256" },
-              { "name": "nonce", "type": "uint256" },
-              { "name": "deadline", "type": "uint256" }
-            ]
-          }
-        },
-        {
-          "primaryType": "quote_with_sign",
-          "types": {
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ],
-            "quote_with_sign": [
-              { "name": "profile_id", "type": "uint256" },
-              { "name": "profile_id_pointed", "type": "uint256" },
-              { "name": "pubid_pointed", "type": "uint256" },
-              { "name": "signatureDeadline", "type": "uint256" }
-            ]
-          }
-        },
-        {
-          "primaryType": "set_block_status",
-          "types": {
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ],
-            "set_block_status": [{ "name": "byProfileId", "type": "uint256" }, { "name": "signatureDeadline", "type": "uint256" }]
-          }
-        },
-        {
-          "primaryType": "SetProfileMetadataURI",
-          "types": {
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ],
-            "SetProfileMetadataURI": [
-              { "name": "profileId", "type": "uint256" },
-              { "name": "metadataURI", "type": "string" },
-              { "name": "nonce", "type": "uint256" },
-              { "name": "deadline", "type": "uint256" }
-            ]
-          }
-        },
-        {
-          "primaryType": "set_block_status_with_sig",
-          "types": {
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ],
-            "set_block_status_with_sig": [{ "name": "byProfileId", "type": "uint256" }, { "name": "signatureDeadline", "type": "uint256" }]
-          }
-        },
-        {
-          "primaryType": "SetFollowModule",
-          "types": {
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ],
-            "SetFollowModule": [
-              { "name": "profileId", "type": "uint256" },
-              { "name": "followModule", "type": "address" },
-              { "name": "followModuleInitData", "type": "bytes" },
-              { "name": "nonce", "type": "uint256" },
-              { "name": "deadline", "type": "uint256" }
-            ]
-          }
-        },
-        {
-          "primaryType": "set_profile_metadata_with_sign",
-          "types": {
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ],
-            "set_profile_metadata_with_sign": [{ "name": "profileId", "type": "uint256" }, { "name": "signatureDeadline", "type": "uint256" }]
-          }
-        },
-        {
-          "primaryType": "Unfollow",
-          "types": {
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ],
-            "Unfollow": [
-              { "name": "unfollowerProfileId", "type": "uint256" },
-              { "name": "idsOfProfilesToUnfollow", "type": "uint256[]" },
-              { "name": "nonce", "type": "uint256" },
-              { "name": "deadline", "type": "uint256" }
-            ]
-          }
-        },
-        {
-          "primaryType": "unfollow_with_sign",
-          "types": {
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ],
-            "unfollow_with_sign": [{ "name": "unfollowerProfileId", "type": "uint256" }, { "name": "signatureDeadline", "type": "uint256" }]
-          }
-        }
-      ]
+      "domain": { "name": "Lens Protocol Profiles", "version": "2" }
     }
   },
   "metadata": { "owner": "LensHub" },
   "display": {
     "formats": {
-      "act": {
-        "intent": "act",
+      "Act(uint256 publicationActedProfileId,uint256 publicationActedId,uint256 actorProfileId,uint256[] referrerProfileIds,uint256[] referrerPubIds,address actionModuleAddress,bytes actionModuleData,uint256 nonce,uint256 deadline)": {
+        "intent": "Act",
         "fields": [
           { "path": "actorProfileId", "label": "actorProfileId", "format": "raw" },
           { "path": "publicationActedId", "label": "publicationActedId", "format": "raw" },
-          { "path": "publicationActedProfileId", "label": "publicationActedProfileId", "format": "raw" }
-        ],
-        "excluded": ["deadline", "actionModuleAddress", "referrerProfileIds.[]", "actionModuleData", "referrerPubIds.[]"]
+          { "path": "publicationActedProfileId", "label": "publicationActedProfileId", "format": "raw" },
+          { "label": "Deadline", "path": "deadline", "visible": "never" },
+          { "label": "Action Module Address", "path": "actionModuleAddress", "visible": "never" },
+          { "label": "Referrer Profile Ids", "path": "referrerProfileIds.[]", "visible": "never" },
+          { "label": "Action Module Data", "path": "actionModuleData", "visible": "never" },
+          { "label": "Referrer Pub Ids", "path": "referrerPubIds.[]", "visible": "never" }
+        ]
       },
-      "burn": { "intent": "burn", "fields": [{ "path": "tokenId", "label": "tokenId", "format": "raw" }] },
-      "ChangeDelegatedExecutorsConfig": {
+      "ChangeDelegatedExecutorsConfig(uint256 delegatorProfileId,address[] delegatedExecutors,bool[] approvals,uint64 configNumber,bool switchToGivenConfig,uint256 nonce,uint256 deadline)": {
         "intent": "ChangeDelegatedExecutorsConfig",
         "fields": [
           { "path": "delegatorProfileId", "label": "Delegator ProfileId", "format": "raw" },
@@ -455,86 +30,54 @@
           { "path": "approvals.[]", "label": "Approvals", "format": "raw" },
           { "path": "configNumber", "label": "configNumber", "format": "raw" },
           { "path": "switchToGivenConfig", "label": "switchToGivenConfig", "format": "raw" },
-          { "path": "nonce", "label": "nonce", "format": "raw" }
-        ],
-        "excluded": ["deadline"]
-      },
-      "collect": {
-        "intent": "collect",
-        "fields": [
-          { "path": "publicationCollectedProfileId", "label": "Publication Collected ProfileId", "format": "raw" },
-          { "path": "publicationCollectedId", "label": "Publication CollectedId", "format": "raw" },
-          { "path": "collectorProfileId", "label": "collector ProfileId", "format": "raw" }
+          { "path": "nonce", "label": "nonce", "format": "raw" },
+          { "label": "Deadline", "path": "deadline", "visible": "never" }
         ]
       },
-      "collect_with_sign": {
-        "intent": "collect_with_sign",
-        "fields": [
-          { "path": "publicationCollectedProfileId", "label": "publicationCollectedProfileId", "format": "raw" },
-          { "path": "publicationCollectedId", "label": "publicationCollectedId", "format": "raw" },
-          { "path": "collectorProfileId", "label": "collectorProfileId", "format": "raw" },
-          { "path": "signatureDeadline", "label": "signatureDeadline", "format": "raw" }
-        ]
-      },
-      "Comment": {
+      "Comment(uint256 profileId,string contentURI,uint256 pointedProfileId,uint256 pointedPubId,uint256[] referrerProfileIds,uint256[] referrerPubIds,bytes referenceModuleData,address[] actionModules,bytes[] actionModulesInitDatas,address referenceModule,bytes referenceModuleInitData,uint256 nonce,uint256 deadline)": {
         "intent": "Comment",
         "fields": [
           { "path": "profileId", "label": "Profile Id", "format": "raw" },
           { "path": "contentURI", "label": "content URI", "format": "raw" },
           { "path": "pointedProfileId", "label": "Pointed Profile Id", "format": "raw" },
           { "path": "pointedPubId", "label": "Pointed Pub Id", "format": "raw" },
-          { "path": "nonce", "label": "nonce", "format": "raw" }
-        ],
-        "excluded": [
-          "referenceModuleInitData",
-          "referenceModuleData",
-          "actionModules",
-          "deadline",
-          "referrerProfileIds",
-          "referenceModule",
-          "actionModulesInitDatas",
-          "referrerPubIds"
+          { "path": "nonce", "label": "nonce", "format": "raw" },
+          { "label": "Reference Module Init Data", "path": "referenceModuleInitData", "visible": "never" },
+          { "label": "Reference Module Data", "path": "referenceModuleData", "visible": "never" },
+          { "label": "Action Modules", "path": "actionModules", "visible": "never" },
+          { "label": "Deadline", "path": "deadline", "visible": "never" },
+          { "label": "Referrer Profile Ids", "path": "referrerProfileIds", "visible": "never" },
+          { "label": "Reference Module", "path": "referenceModule", "visible": "never" },
+          { "label": "Action Modules Init Datas", "path": "actionModulesInitDatas", "visible": "never" },
+          { "label": "Referrer Pub Ids", "path": "referrerPubIds", "visible": "never" }
         ]
       },
-      "comment_with_sign": {
-        "intent": "comment_with_sign",
-        "fields": [
-          { "path": "profile_id", "label": "profile_id", "format": "raw" },
-          { "path": "profile_id_pointed", "label": "profile_id_pointed", "format": "raw" },
-          { "path": "pubid_pointed", "label": "pubid_pointed", "format": "raw" },
-          { "path": "signatureDeadline", "label": "signatureDeadline", "format": "raw" }
-        ]
-      },
-      "create_profile": {
-        "intent": "create_profile",
-        "fields": [{ "path": "to", "label": "to", "format": "raw" }, { "path": "followModule", "label": "followModule", "format": "raw" }]
-      },
-      "Follow": {
+      "Follow(uint256 followerProfileId,uint256[] idsOfProfilesToFollow,uint256[] followTokenIds,bytes[] datas,uint256 nonce,uint256 deadline)": {
         "intent": "Follow",
         "fields": [
           { "path": "followerProfileId", "label": "follower ProfileId", "format": "raw" },
           { "path": "idsOfProfilesToFollow.[]", "label": "ids Of Profiles To Follow", "format": "raw" },
           { "path": "followTokenIds.[]", "label": "follow TokenIds", "format": "raw" },
           { "path": "datas.[]", "label": "datas", "format": "raw" },
-          { "path": "nonce", "label": "nonce", "format": "raw" }
-        ],
-        "excluded": ["deadline"]
+          { "path": "nonce", "label": "nonce", "format": "raw" },
+          { "label": "Deadline", "path": "deadline", "visible": "never" }
+        ]
       },
-      "follow_with_sign": {
+      "follow_with_sign(uint256 followerProfileId,uint256 signatureDeadline)": {
         "intent": "follow_with_sign",
         "fields": [
           { "path": "followerProfileId", "label": "followerProfileId", "format": "raw" },
           { "path": "signatureDeadline", "label": "signatureDeadline", "format": "raw" }
         ]
       },
-      "link": {
+      "link(uint256 handle_id,uint256 profile_id)": {
         "intent": "link",
         "fields": [
           { "path": "handle_id", "label": "handle_id", "format": "raw" },
           { "path": "profile_id", "label": "profile_id", "format": "raw" }
         ]
       },
-      "link_with_sig": {
+      "link_with_sig(uint256 handle_id,uint256 profile_id,uint256 signatureDeadline)": {
         "intent": "link_with_sig",
         "fields": [
           { "path": "handle_id", "label": "handle_id", "format": "raw" },
@@ -542,7 +85,7 @@
           { "path": "signatureDeadline", "label": "signatureDeadline", "format": "raw" }
         ]
       },
-      "mint": {
+      "mint(uint256 to,uint256 profile_id,uint256 profile_id_pointed,uint256 pubid_pointed)": {
         "intent": "mint",
         "fields": [
           { "path": "to", "label": "to", "format": "raw" },
@@ -551,17 +94,21 @@
           { "path": "pubid_pointed", "label": "pubid_pointed", "format": "raw" }
         ]
       },
-      "Mirror": {
+      "Mirror(uint256 profileId,string metadataURI,uint256 pointedProfileId,uint256 pointedPubId,uint256[] referrerProfileIds,uint256[] referrerPubIds,bytes referenceModuleData,uint256 nonce,uint256 deadline)": {
         "intent": "mirror",
         "fields": [
           { "path": "profileId", "label": "profileId", "format": "raw" },
           { "path": "metadataURI", "label": "metadataURI", "format": "raw" },
           { "path": "pointedProfileId", "label": "pointedProfileId", "format": "raw" },
-          { "path": "nonce", "label": "nonce", "format": "raw" }
-        ],
-        "excluded": ["deadline", "pointedPubId", "referenceModuleData", "referrerProfileIds", "referrerPubIds"]
+          { "path": "nonce", "label": "nonce", "format": "raw" },
+          { "label": "Deadline", "path": "deadline", "visible": "never" },
+          { "label": "Pointed Pub Id", "path": "pointedPubId", "visible": "never" },
+          { "label": "Reference Module Data", "path": "referenceModuleData", "visible": "never" },
+          { "label": "Referrer Profile Ids", "path": "referrerProfileIds", "visible": "never" },
+          { "label": "Referrer Pub Ids", "path": "referrerPubIds", "visible": "never" }
+        ]
       },
-      "mirror_with_sig": {
+      "mirror_with_sig(uint256 profile_id,uint256 profile_id_pointed,uint256 pubid_pointed,uint256 signatureDeadline)": {
         "intent": "mirror_with_sig",
         "fields": [
           { "path": "profile_id", "label": "profile_id", "format": "raw" },
@@ -570,23 +117,27 @@
           { "path": "signatureDeadline", "label": "signatureDeadline", "format": "raw" }
         ]
       },
-      "Post": {
+      "Post(uint256 profileId,string contentURI,address[] actionModules,bytes[] actionModulesInitDatas,address referenceModule,bytes referenceModuleInitData,uint256 nonce,uint256 deadline)": {
         "intent": "Post",
         "fields": [
           { "path": "profileId", "label": "Profile Id", "format": "raw" },
           { "path": "contentURI", "label": "Post URI", "format": "raw" },
-          { "path": "nonce", "label": "nonce", "format": "raw" }
-        ],
-        "excluded": ["referenceModuleInitData", "actionModules", "deadline", "referenceModule", "actionModulesInitDatas"]
+          { "path": "nonce", "label": "nonce", "format": "raw" },
+          { "label": "Reference Module Init Data", "path": "referenceModuleInitData", "visible": "never" },
+          { "label": "Action Modules", "path": "actionModules", "visible": "never" },
+          { "label": "Deadline", "path": "deadline", "visible": "never" },
+          { "label": "Reference Module", "path": "referenceModule", "visible": "never" },
+          { "label": "Action Modules Init Datas", "path": "actionModulesInitDatas", "visible": "never" }
+        ]
       },
-      "post_with_sign": {
+      "post_with_sign(uint256 profile_id,uint256 signatureDeadline)": {
         "intent": "post_with_sign",
         "fields": [
           { "path": "profile_id", "label": "profile_id", "format": "raw" },
           { "path": "signatureDeadline", "label": "signatureDeadline", "format": "raw" }
         ]
       },
-      "Quote": {
+      "Quote(uint256 profileId,string contentURI,uint256 pointedProfileId,uint256 pointedPubId,uint256 nonce,uint256 deadline)": {
         "intent": "Quote",
         "fields": [
           { "path": "profileId", "label": "profileId", "format": "raw" },
@@ -597,7 +148,7 @@
           { "path": "deadline", "label": "deadline", "format": "raw" }
         ]
       },
-      "quote_with_sign": {
+      "quote_with_sign(uint256 profile_id,uint256 profile_id_pointed,uint256 pubid_pointed,uint256 signatureDeadline)": {
         "intent": "quote_with_sign",
         "fields": [
           { "path": "profile_id", "label": "profile_id", "format": "raw" },
@@ -606,46 +157,47 @@
           { "path": "signatureDeadline", "label": "signatureDeadline", "format": "raw" }
         ]
       },
-      "set_block_status": {
+      "set_block_status(uint256 byProfileId,uint256 signatureDeadline)": {
         "intent": "set_block_status",
         "fields": [
           { "path": "byProfileId", "label": "byProfileId", "format": "raw" },
           { "path": "signatureDeadline", "label": "signatureDeadline", "format": "raw" }
         ]
       },
-      "SetProfileMetadataURI": {
+      "SetProfileMetadataURI(uint256 profileId,string metadataURI,uint256 nonce,uint256 deadline)": {
         "intent": "SetProfileMetadataURI",
         "fields": [
           { "path": "profileId", "label": "profileId", "format": "raw" },
           { "path": "metadataURI", "label": "metadataURI", "format": "raw" },
-          { "path": "nonce", "label": "nonce", "format": "raw" }
-        ],
-        "excluded": ["deadline"]
+          { "path": "nonce", "label": "nonce", "format": "raw" },
+          { "label": "Deadline", "path": "deadline", "visible": "never" }
+        ]
       },
-      "set_block_status_with_sig": {
+      "set_block_status_with_sig(uint256 byProfileId,uint256 signatureDeadline)": {
         "intent": "set_block_status_with_sig",
         "fields": [
           { "path": "byProfileId", "label": "byProfileId", "format": "raw" },
           { "path": "signatureDeadline", "label": "signatureDeadline", "format": "raw" }
         ]
       },
-      "SetFollowModule": {
+      "SetFollowModule(uint256 profileId,address followModule,bytes followModuleInitData,uint256 nonce,uint256 deadline)": {
         "intent": "Set Follow Module",
         "fields": [
           { "path": "profileId", "label": "profileId", "format": "raw" },
           { "path": "followModule", "label": "followModule", "format": "raw" },
-          { "path": "nonce", "label": "nonce", "format": "raw" }
-        ],
-        "excluded": ["deadline", "followModuleInitData"]
+          { "path": "nonce", "label": "nonce", "format": "raw" },
+          { "label": "Deadline", "path": "deadline", "visible": "never" },
+          { "label": "Follow Module Init Data", "path": "followModuleInitData", "visible": "never" }
+        ]
       },
-      "set_profile_metadata_with_sign": {
+      "set_profile_metadata_with_sign(uint256 profileId,uint256 signatureDeadline)": {
         "intent": "set_profile_metadata_with_sign",
         "fields": [
           { "path": "profileId", "label": "profileId", "format": "raw" },
           { "path": "signatureDeadline", "label": "signatureDeadline", "format": "raw" }
         ]
       },
-      "Unfollow": {
+      "Unfollow(uint256 unfollowerProfileId,uint256[] idsOfProfilesToUnfollow,uint256 nonce,uint256 deadline)": {
         "intent": "Unfollow",
         "fields": [
           { "path": "unfollowerProfileId", "label": "Unfollower ProfileId", "format": "raw" },
@@ -654,7 +206,7 @@
           { "path": "deadline", "label": "deadline", "format": "raw" }
         ]
       },
-      "unfollow_with_sign": {
+      "unfollow_with_sign(uint256 unfollowerProfileId,uint256 signatureDeadline)": {
         "intent": "unfollow_with_sign",
         "fields": [
           { "path": "unfollowerProfileId", "label": "unfollowerProfileId", "format": "raw" },

--- a/registry/lens/eip712-lens-token-handle-registry.json
+++ b/registry/lens/eip712-lens-token-handle-registry.json
@@ -1,50 +1,15 @@
 {
-  "$schema": "../../specs/erc7730-v1.schema.json",
+  "$schema": "../../specs/erc7730-v2.schema.json",
   "context": {
     "eip712": {
       "deployments": [{ "chainId": 137, "address": "0xd4f2f33680fccb36748fa9831851643781608844" }],
-      "domain": { "name": "Lens Protocol Profiles", "version": "2" },
-      "schemas": [
-        {
-          "primaryType": "unlink_with_sig",
-          "types": {
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ],
-            "unlink_with_sig": [
-              { "name": "handle_id", "type": "uint256" },
-              { "name": "profile_id", "type": "uint256" },
-              { "name": "signatureDeadline", "type": "uint256" }
-            ]
-          }
-        },
-        {
-          "primaryType": "unlink",
-          "types": {
-            "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
-            ],
-            "unlink": [
-              { "name": "handleId", "type": "uint256" },
-              { "name": "profileId", "type": "uint256" },
-              { "name": "nonce", "type": "uint256" },
-              { "name": "deadline", "type": "uint256" }
-            ]
-          }
-        }
-      ]
+      "domain": { "name": "Lens Protocol Profiles", "version": "2" }
     }
   },
   "metadata": { "owner": "TokenHandleRegistry" },
   "display": {
     "formats": {
-      "unlink_with_sig": {
+      "unlink_with_sig(uint256 handle_id,uint256 profile_id,uint256 signatureDeadline)": {
         "intent": "unlink_with_sig",
         "fields": [
           { "path": "handle_id", "label": "handle_id", "format": "raw" },
@@ -52,14 +17,14 @@
           { "path": "signatureDeadline", "label": "signatureDeadline", "format": "raw" }
         ]
       },
-      "unlink": {
+      "unlink(uint256 handleId,uint256 profileId,uint256 nonce,uint256 deadline)": {
         "intent": "unlink",
         "fields": [
           { "path": "handleId", "label": "handleId", "format": "raw" },
           { "path": "profileId", "label": "profileId", "format": "raw" },
-          { "path": "nonce", "label": "nonce", "format": "raw" }
-        ],
-        "excluded": ["deadline"]
+          { "path": "nonce", "label": "nonce", "format": "raw" },
+          { "label": "Deadline", "path": "deadline", "visible": "never" }
+        ]
       }
     }
   }

--- a/registry/lens/tests/eip712-lens-lenshub.tests.json
+++ b/registry/lens/tests/eip712-lens-lenshub.tests.json
@@ -1,0 +1,774 @@
+{
+  "$schema": "../../../specs/erc7730-tests.schema.json",
+  "tests": [
+    {
+      "description": "Act",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "Act": [
+            { "name": "publicationActedProfileId", "type": "uint256" },
+            { "name": "publicationActedId", "type": "uint256" },
+            { "name": "actorProfileId", "type": "uint256" },
+            { "name": "referrerProfileIds", "type": "uint256[]" },
+            { "name": "referrerPubIds", "type": "uint256[]" },
+            { "name": "actionModuleAddress", "type": "address" },
+            { "name": "actionModuleData", "type": "bytes" },
+            { "name": "nonce", "type": "uint256" },
+            { "name": "deadline", "type": "uint256" }
+          ]
+        },
+        "primaryType": "Act",
+        "domain": {
+          "name": "Lens Protocol Profiles",
+          "version": "2",
+          "chainId": 137,
+          "verifyingContract": "0xDb46d1Dc155634FbC732f92E853b10B288AD5a1d"
+        },
+        "message": {
+          "publicationActedProfileId": 412876,
+          "publicationActedId": 27,
+          "actorProfileId": 589332,
+          "referrerProfileIds": [412876, 401245],
+          "referrerPubIds": [26, 19],
+          "actionModuleAddress": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+          "actionModuleData": "0x0000000000000000000000002791bca1f2de4661ed88a30c99a7a9449aa8417400000000000000000000000000000000000000000000000000000000000f4240",
+          "nonce": 128,
+          "deadline": 1782864000
+        }
+      },
+      "expectedTexts": ["publicationActedProfileId", "412876", "publicationActedId", "27", "actorProfileId", "589332"]
+    },
+    {
+      "description": "ChangeDelegatedExecutorsConfig",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "ChangeDelegatedExecutorsConfig": [
+            { "name": "delegatorProfileId", "type": "uint256" },
+            { "name": "delegatedExecutors", "type": "address[]" },
+            { "name": "approvals", "type": "bool[]" },
+            { "name": "configNumber", "type": "uint64" },
+            { "name": "switchToGivenConfig", "type": "bool" },
+            { "name": "nonce", "type": "uint256" },
+            { "name": "deadline", "type": "uint256" }
+          ]
+        },
+        "primaryType": "ChangeDelegatedExecutorsConfig",
+        "domain": {
+          "name": "Lens Protocol Profiles",
+          "version": "2",
+          "chainId": 137,
+          "verifyingContract": "0xdb46d1dc155634fbc732f92e853b10b288ad5a1d"
+        },
+        "message": {
+          "delegatorProfileId": 84521,
+          "delegatedExecutors": [
+            "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+            "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
+            "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270"
+          ],
+          "approvals": [true, false, true],
+          "configNumber": 4,
+          "switchToGivenConfig": true,
+          "nonce": 12,
+          "deadline": 1776677136
+        }
+      },
+      "expectedTexts": [
+        "Delegator ProfileId",
+        "84521",
+        "Delegated Executors",
+        "0x2791Bca1f2de4661E D88A30C99A7a9449A a84174 Delegated Executors 0x7ceB23fD6bC0adD5 9E62ac25578270cFf1b 9f619",
+        "Delegated Executors",
+        "0x0d500B1d8E8eF31E2 1C99d1Db9A6444d3A Df1270",
+        "Approvals",
+        "true Approvals false",
+        "Approvals",
+        "true",
+        "configNumber",
+        "4",
+        "switchToGivenConfig",
+        "true",
+        "nonce",
+        "12"
+      ]
+    },
+    {
+      "description": "Comment",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "Comment": [
+            { "name": "profileId", "type": "uint256" },
+            { "name": "contentURI", "type": "string" },
+            { "name": "pointedProfileId", "type": "uint256" },
+            { "name": "pointedPubId", "type": "uint256" },
+            { "name": "referrerProfileIds", "type": "uint256[]" },
+            { "name": "referrerPubIds", "type": "uint256[]" },
+            { "name": "referenceModuleData", "type": "bytes" },
+            { "name": "actionModules", "type": "address[]" },
+            { "name": "actionModulesInitDatas", "type": "bytes[]" },
+            { "name": "referenceModule", "type": "address" },
+            { "name": "referenceModuleInitData", "type": "bytes" },
+            { "name": "nonce", "type": "uint256" },
+            { "name": "deadline", "type": "uint256" }
+          ]
+        },
+        "primaryType": "Comment",
+        "domain": {
+          "name": "Lens Protocol Profiles",
+          "version": "2",
+          "chainId": 137,
+          "verifyingContract": "0xdb46d1dc155634fbc732f92e853b10b288ad5a1d"
+        },
+        "message": {
+          "profileId": "48291",
+          "contentURI": "ipfs://bafybeid7f4m4n7vxxtdh6x2f5w4jv3l2t5n6k2k3x4v5z6y7a8b9c0d1e2",
+          "pointedProfileId": "10987",
+          "pointedPubId": "42",
+          "referrerProfileIds": ["10201", "22117"],
+          "referrerPubIds": ["88", "13"],
+          "referenceModuleData": "0x",
+          "actionModules": ["0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174", "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619"],
+          "actionModulesInitDatas": ["0x", "0x"],
+          "referenceModule": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          "referenceModuleInitData": "0x",
+          "nonce": "17",
+          "deadline": "1798761600"
+        }
+      },
+      "expectedTexts": [
+        "Profile Id",
+        "48291",
+        "content URI",
+        "ipfs://bafybeid7f4m4n7 vxxtdh6x2f5w4jv3l2t5n 6k2k3x4v5z6y7a8b9c0 d1e2",
+        "Pointed Profile Id",
+        "Profile Id",
+        "10987",
+        "Pointed Pub Id",
+        "42",
+        "nonce",
+        "17"
+      ]
+    },
+    {
+      "description": "Follow",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "Follow": [
+            { "name": "followerProfileId", "type": "uint256" },
+            { "name": "idsOfProfilesToFollow", "type": "uint256[]" },
+            { "name": "followTokenIds", "type": "uint256[]" },
+            { "name": "datas", "type": "bytes[]" },
+            { "name": "nonce", "type": "uint256" },
+            { "name": "deadline", "type": "uint256" }
+          ]
+        },
+        "primaryType": "Follow",
+        "domain": {
+          "name": "Lens Protocol Profiles",
+          "version": "2",
+          "chainId": 137,
+          "verifyingContract": "0xdb46d1dc155634fbc732f92e853b10b288ad5a1d"
+        },
+        "message": {
+          "followerProfileId": "84521",
+          "idsOfProfilesToFollow": ["12", "1043"],
+          "followTokenIds": ["0", "0"],
+          "datas": ["0x", "0x"],
+          "nonce": "27",
+          "deadline": "1777680000"
+        }
+      },
+      "expectedTexts": [
+        "follower ProfileId",
+        "84521",
+        "ids Of Profiles To Follow",
+        "12",
+        "ids Of Profiles To Follow",
+        "1043",
+        "follow TokenIds",
+        "0 follow TokenIds 0",
+        "datas",
+        "0x",
+        "datas",
+        "0x",
+        "nonce",
+        "27"
+      ]
+    },
+    {
+      "description": "follow_with_sign",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "follow_with_sign": [{ "name": "followerProfileId", "type": "uint256" }, { "name": "signatureDeadline", "type": "uint256" }]
+        },
+        "primaryType": "follow_with_sign",
+        "domain": {
+          "name": "Lens Protocol Profiles",
+          "version": "2",
+          "chainId": 137,
+          "verifyingContract": "0xDb46d1Dc155634FbC732f92E853b10B288AD5a1d"
+        },
+        "message": { "followerProfileId": "842197", "signatureDeadline": "1776643200" }
+      },
+      "expectedTexts": ["followerProfileId", "842197", "signatureDeadline", "1776643200"]
+    },
+    {
+      "description": "link",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "link": [{ "name": "handle_id", "type": "uint256" }, { "name": "profile_id", "type": "uint256" }]
+        },
+        "primaryType": "link",
+        "domain": {
+          "name": "Lens Protocol Profiles",
+          "version": "2",
+          "chainId": 137,
+          "verifyingContract": "0xDb46d1Dc155634FbC732f92E853b10B288AD5a1d"
+        },
+        "message": { "handle_id": 184467, "profile_id": 93211 }
+      },
+      "expectedTexts": ["handle_id", "184467", "profile_id", "93211"]
+    },
+    {
+      "description": "link_with_sig",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "link_with_sig": [
+            { "name": "handle_id", "type": "uint256" },
+            { "name": "profile_id", "type": "uint256" },
+            { "name": "signatureDeadline", "type": "uint256" }
+          ]
+        },
+        "primaryType": "link_with_sig",
+        "domain": {
+          "name": "Lens Protocol Profiles",
+          "version": "2",
+          "chainId": 137,
+          "verifyingContract": "0xDb46d1Dc155634FbC732f92E853b10B288AD5a1d"
+        },
+        "message": { "handle_id": 1045123, "profile_id": 1045098, "signatureDeadline": 1776643200 }
+      },
+      "expectedTexts": ["handle_id", "1045123", "profile_id", "1045098"]
+    },
+    {
+      "description": "mint",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "mint": [
+            { "name": "to", "type": "uint256" },
+            { "name": "profile_id", "type": "uint256" },
+            { "name": "profile_id_pointed", "type": "uint256" },
+            { "name": "pubid_pointed", "type": "uint256" }
+          ]
+        },
+        "primaryType": "mint",
+        "domain": {
+          "name": "Lens Protocol Profiles",
+          "version": "2",
+          "chainId": 137,
+          "verifyingContract": "0xdb46d1dc155634fbc732f92e853b10b288ad5a1d"
+        },
+        "message": { "to": "1845210", "profile_id": "512944", "profile_id_pointed": "509102", "pubid_pointed": "73" }
+      },
+      "expectedTexts": [
+        "to",
+        "review",
+        "to",
+        "review",
+        "to",
+        "1845210",
+        "profile_id",
+        "512944",
+        "profile_id",
+        "profile_id_pointed",
+        "509102",
+        "pubid_pointed",
+        "73",
+        "to"
+      ]
+    },
+    {
+      "description": "mirror",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "Mirror": [
+            { "name": "profileId", "type": "uint256" },
+            { "name": "metadataURI", "type": "string" },
+            { "name": "pointedProfileId", "type": "uint256" },
+            { "name": "pointedPubId", "type": "uint256" },
+            { "name": "referrerProfileIds", "type": "uint256[]" },
+            { "name": "referrerPubIds", "type": "uint256[]" },
+            { "name": "referenceModuleData", "type": "bytes" },
+            { "name": "nonce", "type": "uint256" },
+            { "name": "deadline", "type": "uint256" }
+          ]
+        },
+        "primaryType": "Mirror",
+        "domain": {
+          "name": "Lens Protocol Profiles",
+          "version": "2",
+          "chainId": 137,
+          "verifyingContract": "0xDb46D1dC155634fBC732f92E853b10B288aD5A1D"
+        },
+        "message": {
+          "profileId": 845321,
+          "metadataURI": "ipfs://bafkreifx2w4m6p7v3k9n2q8s5t1y0z7c4u6e8r9a1b3d5f7h9j0k2l4m",
+          "pointedProfileId": 112233,
+          "pointedPubId": 57,
+          "referrerProfileIds": [445566, 778899],
+          "referrerPubIds": [12, 34],
+          "referenceModuleData": "0x",
+          "nonce": 19,
+          "deadline": 1785168000
+        }
+      },
+      "expectedTexts": [
+        "profileId",
+        "845321",
+        "metadataURI",
+        "ipfs://bafkreifx2w4m6p 7v3k9n2q8s5t1y0z7c4u 6e8r9a1b3d5f7h9j0k2l 4m",
+        "pointedProfileId",
+        "112233",
+        "nonce",
+        "19"
+      ]
+    },
+    {
+      "description": "mirror_with_sig",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "mirror_with_sig": [
+            { "name": "profile_id", "type": "uint256" },
+            { "name": "profile_id_pointed", "type": "uint256" },
+            { "name": "pubid_pointed", "type": "uint256" },
+            { "name": "signatureDeadline", "type": "uint256" }
+          ]
+        },
+        "primaryType": "mirror_with_sig",
+        "domain": {
+          "name": "Lens Protocol Profiles",
+          "version": "2",
+          "chainId": 137,
+          "verifyingContract": "0xDb46d1Dc155634FbC732f92E853b10B288AD5a1d"
+        },
+        "message": { "profile_id": 845321, "profile_id_pointed": 712004, "pubid_pointed": 43, "signatureDeadline": 1779321600 }
+      },
+      "expectedTexts": ["Deadline", "1779321600"]
+    },
+    {
+      "description": "Post",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "Post": [
+            { "name": "profileId", "type": "uint256" },
+            { "name": "contentURI", "type": "string" },
+            { "name": "actionModules", "type": "address[]" },
+            { "name": "actionModulesInitDatas", "type": "bytes[]" },
+            { "name": "referenceModule", "type": "address" },
+            { "name": "referenceModuleInitData", "type": "bytes" },
+            { "name": "nonce", "type": "uint256" },
+            { "name": "deadline", "type": "uint256" }
+          ]
+        },
+        "primaryType": "Post",
+        "domain": {
+          "name": "Lens Protocol Profiles",
+          "version": "2",
+          "chainId": 137,
+          "verifyingContract": "0xDb46d1Dc155634Fbc732f92E853b10B288Ad5A1d"
+        },
+        "message": {
+          "profileId": 42817,
+          "contentURI": "ipfs://bafybeid5n5x7m2z4j4q4s5j2xjv4f4m2j3mq6y7f7z3e6x2h6z4f2u3m3a/metadata.json",
+          "actionModules": [],
+          "actionModulesInitDatas": [],
+          "referenceModule": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+          "referenceModuleInitData": "0x",
+          "nonce": 12,
+          "deadline": 1776681600
+        }
+      },
+      "expectedTexts": [
+        "Profile Id",
+        "42817",
+        "Post URI",
+        "ipfs://bafybeid5n5x7m2 z4j4q4s5j2xjv4f4m2j3 mq6y7f7z3e6x2h6z4f2 u3m3a/metadata.json",
+        "nonce",
+        "12"
+      ]
+    },
+    {
+      "description": "post_with_sign",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "post_with_sign": [{ "name": "profile_id", "type": "uint256" }, { "name": "signatureDeadline", "type": "uint256" }]
+        },
+        "primaryType": "post_with_sign",
+        "domain": {
+          "name": "Lens Protocol Profiles",
+          "version": "2",
+          "chainId": 137,
+          "verifyingContract": "0xdb46d1dc155634fbc732f92e853b10b288ad5a1d"
+        },
+        "message": { "profile_id": 735421, "signatureDeadline": 1776643200 }
+      },
+      "expectedTexts": ["profile_id", "735421", "signatureDeadline", "1776643200"]
+    },
+    {
+      "description": "Quote",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "Quote": [
+            { "name": "profileId", "type": "uint256" },
+            { "name": "contentURI", "type": "string" },
+            { "name": "pointedProfileId", "type": "uint256" },
+            { "name": "pointedPubId", "type": "uint256" },
+            { "name": "nonce", "type": "uint256" },
+            { "name": "deadline", "type": "uint256" }
+          ]
+        },
+        "primaryType": "Quote",
+        "domain": {
+          "name": "Lens Protocol Profiles",
+          "version": "2",
+          "chainId": 137,
+          "verifyingContract": "0xdb46d1dc155634fbc732f92e853b10b288ad5a1d"
+        },
+        "message": {
+          "profileId": 84291,
+          "contentURI": "ipfs://bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku",
+          "pointedProfileId": 21841,
+          "pointedPubId": 57,
+          "nonce": 19,
+          "deadline": 1779321600
+        }
+      },
+      "expectedTexts": [
+        "profileId",
+        "84291",
+        "contentURI",
+        "ipfs://bafkreihdwdcefgh 4dqkjv67uzcmw7ojee6 xedzdetojuzjevtenxquv yku",
+        "pointedProfileId",
+        "21841",
+        "pointedPubId",
+        "57",
+        "nonce",
+        "19",
+        "deadline",
+        "1779321600"
+      ]
+    },
+    {
+      "description": "quote_with_sign",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "quote_with_sign": [
+            { "name": "profile_id", "type": "uint256" },
+            { "name": "profile_id_pointed", "type": "uint256" },
+            { "name": "pubid_pointed", "type": "uint256" },
+            { "name": "signatureDeadline", "type": "uint256" }
+          ]
+        },
+        "primaryType": "quote_with_sign",
+        "domain": {
+          "name": "Lens Protocol Profiles",
+          "version": "2",
+          "chainId": 137,
+          "verifyingContract": "0xdb46d1dc155634fbc732f92e853b10b288ad5a1d"
+        },
+        "message": { "profile_id": 482913, "profile_id_pointed": 136204, "pubid_pointed": 27, "signatureDeadline": 1781913600 }
+      },
+      "expectedTexts": ["profile_id", "482913", "profile_id_pointed", "136204", "pubid_pointed", "27", "signatureDeadline", "1781913600"]
+    },
+    {
+      "description": "set_block_status",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "set_block_status": [{ "name": "byProfileId", "type": "uint256" }, { "name": "signatureDeadline", "type": "uint256" }]
+        },
+        "primaryType": "set_block_status",
+        "domain": {
+          "name": "Lens Protocol Profiles",
+          "version": "2",
+          "chainId": 137,
+          "verifyingContract": "0xdb46d1dc155634fbc732f92e853b10b288ad5a1d"
+        },
+        "message": { "byProfileId": "845211", "signatureDeadline": "1777699200" }
+      },
+      "expectedTexts": ["byProfileId", "845211", "signatureDeadline", "1777699200"]
+    },
+    {
+      "description": "SetProfileMetadataURI",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "SetProfileMetadataURI": [
+            { "name": "profileId", "type": "uint256" },
+            { "name": "metadataURI", "type": "string" },
+            { "name": "nonce", "type": "uint256" },
+            { "name": "deadline", "type": "uint256" }
+          ]
+        },
+        "primaryType": "SetProfileMetadataURI",
+        "domain": {
+          "name": "Lens Protocol Profiles",
+          "version": "2",
+          "chainId": 137,
+          "verifyingContract": "0xDb46d1Dc155634Fbc732f92E853b10B288Ad5A1d"
+        },
+        "message": {
+          "profileId": 482913,
+          "metadataURI": "ipfs://bafybeid5n5x7m2z4j4q4s5j2xjv4f4m2j3mq6y7f7z3e6x2h6z4f2u3m3a",
+          "nonce": 27,
+          "deadline": 1782864000
+        }
+      },
+      "expectedTexts": [
+        "profileId",
+        "482913",
+        "metadataURI",
+        "ipfs://bafybeid5n5x7m2 z4j4q4s5j2xjv4f4m2j3 mq6y7f7z3e6x2h6z4f2 u3m3a",
+        "nonce",
+        "27"
+      ]
+    },
+    {
+      "description": "set_block_status_with_sig",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "set_block_status_with_sig": [{ "name": "byProfileId", "type": "uint256" }, { "name": "signatureDeadline", "type": "uint256" }]
+        },
+        "primaryType": "set_block_status_with_sig",
+        "domain": {
+          "name": "Lens Protocol Profiles",
+          "version": "2",
+          "chainId": 137,
+          "verifyingContract": "0xDb46d1Dc155634FbC732f92E853b10B288AD5a1d"
+        },
+        "message": { "byProfileId": "84521", "signatureDeadline": "1776672000" }
+      },
+      "expectedTexts": ["byProfileId", "84521", "signatureDeadline", "1776672000"]
+    },
+    {
+      "description": "Set Follow Module",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "SetFollowModule": [
+            { "name": "profileId", "type": "uint256" },
+            { "name": "followModule", "type": "address" },
+            { "name": "followModuleInitData", "type": "bytes" },
+            { "name": "nonce", "type": "uint256" },
+            { "name": "deadline", "type": "uint256" }
+          ]
+        },
+        "primaryType": "SetFollowModule",
+        "domain": {
+          "name": "Lens Protocol Profiles",
+          "version": "2",
+          "chainId": 137,
+          "verifyingContract": "0xdb46d1dc155634fbc732f92e853b10b288ad5a1d"
+        },
+        "message": {
+          "profileId": 128472,
+          "followModule": "0x794a61358D6845594F94dc1DB02A252b5b4814aD",
+          "followModuleInitData": "0x",
+          "nonce": 42,
+          "deadline": 1782864000
+        }
+      },
+      "expectedTexts": ["nonce", "42"]
+    },
+    {
+      "description": "set_profile_metadata_with_sign",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "set_profile_metadata_with_sign": [{ "name": "profileId", "type": "uint256" }, { "name": "signatureDeadline", "type": "uint256" }]
+        },
+        "primaryType": "set_profile_metadata_with_sign",
+        "domain": {
+          "name": "Lens Protocol Profiles",
+          "version": "2",
+          "chainId": 137,
+          "verifyingContract": "0xdb46d1dc155634fbc732f92e853b10b288ad5a1d"
+        },
+        "message": { "profileId": 42817, "signatureDeadline": 1776686400 }
+      },
+      "expectedTexts": ["profileId", "42817", "signatureDeadline", "1776686400"]
+    },
+    {
+      "description": "Unfollow",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "Unfollow": [
+            { "name": "unfollowerProfileId", "type": "uint256" },
+            { "name": "idsOfProfilesToUnfollow", "type": "uint256[]" },
+            { "name": "nonce", "type": "uint256" },
+            { "name": "deadline", "type": "uint256" }
+          ]
+        },
+        "primaryType": "Unfollow",
+        "domain": {
+          "name": "Lens Protocol Profiles",
+          "version": "2",
+          "chainId": 137,
+          "verifyingContract": "0xDb46d1Dc155634FbC732f92E853b10B288AD5a1d"
+        },
+        "message": { "unfollowerProfileId": 48219, "idsOfProfilesToUnfollow": [9182, 22451, 77604], "nonce": 17, "deadline": 1779273600 }
+      },
+      "expectedTexts": [
+        "Unfollower ProfileId",
+        "48219",
+        "ids Of Profiles To Unfollow",
+        "9182",
+        "ids Of Profiles To Unfollow",
+        "22451 ids Of Profiles To Unfollow 77604",
+        "nonce",
+        "17",
+        "deadline",
+        "1779273600"
+      ]
+    },
+    {
+      "description": "unfollow_with_sign",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "unfollow_with_sign": [{ "name": "unfollowerProfileId", "type": "uint256" }, { "name": "signatureDeadline", "type": "uint256" }]
+        },
+        "primaryType": "unfollow_with_sign",
+        "domain": {
+          "name": "Lens Protocol Profiles",
+          "version": "2",
+          "chainId": 137,
+          "verifyingContract": "0xDb46d1Dc155634FbC732f92E853b10B288AD5a1d"
+        },
+        "message": { "unfollowerProfileId": 482193, "signatureDeadline": 1779321600 }
+      },
+      "expectedTexts": ["followerProfileId", "482193", "signatureDeadline", "1779321600"]
+    }
+  ]
+}

--- a/registry/lens/tests/eip712-lens-token-handle-registry.tests.json
+++ b/registry/lens/tests/eip712-lens-token-handle-registry.tests.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "../../../specs/erc7730-tests.schema.json",
+  "tests": [
+    {
+      "description": "unlink_with_sig",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "unlink_with_sig": [
+            { "name": "handle_id", "type": "uint256" },
+            { "name": "profile_id", "type": "uint256" },
+            { "name": "signatureDeadline", "type": "uint256" }
+          ]
+        },
+        "primaryType": "unlink_with_sig",
+        "domain": { "name": "Example", "version": "1", "chainId": 137, "verifyingContract": "0xd4f2f33680fccb36748fa9831851643781608844" },
+        "message": { "handle_id": "1000000000000000000", "profile_id": "1000000000000000000", "signatureDeadline": "1000000000000000000" }
+      },
+      "expectedTexts": ["handle_id", "100000000000000000 0", "profile_id", "100000000000000000 0", "signatureDeadline", "100000000000000000 0"]
+    },
+    {
+      "description": "unlink",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "unlink": [
+            { "name": "handleId", "type": "uint256" },
+            { "name": "profileId", "type": "uint256" },
+            { "name": "nonce", "type": "uint256" },
+            { "name": "deadline", "type": "uint256" }
+          ]
+        },
+        "primaryType": "unlink",
+        "domain": {
+          "name": "Lens Protocol Profiles",
+          "version": "2",
+          "chainId": 137,
+          "verifyingContract": "0xD4F2F33680FCCb36748FA9831851643781608844"
+        },
+        "message": { "handleId": "904217", "profileId": "129381", "nonce": "12", "deadline": "1777449600" }
+      },
+      "expectedTexts": ["handleId", "904217", "profileId", "129381", "nonce", "12"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR contains batch updates for `lens` in the registry.

### Changes Made

- **Schema Migrations**: Migrated 2 files from ERC-7730 v1 to v2 schema
- **Test Generation**: Generated 2 new test files with device-verified `expectedTexts`
- **Fix**: Corrected `act` type name casing to `Act` (matching on-chain typehash)
- **Fix**: Removed 5 invalid EIP-712 message types from `eip712-lens-lenshub.json` (see notes)

### Modified Files

- `registry/lens/eip712-lens-lenshub.json`
- `registry/lens/eip712-lens-token-handle-registry.json`

### New Files

- `registry/lens/tests/eip712-lens-lenshub.tests.json`
- `registry/lens/tests/eip712-lens-token-handle-registry.tests.json`

### Validation Status

| Check | Status |
|-------|--------|
| Schema Migration | ✅ Passed |
| Test Generation — eip712-lens-lenshub | ✅ Passed (21/21 clear signed) |
| Test Generation — eip712-lens-token-handle-registry | ✅ Passed (2/2 clear signed) |

### Notes — Removed Invalid Message Types

The following 5 message types were removed from `eip712-lens-lenshub.json` because they are **not real EIP-712 types** in the LensHub contract (`0xdb46d1dc155634fbc732f92e853b10b288ad5a1d` on Polygon). Verified against the on-chain `Typehash.sol` source:

| Removed Type | Reason |
|---|---|
| `burn(uint256 tokenId)` | Regular ERC-721 function, not an EIP-712 signed message. No `Burn` typehash exists in the contract. |
| `collect(uint256 publicationCollectedProfileId,...)` | Wrong type name and missing fields. Real on-chain type is `CollectLegacy(...)` with 7 fields (this had 3). |
| `collect_with_sign(...)` | Fabricated type name. The `collectWithSig` function uses the `CollectLegacy` typehash internally. |
| `comment_with_sign(...)` | Fabricated type name with snake_case fields. The real `Comment(...)` type (13 fields) is already in the descriptor. |
| `create_profile(address to,address followModule)` | Regular governance function, not an EIP-712 signed message. No `CreateProfile` typehash exists in the contract. |

Additionally, the `act(...)` type was renamed to `Act(...)` — the on-chain typehash uses `Act` (PascalCase) but the v1 descriptor had `act` (lowercase), causing a typehash mismatch and blind signing.

### Test Plan

- [ ] Review migrated schema files
- [ ] Review generated test files
- [ ] Run CI checks


Made with [Cursor](https://cursor.com)