### PR TITLE
fix: allow  on display references

### DIFF
--- a/specs/erc-7730.md
+++ b/specs/erc-7730.md
@@ -718,6 +718,7 @@ each key name is a [path](#path-references) in the structured data,
 `fields` is an array of elements, each element being either:
   * A single [*field format specification*](#field-format-specification)
   * A reference to a format specification in the `definitions` section: by declaring an object with two keys, a `path` key with the [path](#path-references) to the field being formatted, and a `$ref` key with a path to the internal definition. 
+    * A reference object can also carry an optional internal `$id` used to identify the field override
     * A reference object can override a field format specification `params` by including its own `params` sub-key, whose values will take precedence over the common definition
   * A recursive [*structured data format specification*](#structured-data-format-specification), by declaring an object with two keys, a `path` key with the [path](#path-references) to the field(s) being formatted, and a `fields` with the recursive list of sub-fields. 
 

--- a/specs/erc7730-v2.schema.json
+++ b/specs/erc7730-v2.schema.json
@@ -466,6 +466,9 @@
             "title": "Reference",
             "description": "A reference to a shared definition that should be used as the field formatting definition. The value is the key in the display definitions section, as a path expression $.display.definitions.DEFINITION_NAME. It is used to share definitions between multiple messages / functions.",
             "properties": {
+                "$id": {
+                    "$ref": "#/$definitions/id"
+                },
                 "path": {
                     "$ref": "#/$format/path"
                 },


### PR DESCRIPTION
## Summary
- allow optional `$id` on `display.reference` entries in `specs/erc7730-v2.schema.json`
- document in `specs/erc-7730.md` that reference overrides may carry an internal `$id`
- fix validation for descriptors that reuse a shared definition while assigning a field-level identifier

## Test plan
- [x] Parse `specs/erc7730-v2.schema.json` with Python `json.loads`
- [ ] Validate a descriptor using a reference override with both `$ref` and `$id`


Made with [Cursor](https://cursor.com)