### PR TITLE
ci: nightly on-chain selector drift check

### DIFF
--- a/.github/workflows/nightly-drift.yml
+++ b/.github/workflows/nightly-drift.yml
@@ -1,0 +1,90 @@
+name: 🌙 nightly selector drift
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every day at 03:00 UTC
+    - cron: "0 3 * * *"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  drift:
+    name: 🔬 check on-chain selectors
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    env:
+      ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+    steps:
+      - name: Skip when no Etherscan API key
+        if: ${{ env.ETHERSCAN_API_KEY == '' }}
+        run: |
+          echo "::notice::ETHERSCAN_API_KEY secret is not set on this repo; skipping drift check."
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+        id: gate
+
+      - name: Checkout
+        if: ${{ env.ETHERSCAN_API_KEY != '' }}
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup Node
+        if: ${{ env.ETHERSCAN_API_KEY != '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install JS deps
+        if: ${{ env.ETHERSCAN_API_KEY != '' }}
+        run: npm ci --no-audit --no-fund
+
+      - name: Run drift check across all calldata descriptors
+        if: ${{ env.ETHERSCAN_API_KEY != '' }}
+        id: drift
+        run: |
+          set +e
+          bash tools/scripts/run-drift-check-all.sh --all-chains | tee drift-report.md
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Upload drift report
+        if: ${{ env.ETHERSCAN_API_KEY != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: drift-report
+          path: drift-report.md
+          retention-days: 30
+
+      - name: Open or update sticky issue on drift
+        if: ${{ env.ETHERSCAN_API_KEY != '' && steps.drift.outputs.exit_code != '0' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TITLE="🌙 Nightly drift report"
+          BODY_FILE=drift-report.md
+          # Find an existing open issue with the same title authored by github-actions.
+          EXISTING=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --search "in:title \"$TITLE\"" \
+            --json number,title \
+            --jq ".[] | select(.title == \"$TITLE\") | .number" \
+            | head -n 1)
+          if [[ -n "$EXISTING" ]]; then
+            gh issue edit "$EXISTING" --repo "$GITHUB_REPOSITORY" --body-file "$BODY_FILE"
+            gh issue comment "$EXISTING" --repo "$GITHUB_REPOSITORY" --body "Refreshed at $(date -u +%FT%TZ) by workflow run ${{ github.run_id }}."
+          else
+            gh issue create \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$TITLE" \
+              --body-file "$BODY_FILE" \
+              --label "drift,automated" || \
+            gh issue create \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$TITLE" \
+              --body-file "$BODY_FILE"
+          fi

--- a/tools/scripts/run-drift-check-all.sh
+++ b/tools/scripts/run-drift-check-all.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Run tools/scripts/check-contract-functions.js over every calldata
+# descriptor in registry/ and ercs/ and emit a markdown summary.
+#
+# Per-file exits 0 (clean), 2 (mismatches), or 1 (errors); this driver
+# never aborts on a single failure — it aggregates and reports.
+#
+# Output goes to stdout, and (when set) to $GITHUB_STEP_SUMMARY.
+#
+# Environment:
+#   ETHERSCAN_API_KEY (required by the checker)
+#
+# Usage:
+#   ETHERSCAN_API_KEY=... tools/scripts/run-drift-check-all.sh
+#   ETHERSCAN_API_KEY=... tools/scripts/run-drift-check-all.sh --all-chains
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+EXTRA_ARGS=("$@")
+
+CHECKER="tools/scripts/check-contract-functions.js"
+if [[ ! -f "$CHECKER" ]]; then
+  echo "Checker not found at $CHECKER" >&2
+  exit 1
+fi
+
+shopt -s globstar nullglob
+FILES=(registry/**/calldata-*.json ercs/calldata-*.json)
+
+# Drop anything under registry/**/tests/ (matches the rest of CI).
+FILTERED=()
+for f in "${FILES[@]}"; do
+  case "$f" in
+    registry/*/tests/*) ;;
+    *) FILTERED+=("$f") ;;
+  esac
+done
+
+TOTAL=${#FILTERED[@]}
+CLEAN=0
+MISMATCH=0
+ERROR=0
+MISMATCH_LIST=()
+ERROR_LIST=()
+
+echo "Running drift check across $TOTAL calldata descriptor(s)..." >&2
+
+for file in "${FILTERED[@]}"; do
+  OUTPUT=$(node "$CHECKER" "$file" "${EXTRA_ARGS[@]}" 2>&1)
+  STATUS=$?
+  case $STATUS in
+    0)
+      CLEAN=$((CLEAN + 1))
+      ;;
+    2)
+      MISMATCH=$((MISMATCH + 1))
+      MISMATCH_LIST+=("$file")
+      echo "::group::MISMATCH $file"
+      printf '%s\n' "$OUTPUT"
+      echo "::endgroup::"
+      ;;
+    *)
+      ERROR=$((ERROR + 1))
+      ERROR_LIST+=("$file")
+      echo "::group::ERROR ($STATUS) $file"
+      printf '%s\n' "$OUTPUT"
+      echo "::endgroup::"
+      ;;
+  esac
+done
+
+# Markdown summary.
+SUMMARY=$(cat <<EOF
+# Registry selector drift report
+
+- ✅ Clean: **$CLEAN**
+- ❌ Mismatches: **$MISMATCH**
+- ⚠️ Errors: **$ERROR**
+- Total checked: **$TOTAL**
+
+EOF
+)
+
+if (( MISMATCH > 0 )); then
+  SUMMARY+=$'\n## Descriptors with on-chain selector mismatches\n\n'
+  for f in "${MISMATCH_LIST[@]}"; do
+    SUMMARY+="- \`$f\`"$'\n'
+  done
+fi
+
+if (( ERROR > 0 )); then
+  SUMMARY+=$'\n## Descriptors that errored during validation\n\n'
+  for f in "${ERROR_LIST[@]}"; do
+    SUMMARY+="- \`$f\`"$'\n'
+  done
+fi
+
+printf '%s' "$SUMMARY"
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  printf '%s' "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
+fi
+
+# Exit non-zero if anything failed, so the workflow can decide to open an issue.
+if (( MISMATCH > 0 || ERROR > 0 )); then
+  exit 2
+fi
+exit 0


### PR DESCRIPTION
## Summary

`tools/scripts/check-contract-functions.js` already validates that a descriptor's function selectors exist in the on-chain ABI (with proxy resolution). Today it's only runnable manually, so descriptors can become stale when their backing contracts upgrade, without CI noticing.

This PR adds:

- **`tools/scripts/run-drift-check-all.sh`** — iterates every `calldata-*.json` descriptor under `registry/**` and `ercs/`, runs the checker per-file, and emits a markdown summary. Exits 0 on a clean run, 2 if any descriptor has mismatches or errors. Writes to `$GITHUB_STEP_SUMMARY` when present.

- **`.github/workflows/nightly-drift.yml`** — runs daily at 03:00 UTC and on `workflow_dispatch`. **Skips cleanly when `ETHERSCAN_API_KEY` is not set on the repo**, so this workflow is safe to merge even before the secret is configured. When drift is detected, opens (or updates) a sticky issue titled `🌙 Nightly drift report` with the summary, and uploads `drift-report.md` as a 30-day artifact.

## Why nightly + sticky issue

- Daily is the right cadence: contract upgrades are rare-but-real (proxy implementations rotate, parameters change) and same-day notice is high signal.
- A sticky issue beats a fresh issue per night: maintainers see one item to act on, not 30 stale duplicates, and old runs leave history via comments.
- The script is also re-runnable via `workflow_dispatch` for spot checks during incident response.

## To enable on the upstream repo

1. Merge this PR.
2. Add `ETHERSCAN_API_KEY` to the repo's **Actions secrets** (the README already references this convention for `tools/analyzer/` and `tools/scripts/`).

Until step 2, every nightly run is a no-op (one notice line in the summary, no other side effects).

## Test plan

- [x] `bash -n tools/scripts/run-drift-check-all.sh` — shell syntax check passes.
- [x] YAML parses cleanly.
- [ ] Trigger via `workflow_dispatch` from a fork with `ETHERSCAN_API_KEY` set and confirm the report renders + the sticky issue is created.
- [ ] Trigger from a repo without the secret and confirm the gate step prints the notice and remaining steps are skipped.