### PR TITLE
tools: add missing-permit detector

### DIFF
--- a/tools/scripts/check-contract-functions.js
+++ b/tools/scripts/check-contract-functions.js
@@ -24,13 +24,17 @@
 
 const fs = require("fs");
 const path = require("path");
-const https = require("https");
-const http = require("http");
 const { keccak256 } = require("js-sha3");
+const {
+  PROVIDERS,
+  MIN_REQUEST_INTERVAL_MS,
+  setLogger: setAbiFetcherLogger,
+  isNonZeroAddress,
+  fetchAbiFromExplorer,
+  fetchContractSourceMetadata,
+} = require("./lib/abi-fetcher");
 
 const ROOT_DIR = path.join(__dirname, "..", "..");
-const MIN_REQUEST_INTERVAL_MS = 380;
-let _lastExplorerRequestAt = 0;
 const LOGS_DIR = path.join(__dirname, "logs");
 const DEFAULT_LOG_FILE = path.join(LOGS_DIR, `check-contract-functions-${new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19)}.verbose.log`);
 const LOG_FILE_PATH = getLogFilePath();
@@ -43,20 +47,6 @@ const CONFIG = {
   chainExplicit: process.argv.includes("--chain"),
   chainId: getArgValue("--chain", 1),
   filePath: getFilePathArg(),
-};
-
-/**
- * Provider registry using Etherscan V2 API.
- * Same supported chain set as tools/scripts/generate-tests.js.
- */
-const PROVIDERS = {
-  1: { name: "Etherscan", baseUrl: "api.etherscan.io", apiKeyEnv: "ETHERSCAN_API_KEY" },
-  10: { name: "Optimism Etherscan", baseUrl: "api.etherscan.io", apiKeyEnv: "ETHERSCAN_API_KEY" },
-  56: { name: "BSCScan", baseUrl: "api.etherscan.io", apiKeyEnv: "ETHERSCAN_API_KEY" },
-  137: { name: "Polygonscan", baseUrl: "api.etherscan.io", apiKeyEnv: "ETHERSCAN_API_KEY" },
-  8453: { name: "Basescan", baseUrl: "api.etherscan.io", apiKeyEnv: "ETHERSCAN_API_KEY" },
-  42161: { name: "Arbiscan", baseUrl: "api.etherscan.io", apiKeyEnv: "ETHERSCAN_API_KEY" },
-  43114: { name: "Snowtrace", baseUrl: "api.etherscan.io", apiKeyEnv: "ETHERSCAN_API_KEY" },
 };
 
 function getArgValue(flag, defaultValue) {
@@ -154,6 +144,8 @@ function log(msg) {
   }
 }
 
+setAbiFetcherLogger(log);
+
 function printHelp(exitCode = 0, errorMessage = null) {
   const write = exitCode === 0 ? console.log : console.error;
   if (errorMessage) {
@@ -182,58 +174,6 @@ function printHelp(exitCode = 0, errorMessage = null) {
 
 if (process.argv.includes("--help") || process.argv.includes("-h")) {
   printHelp(0);
-}
-
-function httpsGet(url) {
-  return new Promise((resolve, reject) => {
-    const parsed = new URL(url);
-    const client = parsed.protocol === "https:" ? https : http;
-    client
-      .get(url, (res) => {
-        let data = "";
-        res.on("data", (chunk) => {
-          data += chunk;
-        });
-        res.on("end", () => {
-          try {
-            resolve(JSON.parse(data));
-          } catch {
-            resolve(data);
-          }
-        });
-      })
-      .on("error", reject);
-  });
-}
-
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-async function rateLimitedHttpsGet(url) {
-  const now = Date.now();
-  const elapsed = now - _lastExplorerRequestAt;
-  if (elapsed < MIN_REQUEST_INTERVAL_MS) {
-    await sleep(MIN_REQUEST_INTERVAL_MS - elapsed);
-  }
-  _lastExplorerRequestAt = Date.now();
-  return httpsGet(url);
-}
-
-async function callExplorerWithRetry(url, retries = 4) {
-  let lastError = null;
-  for (let attempt = 0; attempt <= retries; attempt++) {
-    try {
-      const response = await rateLimitedHttpsGet(url);
-      return response;
-    } catch (e) {
-      lastError = e;
-    }
-    if (attempt < retries) {
-      await sleep((attempt + 1) * 600);
-    }
-  }
-  throw lastError || new Error("Unknown explorer request failure");
 }
 
 function findMatchingParen(str, start) {
@@ -435,80 +375,6 @@ function pickBestByName(candidates, targetName) {
     }
   }
   return best;
-}
-
-async function fetchAbiFromExplorer(chainId, address) {
-  const provider = PROVIDERS[chainId];
-  if (!provider) {
-    throw new Error(`No supported explorer provider configured for chain ${chainId}`);
-  }
-
-  const apiKey = process.env[provider.apiKeyEnv];
-  if (!apiKey) {
-    throw new Error(`Missing API key env var: ${provider.apiKeyEnv}`);
-  }
-
-  const url =
-    `https://${provider.baseUrl}/v2/api` +
-    `?chainid=${chainId}` +
-    `&module=contract&action=getabi` +
-    `&address=${address}` +
-    `&apikey=${apiKey}`;
-
-  log(`  📡 Fetching ABI: chain=${chainId}, address=${address}`);
-  const response = await callExplorerWithRetry(url);
-  if (!response || typeof response !== "object") {
-    throw new Error("Explorer response is not JSON");
-  }
-  if (response.status !== "1" || typeof response.result !== "string") {
-    throw new Error(`Explorer error: ${response.message || "unknown"} (${response.result || "no result"})`);
-  }
-
-  let abi;
-  try {
-    abi = JSON.parse(response.result);
-  } catch (e) {
-    throw new Error(`Failed to parse ABI JSON from explorer: ${e.message}`);
-  }
-  return abi;
-}
-
-async function fetchContractSourceMetadata(chainId, address) {
-  const provider = PROVIDERS[chainId];
-  if (!provider) {
-    throw new Error(`No supported explorer provider configured for chain ${chainId}`);
-  }
-  const apiKey = process.env[provider.apiKeyEnv];
-  if (!apiKey) {
-    throw new Error(`Missing API key env var: ${provider.apiKeyEnv}`);
-  }
-
-  const url =
-    `https://${provider.baseUrl}/v2/api` +
-    `?chainid=${chainId}` +
-    `&module=contract&action=getsourcecode` +
-    `&address=${address}` +
-    `&apikey=${apiKey}`;
-
-  const response = await callExplorerWithRetry(url);
-  if (!response || typeof response !== "object") {
-    throw new Error("Explorer response is not JSON");
-  }
-  if (response.status !== "1" || !Array.isArray(response.result)) {
-    throw new Error(`Explorer getsourcecode error: ${response.message || "unknown"} (${response.result || "no result"})`);
-  }
-  const meta = response.result[0];
-  if (!meta || typeof meta !== "object") {
-    throw new Error("Explorer getsourcecode returned no metadata");
-  }
-  return meta;
-}
-
-function isNonZeroAddress(addr) {
-  if (typeof addr !== "string") return false;
-  const cleaned = addr.trim();
-  if (!/^0x[0-9a-fA-F]{40}$/.test(cleaned)) return false;
-  return cleaned.toLowerCase() !== "0x0000000000000000000000000000000000000000";
 }
 
 function getTargetChains(deployments) {

--- a/tools/scripts/check-missing-permit.README.md
+++ b/tools/scripts/check-missing-permit.README.md
@@ -1,0 +1,47 @@
+# Check missing permit descriptors
+
+Detects ERC-7730 entities whose contracts expose a permit-style function (EIP-2612, Permit2) but have no matching descriptor in the registry.
+
+Useful both as a contributor finding-tool ("which entities would benefit from a `eip712-*-permit.json` next?") and as a sanity check on new entities ("did the submitter forget to add a permit descriptor?").
+
+## Phases
+
+The script runs in two phases:
+
+1. **Phase 1 (offline, default)** — walks `registry/*/` and reports entities where:
+   - the entity has one or more `calldata-*.json` descriptors, **and**
+   - no descriptor in the entity is permit-shaped, either by filename (`*permit*`) or by `display.formats` key (`permit(...)`, `permitSingle(...)`, etc.).
+   - This is a pure filesystem scan — no network, no API key.
+
+2. **Phase 2 (`--check-onchain`)** — for each candidate, fetches the on-chain ABI for its deployment addresses via `tools/scripts/lib/abi-fetcher.js` and confirms the contract actually exposes a permit function. Requires `ETHERSCAN_API_KEY`.
+
+## Usage
+
+```bash
+# Offline scan — list all candidate entities
+node tools/scripts/check-missing-permit.js
+
+# Scope to a single entity
+node tools/scripts/check-missing-permit.js --entity aave
+
+# Confirm on-chain (chain 1 by default)
+ETHERSCAN_API_KEY=... node tools/scripts/check-missing-permit.js --check-onchain
+ETHERSCAN_API_KEY=... node tools/scripts/check-missing-permit.js --check-onchain --chain 42161
+
+# JSON output for downstream tooling
+node tools/scripts/check-missing-permit.js --json
+```
+
+## Permit function names matched
+
+The script treats the following ABI function names (case-insensitive) as permit-shaped:
+
+- `permit`
+- `permitSingle`, `permitBatch` (Permit2)
+- `permitTransferFrom`, `permitWitnessTransferFrom` (Permit2 SignatureTransfer)
+
+## Notes
+
+- A candidate from phase 1 does not necessarily mean a permit descriptor is missing — many entities ship non-token contracts (routers, vaults, bridges) that legitimately have no permit. Phase 2 separates real opportunities from false positives.
+- Phase 2 only checks the chain you ask for (`--chain`, default 1). If an entity has deployments only on chains not yet in `PROVIDERS`, the entry is reported as `checked: false`.
+- The script reuses `tools/scripts/lib/abi-fetcher.js` (same rate limit and proxy resolution as `check-contract-functions.js`).

--- a/tools/scripts/check-missing-permit.js
+++ b/tools/scripts/check-missing-permit.js
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+/**
+ * Detect ERC-7730 entities whose contracts expose a permit-style function
+ * (EIP-2612, Permit2) but have no matching descriptor in the registry.
+ *
+ * The script has two phases:
+ *
+ *   Phase 1 (no network, default):
+ *     Walks registry/ and reports entities where:
+ *       - the entity has one or more calldata descriptors, AND
+ *       - no descriptor in the entity (calldata or eip712) is permit-shaped
+ *         by filename or by 'display.formats' key.
+ *
+ *   Phase 2 (--check-onchain):
+ *     For each candidate from phase 1, fetches the contract ABI via
+ *     tools/scripts/lib/abi-fetcher.js and confirms that the contract
+ *     actually exposes 'permit', 'permitSingle', 'permitBatch',
+ *     'permitTransferFrom', or 'permitWitnessTransferFrom'.
+ *
+ * Usage:
+ *   node tools/scripts/check-missing-permit.js              # phase 1 (offline)
+ *   node tools/scripts/check-missing-permit.js --check-onchain --chain 1
+ *   node tools/scripts/check-missing-permit.js --entity aave
+ *   node tools/scripts/check-missing-permit.js --json
+ *
+ * Environment (phase 2 only):
+ *   ETHERSCAN_API_KEY
+ */
+
+const fs = require("fs");
+const path = require("path");
+const {
+  PROVIDERS,
+  fetchResolvedAbi,
+  setLogger,
+} = require("./lib/abi-fetcher");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const REGISTRY_DIR = path.join(REPO_ROOT, "registry");
+
+const PERMIT_FUNCTION_NAMES = new Set([
+  "permit",
+  "permitsingle",
+  "permitbatch",
+  "permittransferfrom",
+  "permitwitnesstransferfrom",
+]);
+
+function getArg(flag, defaultValue) {
+  const idx = process.argv.indexOf(flag);
+  if (idx === -1) return defaultValue;
+  const next = process.argv[idx + 1];
+  if (!next || next.startsWith("-")) return true;
+  return next;
+}
+
+const CONFIG = {
+  entity: getArg("--entity", null),
+  checkOnchain: process.argv.includes("--check-onchain"),
+  chainId: Number(getArg("--chain", 1)),
+  json: process.argv.includes("--json"),
+  verbose: process.argv.includes("--verbose"),
+};
+
+if (CONFIG.verbose) setLogger((msg) => console.error(msg));
+
+function readJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function listFiles(dir, prefix) {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.startsWith(`${prefix}-`) && f.endsWith(".json"))
+    .map((f) => path.join(dir, f));
+}
+
+function descriptorIsPermitShaped(filePath, json) {
+  const base = path.basename(filePath).toLowerCase();
+  for (const name of PERMIT_FUNCTION_NAMES) {
+    if (base.includes(name)) return true;
+  }
+  const formats = json && json.display && json.display.formats;
+  if (formats && typeof formats === "object") {
+    for (const key of Object.keys(formats)) {
+      const lk = key.toLowerCase().trim();
+      const nameMatch = lk.match(/^([a-z_][\w]*)\s*\(/);
+      if (nameMatch && PERMIT_FUNCTION_NAMES.has(nameMatch[1])) return true;
+      if (lk.startsWith("permit(")) return true;
+    }
+  }
+  return false;
+}
+
+function collectDeployments(json) {
+  const dep =
+    (json && json.context && json.context.contract && json.context.contract.deployments) || [];
+  return dep
+    .filter((d) => d && typeof d.chainId === "number" && typeof d.address === "string")
+    .map((d) => ({ chainId: d.chainId, address: d.address }));
+}
+
+function analyzeEntityOffline(entityDir) {
+  const entity = path.basename(entityDir);
+  const calldataFiles = listFiles(entityDir, "calldata");
+  const eip712Files = listFiles(entityDir, "eip712");
+
+  if (calldataFiles.length === 0) {
+    return { entity, status: "skip-no-calldata", deployments: [] };
+  }
+
+  const allDescriptors = [...calldataFiles, ...eip712Files];
+  let hasPermit = false;
+  for (const f of allDescriptors) {
+    const json = readJson(f);
+    if (!json) continue;
+    if (descriptorIsPermitShaped(f, json)) {
+      hasPermit = true;
+      break;
+    }
+  }
+
+  if (hasPermit) {
+    return { entity, status: "has-permit", deployments: [] };
+  }
+
+  // Collect candidate deployment addresses from all calldata descriptors.
+  const deployments = [];
+  for (const f of calldataFiles) {
+    const json = readJson(f);
+    if (!json) continue;
+    for (const d of collectDeployments(json)) {
+      deployments.push({ ...d, source: path.basename(f) });
+    }
+  }
+
+  return { entity, status: "candidate", deployments };
+}
+
+async function confirmOnchain(candidates) {
+  const provider = PROVIDERS[CONFIG.chainId];
+  if (!provider) {
+    throw new Error(`Chain ${CONFIG.chainId} is not in the supported PROVIDERS registry`);
+  }
+  if (!process.env[provider.apiKeyEnv]) {
+    throw new Error(`Missing ${provider.apiKeyEnv} for chain ${CONFIG.chainId}`);
+  }
+
+  const confirmed = [];
+  for (const cand of candidates) {
+    const deployments = cand.deployments.filter((d) => d.chainId === CONFIG.chainId);
+    if (deployments.length === 0) {
+      cand.onchain = { checked: false, reason: `no deployment on chain ${CONFIG.chainId}` };
+      continue;
+    }
+    cand.onchain = { checked: true, hits: [] };
+    for (const dep of deployments) {
+      try {
+        const { resolvedAddress, proxyInfo, abi } = await fetchResolvedAbi(
+          dep.chainId,
+          dep.address
+        );
+        const permitFns = (Array.isArray(abi) ? abi : [])
+          .filter((e) => e && e.type === "function" && typeof e.name === "string")
+          .filter((e) => PERMIT_FUNCTION_NAMES.has(e.name.toLowerCase()))
+          .map((e) => e.name);
+        if (permitFns.length > 0) {
+          cand.onchain.hits.push({
+            address: dep.address,
+            resolvedAddress,
+            proxyInfo,
+            permitFunctions: [...new Set(permitFns)],
+            source: dep.source,
+          });
+        }
+      } catch (e) {
+        cand.onchain.hits.push({
+          address: dep.address,
+          error: e.message,
+          source: dep.source,
+        });
+      }
+    }
+    if (cand.onchain.hits.some((h) => Array.isArray(h.permitFunctions))) {
+      confirmed.push(cand);
+    }
+  }
+  return confirmed;
+}
+
+function listEntities() {
+  if (!fs.existsSync(REGISTRY_DIR)) return [];
+  return fs
+    .readdirSync(REGISTRY_DIR)
+    .map((n) => path.join(REGISTRY_DIR, n))
+    .filter((p) => fs.statSync(p).isDirectory())
+    .filter((p) => !CONFIG.entity || path.basename(p) === CONFIG.entity)
+    .sort();
+}
+
+function renderText(candidates, confirmed) {
+  const lines = [];
+  lines.push(`Missing-permit candidates (offline scan): ${candidates.length}`);
+  for (const c of candidates) {
+    lines.push(`  - ${c.entity} (${c.deployments.length} deployment(s))`);
+  }
+  if (CONFIG.checkOnchain) {
+    lines.push("");
+    lines.push(`On-chain confirmed (chain ${CONFIG.chainId}): ${confirmed.length}`);
+    for (const c of confirmed) {
+      const hits = c.onchain.hits.filter((h) => Array.isArray(h.permitFunctions));
+      const fns = [...new Set(hits.flatMap((h) => h.permitFunctions))];
+      lines.push(`  - ${c.entity}: ${fns.join(", ")}`);
+      for (const h of hits) {
+        lines.push(`      ${h.address}  (${h.source})${h.resolvedAddress && h.resolvedAddress !== h.address ? ` -> ${h.resolvedAddress}` : ""}`);
+      }
+    }
+  }
+  return lines.join("\n");
+}
+
+async function main() {
+  const entities = listEntities();
+  const candidates = entities
+    .map(analyzeEntityOffline)
+    .filter((r) => r.status === "candidate");
+
+  let confirmed = [];
+  if (CONFIG.checkOnchain) {
+    confirmed = await confirmOnchain(candidates);
+  }
+
+  if (CONFIG.json) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          chainChecked: CONFIG.checkOnchain ? CONFIG.chainId : null,
+          candidates,
+          confirmed,
+        },
+        null,
+        2
+      ) + "\n"
+    );
+  } else {
+    process.stdout.write(renderText(candidates, confirmed) + "\n");
+  }
+}
+
+main().catch((err) => {
+  console.error(`Fatal: ${err.message}`);
+  process.exit(1);
+});

--- a/tools/scripts/lib/abi-fetcher.js
+++ b/tools/scripts/lib/abi-fetcher.js
@@ -1,0 +1,212 @@
+/**
+ * Shared Etherscan-style ABI fetcher used by tools/scripts/.
+ *
+ * Responsibilities:
+ *   - Provider registry (chainId -> explorer config)
+ *   - Rate-limited, retrying HTTPS GET
+ *   - getabi and getsourcecode wrappers (with proxy resolution)
+ *   - Address utility (isNonZeroAddress)
+ *
+ * No CLI / no process.exit / no implicit logging — callers inject a logger
+ * via setLogger() if they want verbose traces.
+ *
+ * Extracted from tools/scripts/check-contract-functions.js without
+ * behavior change so it can be reused by sibling scripts (e.g.
+ * check-missing-permit.js).
+ */
+
+const https = require("https");
+const http = require("http");
+
+const MIN_REQUEST_INTERVAL_MS = 380;
+let _lastExplorerRequestAt = 0;
+
+let _log = () => {};
+
+function setLogger(fn) {
+  _log = typeof fn === "function" ? fn : () => {};
+}
+
+/**
+ * Provider registry using Etherscan V2 API.
+ * Same supported chain set as tools/scripts/generate-tests.js.
+ */
+const PROVIDERS = {
+  1: { name: "Etherscan", baseUrl: "api.etherscan.io", apiKeyEnv: "ETHERSCAN_API_KEY" },
+  10: { name: "Optimism Etherscan", baseUrl: "api.etherscan.io", apiKeyEnv: "ETHERSCAN_API_KEY" },
+  56: { name: "BSCScan", baseUrl: "api.etherscan.io", apiKeyEnv: "ETHERSCAN_API_KEY" },
+  137: { name: "Polygonscan", baseUrl: "api.etherscan.io", apiKeyEnv: "ETHERSCAN_API_KEY" },
+  8453: { name: "Basescan", baseUrl: "api.etherscan.io", apiKeyEnv: "ETHERSCAN_API_KEY" },
+  42161: { name: "Arbiscan", baseUrl: "api.etherscan.io", apiKeyEnv: "ETHERSCAN_API_KEY" },
+  43114: { name: "Snowtrace", baseUrl: "api.etherscan.io", apiKeyEnv: "ETHERSCAN_API_KEY" },
+};
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function httpsGet(url) {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const client = parsed.protocol === "https:" ? https : http;
+    client
+      .get(url, (res) => {
+        let data = "";
+        res.on("data", (chunk) => {
+          data += chunk;
+        });
+        res.on("end", () => {
+          try {
+            resolve(JSON.parse(data));
+          } catch {
+            resolve(data);
+          }
+        });
+      })
+      .on("error", reject);
+  });
+}
+
+async function rateLimitedHttpsGet(url) {
+  const now = Date.now();
+  const elapsed = now - _lastExplorerRequestAt;
+  if (elapsed < MIN_REQUEST_INTERVAL_MS) {
+    await sleep(MIN_REQUEST_INTERVAL_MS - elapsed);
+  }
+  _lastExplorerRequestAt = Date.now();
+  return httpsGet(url);
+}
+
+async function callExplorerWithRetry(url, retries = 4) {
+  let lastError = null;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const response = await rateLimitedHttpsGet(url);
+      return response;
+    } catch (e) {
+      lastError = e;
+    }
+    if (attempt < retries) {
+      await sleep((attempt + 1) * 600);
+    }
+  }
+  throw lastError || new Error("Unknown explorer request failure");
+}
+
+function isNonZeroAddress(addr) {
+  if (typeof addr !== "string") return false;
+  const cleaned = addr.trim();
+  if (!/^0x[0-9a-fA-F]{40}$/.test(cleaned)) return false;
+  return cleaned.toLowerCase() !== "0x0000000000000000000000000000000000000000";
+}
+
+async function fetchAbiFromExplorer(chainId, address) {
+  const provider = PROVIDERS[chainId];
+  if (!provider) {
+    throw new Error(`No supported explorer provider configured for chain ${chainId}`);
+  }
+
+  const apiKey = process.env[provider.apiKeyEnv];
+  if (!apiKey) {
+    throw new Error(`Missing API key env var: ${provider.apiKeyEnv}`);
+  }
+
+  const url =
+    `https://${provider.baseUrl}/v2/api` +
+    `?chainid=${chainId}` +
+    `&module=contract&action=getabi` +
+    `&address=${address}` +
+    `&apikey=${apiKey}`;
+
+  _log(`  📡 Fetching ABI: chain=${chainId}, address=${address}`);
+  const response = await callExplorerWithRetry(url);
+  if (!response || typeof response !== "object") {
+    throw new Error("Explorer response is not JSON");
+  }
+  if (response.status !== "1" || typeof response.result !== "string") {
+    throw new Error(`Explorer error: ${response.message || "unknown"} (${response.result || "no result"})`);
+  }
+
+  let abi;
+  try {
+    abi = JSON.parse(response.result);
+  } catch (e) {
+    throw new Error(`Failed to parse ABI JSON from explorer: ${e.message}`);
+  }
+  return abi;
+}
+
+async function fetchContractSourceMetadata(chainId, address) {
+  const provider = PROVIDERS[chainId];
+  if (!provider) {
+    throw new Error(`No supported explorer provider configured for chain ${chainId}`);
+  }
+  const apiKey = process.env[provider.apiKeyEnv];
+  if (!apiKey) {
+    throw new Error(`Missing API key env var: ${provider.apiKeyEnv}`);
+  }
+
+  const url =
+    `https://${provider.baseUrl}/v2/api` +
+    `?chainid=${chainId}` +
+    `&module=contract&action=getsourcecode` +
+    `&address=${address}` +
+    `&apikey=${apiKey}`;
+
+  const response = await callExplorerWithRetry(url);
+  if (!response || typeof response !== "object") {
+    throw new Error("Explorer response is not JSON");
+  }
+  if (response.status !== "1" || !Array.isArray(response.result)) {
+    throw new Error(`Explorer getsourcecode error: ${response.message || "unknown"} (${response.result || "no result"})`);
+  }
+  const meta = response.result[0];
+  if (!meta || typeof meta !== "object") {
+    throw new Error("Explorer getsourcecode returned no metadata");
+  }
+  return meta;
+}
+
+/**
+ * Resolve an address to its implementation ABI:
+ *   - looks up getsourcecode metadata
+ *   - if Proxy=1 and Implementation is a non-zero address, returns that address's ABI
+ *   - otherwise returns the address's own ABI
+ *
+ * Returns { resolvedAddress, proxyInfo, abi }.
+ */
+async function fetchResolvedAbi(chainId, address) {
+  let resolvedAddress = address;
+  let proxyInfo = "not-proxy";
+  try {
+    const meta = await fetchContractSourceMetadata(chainId, address);
+    const isProxy = String(meta.Proxy || "").trim() === "1";
+    const implementation = String(meta.Implementation || "").trim();
+    if (isProxy) {
+      if (isNonZeroAddress(implementation)) {
+        resolvedAddress = implementation;
+        proxyInfo = `proxy->${resolvedAddress}`;
+      } else {
+        proxyInfo = "proxy->(missing implementation)";
+      }
+    }
+  } catch (e) {
+    proxyInfo = `proxy-check-failed: ${e.message}`;
+  }
+  const abi = await fetchAbiFromExplorer(chainId, resolvedAddress);
+  return { resolvedAddress, proxyInfo, abi };
+}
+
+module.exports = {
+  PROVIDERS,
+  MIN_REQUEST_INTERVAL_MS,
+  setLogger,
+  sleep,
+  httpsGet,
+  rateLimitedHttpsGet,
+  callExplorerWithRetry,
+  isNonZeroAddress,
+  fetchAbiFromExplorer,
+  fetchContractSourceMetadata,
+  fetchResolvedAbi,
+};


### PR DESCRIPTION
> Stacked on #2565 (abi-fetcher lib extraction). Please review that PR first; this branch is based on it. Once #2565 lands, GitHub should auto-rebase the diff here onto master.

## Summary

Adds `tools/scripts/check-missing-permit.js`, which finds entities whose contracts expose a permit-style function (EIP-2612 `permit`, Permit2 `permitSingle` / `permitBatch` / `permitTransferFrom` / `permitWitnessTransferFrom`) but have no matching descriptor.

Two phases:

- **Phase 1 (offline, default)** — filesystem scan. Flags every entity with calldata descriptors but no permit-shaped descriptor (by filename or by `display.formats` key). No network, no API key.
- **Phase 2 (`--check-onchain`)** — for each candidate, fetches the contract ABI via `tools/scripts/lib/abi-fetcher.js` and confirms the contract actually exposes a permit function. Filters out false positives like routers, bridges, and other non-token contracts. Requires `ETHERSCAN_API_KEY`.

## Initial offline scan (committed in PR description for transparency)

```
Missing-permit candidates (offline scan): 32
  - 1inch, aave, benqi, celo, consensus-specs, corestake, ethena, fellow-fund,
    figment, flare, hyperliquid, kiln, lido, lifi, midas, morpho, okx,
    opencover, p2p, paraswap, poap, quickswap, safe, sei, serenita, starkgate,
    swell, swissborg, tether, walletconnect, weth, yieldxyz
```

Each is a concrete contribution opportunity: many of these are ERC-20 token contracts (lido stETH, weth, ethena USDe, swell) that ship `permit()` but have no EIP-2612 descriptor.

## Why

- Gives reviewers a sanity check during entity submissions ("the submitter's contract has `permit` but the PR has no permit descriptor — should it?").
- Gives contributors a concrete worklist of entities likely missing an EIP-2612 / Permit2 descriptor.
- Pure additive — no existing behavior touched.

## Test plan

- [x] `node tools/scripts/check-missing-permit.js` lists 32 candidates against the current registry.
- [x] `--entity aave` scopes correctly to one entity.
- [x] `--json` emits structured output suitable for downstream tooling.
- [ ] `ETHERSCAN_API_KEY=... --check-onchain` on a known-permit entity (e.g. `lido`) confirms `permit` in the ABI.