### PR TITLE
fix: sei staking decimals

### DIFF
--- a/registry/sei/calldata-sei-staking.json
+++ b/registry/sei/calldata-sei-staking.json
@@ -56,7 +56,7 @@
             "path": "#.minSelfDelegation",
             "label": "Min self delegation",
             "format": "unit",
-            "params": { "base": "SEI", "decimals": 18 },
+            "params": { "base": "SEI", "decimals": 6 },
             "visible": "always"
           },
           {
@@ -103,7 +103,7 @@
             "path": "#.minSelfDelegation",
             "label": "Min self delegation",
             "format": "unit",
-            "params": { "base": "SEI", "decimals": 18 },
+            "params": { "base": "SEI", "decimals": 6 },
             "visible": "always"
           }
         ]
@@ -127,7 +127,7 @@
             "path": "#.amount",
             "label": "Amount",
             "format": "unit",
-            "params": { "base": "SEI", "decimals": 18 },
+            "params": { "base": "SEI", "decimals": 6 },
             "visible": "always"
           }
         ]
@@ -145,7 +145,7 @@
             "path": "#.amount",
             "label": "Amount",
             "format": "unit",
-            "params": { "base": "SEI", "decimals": 18 },
+            "params": { "base": "SEI", "decimals": 6 },
             "visible": "always"
           }
         ]


### PR DESCRIPTION
Update the SEI staking descriptor decimals: adjust from 18 to 6 (invalid amount displayed in device for delegation/redelegation actions)
