### PR TITLE
ci: use Github public runners

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,7 +3,7 @@ name: 🤖 format descriptors
 
 on:
   schedule:
-    - cron: '0 7 * * *'
+    - cron: "0 7 * * *"
   workflow_dispatch:
 
 permissions:
@@ -19,10 +19,9 @@ env:
 jobs:
   format:
     name: format descriptors
-    runs-on: public-ledgerhq-shared-small
+    runs-on: unbuntu-latest
     timeout-minutes: 60
     steps:
-
       - name: Checkout
         timeout-minutes: 10
         uses: actions/checkout@v6
@@ -35,20 +34,12 @@ jobs:
         timeout-minutes: 10
         uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
-          cache: 'pip'
-
-      - name: Login to Ledger JFrog
-        timeout-minutes: 10
-        uses: LedgerHQ/actions-security/actions/jfrog-login@actions/jfrog-login-1
-
-      - name: Setup pip
-        timeout-minutes: 10
-        run: jf pipc --global --repo-resolve=virtual-pypi-prod-green
+          python-version: "3.12"
+          cache: "pip"
 
       - name: Install ERC-7730 library
         timeout-minutes: 10
-        run: jf pip install erc7730
+        run: pip install erc7730
 
       - name: Format ERC-7730 descriptors
         timeout-minutes: 10
@@ -71,8 +62,8 @@ jobs:
           branch: ${{ env.BRANCH }}-format-descriptors
           base: ${{ env.BRANCH }}
           delete-branch: false
-          commit-message: 'chore: format descriptors - ${{ env.CURRENT_DATE }}'
-          title: 'chore: format descriptors - ${{ env.CURRENT_DATE }}'
+          commit-message: "chore: format descriptors - ${{ env.CURRENT_DATE }}"
+          title: "chore: format descriptors - ${{ env.CURRENT_DATE }}"
           body: ${{ steps.submodules.outputs.prBody }}
           draft: false
           signoff: false

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -6,7 +6,7 @@ on:
       - master
       - demo
     paths-ignore:
-      - 'developer-preview/**'
+      - "developer-preview/**"
 
 permissions:
   id-token: write
@@ -21,10 +21,9 @@ env:
 jobs:
   validate_descriptors:
     name: 🔎 validate descriptors
-    runs-on: public-ledgerhq-shared-small
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-
       - name: Checkout
         timeout-minutes: 10
         uses: actions/checkout@v6
@@ -33,31 +32,23 @@ jobs:
         timeout-minutes: 10
         uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
-          cache: 'pip'
-
-      - name: Login to Ledger JFrog
-        timeout-minutes: 10
-        uses: LedgerHQ/actions-security/actions/jfrog-login@actions/jfrog-login-1
-
-      - name: Setup pip
-        timeout-minutes: 10
-        run: jf pipc --global --repo-resolve=virtual-pypi-prod-green
+          python-version: "3.12"
+          cache: "pip"
 
       - name: Install ERC-7730 library
         timeout-minutes: 10
-        run: jf pip install erc7730
+        run: pip install erc7730
 
       - name: Validate ERC-7730 descriptors
         timeout-minutes: 10
         run: erc7730 lint registry --gha
 
+  # TODO: To be removed once the registry ownership is transferred
   update_cal:
     name: 🔁 trigger updates
-    runs-on: public-ledgerhq-shared-small
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-
       - name: Trigger update on LedgerHQ/crypto-assets
         if: ${{ !cancelled() }}
         timeout-minutes: 60

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -3,7 +3,7 @@ name: ✨ pull request
 on:
   pull_request:
     paths-ignore:
-      - 'developer-preview/**'
+      - "developer-preview/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,10 +15,9 @@ env:
 jobs:
   validate_descriptors:
     name: 🔎 validate descriptors
-    runs-on: public-ledgerhq-shared-small
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-
       - name: Checkout
         timeout-minutes: 10
         uses: actions/checkout@v6
@@ -38,8 +37,8 @@ jobs:
         if: steps.changed-descriptor-files.outputs.any_changed == 'true'
         uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
-          cache: 'pip'
+          python-version: "3.12"
+          cache: "pip"
 
       - name: Install ERC-7730 library
         timeout-minutes: 10

--- a/.github/workflows/pull_request_setup.yml
+++ b/.github/workflows/pull_request_setup.yml
@@ -14,10 +14,9 @@ concurrency:
 jobs:
   setup_pull_request:
     name: 🤖 setup pull request
-    runs-on: public-ledgerhq-shared-small
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-
       - name: Checkout
         timeout-minutes: 10
         uses: actions/checkout@v6


### PR DESCRIPTION
There is no remaining reason to use Ledger runners for this repository workflow