### PR TITLE
ci: add upstream spec sync workflow and JSON schema validation on PR

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -51,3 +51,83 @@ jobs:
         env:
           CHANGED_FILES: ${{ steps.changed-descriptor-files.outputs.all_changed_files }}
         run: erc7730 lint $CHANGED_FILES --gha
+
+  validate_schemas:
+    name: 🔎 validate JSON schemas
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        timeout-minutes: 10
+        uses: actions/checkout@v6
+
+      - name: Get all changed JSON files
+        timeout-minutes: 5
+        id: changed-json-files
+        uses: tj-actions/changed-files@v47
+        with:
+          files: |
+            registry/**/*.json
+            ercs/**/*.json
+          files_ignore: registry/**/tests/**
+
+      - name: Setup python
+        timeout-minutes: 10
+        if: steps.changed-json-files.outputs.any_changed == 'true'
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install check-jsonschema
+        timeout-minutes: 10
+        if: steps.changed-json-files.outputs.any_changed == 'true'
+        run: pip install check-jsonschema
+
+      - name: Validate changed files against JSON schemas
+        timeout-minutes: 60
+        if: steps.changed-json-files.outputs.any_changed == 'true'
+        env:
+          CHANGED_FILES: ${{ steps.changed-json-files.outputs.all_changed_files }}
+        run: |
+          DEFAULT_SCHEMA="specs/erc7730-v2.schema.json"
+          FAILED=0
+
+          for file in $CHANGED_FILES; do
+            # Extract $schema value from the JSON file
+            SCHEMA_REF=$(python3 -c "
+          import json, sys
+          try:
+              with open('$file') as f:
+                  data = json.load(f)
+              print(data.get('\$schema', ''))
+          except Exception:
+              print('')
+          ")
+
+            # Resolve schema path
+            if [ -z "$SCHEMA_REF" ]; then
+              SCHEMA_PATH="$DEFAULT_SCHEMA"
+            elif echo "$SCHEMA_REF" | grep -qE '^https?://'; then
+              SCHEMA_PATH="$DEFAULT_SCHEMA"
+            else
+              FILE_DIR=$(dirname "$file")
+              RESOLVED=$(cd "$FILE_DIR" && realpath -m "$SCHEMA_REF" 2>/dev/null || echo "")
+              if [ -n "$RESOLVED" ] && [ -f "$RESOLVED" ]; then
+                SCHEMA_PATH="$RESOLVED"
+              else
+                SCHEMA_PATH="$DEFAULT_SCHEMA"
+              fi
+            fi
+
+            echo "::group::Validating $file against $SCHEMA_PATH"
+            if ! check-jsonschema --schemafile "$SCHEMA_PATH" "$file"; then
+              FAILED=1
+            fi
+            echo "::endgroup::"
+          done
+
+          if [ "$FAILED" -ne 0 ]; then
+            echo "::error::One or more files failed JSON schema validation"
+            exit 1
+          fi

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,6 +5,9 @@ on:
     paths-ignore:
       - "developer-preview/**"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/sync-specs.yml
+++ b/.github/workflows/sync-specs.yml
@@ -1,0 +1,74 @@
+---
+name: 🔄 sync spec files from upstream ERCs
+
+on:
+  schedule:
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  BRANCH: "master"
+
+jobs:
+  sync-specs:
+    name: sync spec files
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        timeout-minutes: 10
+        uses: actions/checkout@v6
+
+      - name: Get date
+        timeout-minutes: 10
+        run: echo "CURRENT_DATE=$(date +"%Y-%m-%d %H:%M")" >> $GITHUB_ENV
+
+      # File mapping (upstream -> local):
+      #   ERCS/erc-7734.md                          -> specs/erc-7730.md
+      #   assets/erc-7730/erc7730-v2.schema.json     -> specs/erc7730-v2.schema.json
+      #   assets/erc-7730/erc7730-v1.schema.json     -> specs/erc7730-v1.schema.json
+      - name: Fetch upstream spec files
+        timeout-minutes: 10
+        run: |
+          curl -fsSL "https://raw.githubusercontent.com/ethereum/ERCs/master/ERCS/erc-7734.md" \
+            -o specs/erc-7730.md
+          curl -fsSL "https://raw.githubusercontent.com/ethereum/ERCs/master/assets/erc-7730/erc7730-v2.schema.json" \
+            -o specs/erc7730-v2.schema.json
+          curl -fsSL "https://raw.githubusercontent.com/ethereum/ERCs/master/assets/erc-7730/erc7730-v1.schema.json" \
+            -o specs/erc7730-v1.schema.json
+
+      - name: Check changes
+        id: changes
+        timeout-minutes: 10
+        shell: bash
+        run: |
+          [[ -n "$(git status -s)" ]] && echo "changes=true" >> $GITHUB_OUTPUT || true
+
+      - name: Open pull request
+        if: ${{ !cancelled() && steps.changes.outputs.changes == 'true' }}
+        timeout-minutes: 10
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.CI_BOT_TOKEN }}
+          author: ${{ secrets.CI_BOT_USERNAME }} <${{ secrets.CI_BOT_USERNAME }}@users.noreply.github.com>
+          branch: ${{ env.BRANCH }}-sync-specs
+          base: ${{ env.BRANCH }}
+          delete-branch: false
+          commit-message: "chore: sync spec files from upstream ERCs - ${{ env.CURRENT_DATE }}"
+          title: "chore: sync spec files from upstream ERCs - ${{ env.CURRENT_DATE }}"
+          body: |
+            Automated sync of spec files from [ethereum/ERCs](https://github.com/ethereum/ERCs).
+
+            Files synced:
+            - `ERCS/erc-7734.md` -> `specs/erc-7730.md`
+            - `assets/erc-7730/erc7730-v2.schema.json` -> `specs/erc7730-v2.schema.json`
+            - `assets/erc-7730/erc7730-v1.schema.json` -> `specs/erc7730-v1.schema.json`
+          draft: false
+          signoff: false

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,22 @@
+# Specs
+
+This directory contains the ERC-7730 specification and JSON schemas used to validate clear signing descriptors in the registry.
+
+## Files synced from upstream
+
+The following files are automatically synced from the [ethereum/ERCs](https://github.com/ethereum/ERCs) repository by the `sync-specs` CI workflow (weekly, or on-demand):
+
+| Local file | Upstream source |
+|---|---|
+| `erc-7730.md` | [ERCS/erc-7734.md](https://github.com/ethereum/ERCs/blob/master/ERCS/erc-7734.md) |
+| `erc7730-v2.schema.json` | [assets/erc-7730/erc7730-v2.schema.json](https://github.com/ethereum/ERCs/blob/master/assets/erc-7730/erc7730-v2.schema.json) |
+| `erc7730-v1.schema.json` | [assets/erc-7730/erc7730-v1.schema.json](https://github.com/ethereum/ERCs/blob/master/assets/erc-7730/erc7730-v1.schema.json) |
+
+Do not edit these files directly — changes should be made upstream and will be picked up automatically.
+
+## Other files
+
+| File | Description |
+|---|---|
+| `erc7730-tests.schema.json` | JSON schema for device test files (`*.tests.json`) |
+| `templates/` | Descriptor templates for new contributions |


### PR DESCRIPTION
## Summary
- Add `sync-specs` workflow that fetches ERC-7730 spec and schemas from `ethereum/ERCs` weekly (+ manual dispatch) and opens a PR if they changed
- Add `validate_schemas` job to the pull request workflow that validates changed JSON files against their referenced `$schema` (falling back to v2 schema as default)
- Add `specs/README.md` documenting which files are synced and their upstream sources

## Details

### Spec sync (`sync-specs.yml`)
- Runs weekly (Monday 7 AM UTC) or on-demand via `workflow_dispatch`
- Fetches 3 files from `ethereum/ERCs` via `curl`:
  - `ERCS/erc-7734.md` → `specs/erc-7730.md`
  - `assets/erc-7730/erc7730-v2.schema.json` → `specs/erc7730-v2.schema.json`
  - `assets/erc-7730/erc7730-v1.schema.json` → `specs/erc7730-v1.schema.json`
- Opens a PR using `peter-evans/create-pull-request` if any file changed
- Uses fixed branch `master-sync-specs` to avoid duplicate PRs

### JSON schema validation (`pull_request.yml`)
- New `validate_schemas` job runs in parallel with existing `validate_descriptors`
- Detects all changed JSON files under `registry/` and `ercs/` (excluding tests)
- Resolves each file's `$schema` field to a local schema path
- Validates using `check-jsonschema` (Python CLI, supports Draft-04 and Draft-07)
- Falls back to `specs/erc7730-v2.schema.json` when `$schema` is missing or is a URL

## Test plan
- [ ] Trigger sync-specs workflow manually via Actions → verify it runs without error
- [ ] Open a test PR modifying a registry JSON file → verify `validate JSON schemas` job passes
- [ ] Intentionally break a JSON file's schema compliance → verify the job fails with clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)