### PR TITLE
fix: make NttManager relayingFee field optional

### DIFF
--- a/registry/swissborg/calldata-ChsbToBorgMigrator.json
+++ b/registry/swissborg/calldata-ChsbToBorgMigrator.json
@@ -15,6 +15,7 @@
       "migrate(uint256 _amount)": {
         "$id": "migrate",
         "intent": "Migrate CHSB to BORG",
+        "interpolatedIntent": "Migrate {#._amount} to BORG",
         "fields": [
           {
             "$id": "migrate",

--- a/registry/swissborg/calldata-NttManager.json
+++ b/registry/swissborg/calldata-NttManager.json
@@ -15,6 +15,7 @@
       "transfer(uint256 amount, uint16 recipientChain, bytes32 recipient)": {
         "$id": "transfer",
         "intent": "Bridge BORG",
+        "interpolatedIntent": "Bridge {#.amount} BORG",
         "fields": [
           {
             "$id": "amount",
@@ -43,6 +44,7 @@
       "transfer(uint256 amount, uint16 recipientChain, bytes32 recipient, bytes32 refundAddress, bool shouldQueue, bytes transceiverInstructions)": {
         "$id": "transfer2",
         "intent": "Bridge BORG",
+        "interpolatedIntent": "Bridge {#.amount} BORG",
         "fields": [
           {
             "$id": "amount",

--- a/registry/swissborg/calldata-NttManager.json
+++ b/registry/swissborg/calldata-NttManager.json
@@ -69,7 +69,7 @@
           { "$id": "refundAddress", "label": "Refund Address", "format": "raw", "path": "#.refundAddress" },
           { "$id": "shouldQueue", "label": "Should Queue", "format": "raw", "path": "#.shouldQueue" },
           { "$id": "transceiverInstructions", "label": "Instructions", "format": "raw", "path": "#.transceiverInstructions" },
-          { "$id": "relayingFee", "label": "Relaying Fee", "path": "@.value", "format": "amount" }
+          { "$id": "relayingFee", "label": "Relaying Fee", "path": "@.value", "format": "amount", "visible": "optional" }
         ]
       }
     }

--- a/registry/swissborg/calldata-WormholeTransceiver.json
+++ b/registry/swissborg/calldata-WormholeTransceiver.json
@@ -10,6 +10,7 @@
       "receiveMessage(bytes encodedMessage)": {
         "$id": "receiveMessage",
         "intent": "Receive Bridged BORG",
+        "interpolatedIntent": "Receive Bridged BORG",
         "fields": [{ "$id": "encodedMessage", "label": "Encoded Message", "format": "raw", "path": "#.encodedMessage", "visible": "always" }]
       }
     }

--- a/registry/swissborg/tests/calldata-NttManager.tests.json
+++ b/registry/swissborg/tests/calldata-NttManager.tests.json
@@ -20,8 +20,6 @@
         "false",
         "Instructions",
         "0x01000101",
-        "Relaying Fee",
-        "0 ETH",
         "Max fees",
         "0.0000505734835 ETH"
       ]


### PR DESCRIPTION
Make the `NttManager.transfer` `relayingFee` field optional so the descriptor stays valid when `msg.value` is 0 (currently triggers `INVALID_DESCRIPTOR` and falls back to raw calldata on Ledger).
Test expectations updated to drop the now-hidden "Relaying Fee / 0 ETH" lines.