### PR TITLE
Add Igra KasExitBridge clear signing descriptor

### DIFF
--- a/registry/igra/calldata-KasExitBridge.json
+++ b/registry/igra/calldata-KasExitBridge.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "context": {
+    "$id": "IgraKasExitBridge",
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 38833,
+          "address": "0x4bb88c213d3ed9dc4bae694f1bc1bf745903b2d0"
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "Igra Labs",
+    "info": {
+      "url": "https://igra.network"
+    },
+    "contractName": "KasExitBridge"
+  },
+  "display": {
+    "formats": {
+      "requestExit(string kasPayoutAddress, uint64 unlockAmountSompi)": {
+        "intent": "Exit iKAS to Kaspa L1",
+        "fields": [
+          {
+            "path": "#.kasPayoutAddress",
+            "label": "Kaspa destination",
+            "format": "raw",
+            "visible": "always"
+          },
+          {
+            "path": "#.unlockAmountSompi",
+            "label": "KAS amount (sompi)",
+            "format": "raw",
+            "visible": "always"
+          },
+          {
+            "path": "@.value",
+            "label": "iKAS burned",
+            "format": "amount",
+            "visible": "always"
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add clear signing descriptor for the KasExitBridge contract on Igra Network (chain ID 38833).

Igra is an EVM-compatible based rollup on Kaspa. KasExitBridge allows users to exit iKAS (native L2 gas token) to KAS on Kaspa L1.

Covered function:
- `requestExit(string kasPayoutAddress, uint64 unlockAmountSompi)` — payable, burns iKAS and initiates exit to a Kaspa address

Contract: [0x4bb88c213d3ed9dc4bae694f1bc1bf745903b2d0](https://explorer.igralabs.com/address/0x4bb88c213d3ed9dc4bae694f1bc1bf745903b2d0)
Documentation: https://igra-labs.gitbook.io/igralab-docs/for-developers/contract-addresses