### PR TITLE
ci: add PR-time on-chain selector check (warning-only)

### DIFF
--- a/.github/workflows/nightly-drift.yml
+++ b/.github/workflows/nightly-drift.yml
@@ -1,0 +1,90 @@
+name: 🌙 nightly selector drift
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every day at 03:00 UTC
+    - cron: "0 3 * * *"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  drift:
+    name: 🔬 check on-chain selectors
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    env:
+      ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+    steps:
+      - name: Skip when no Etherscan API key
+        if: ${{ env.ETHERSCAN_API_KEY == '' }}
+        run: |
+          echo "::notice::ETHERSCAN_API_KEY secret is not set on this repo; skipping drift check."
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+        id: gate
+
+      - name: Checkout
+        if: ${{ env.ETHERSCAN_API_KEY != '' }}
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup Node
+        if: ${{ env.ETHERSCAN_API_KEY != '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install JS deps
+        if: ${{ env.ETHERSCAN_API_KEY != '' }}
+        run: npm ci --no-audit --no-fund
+
+      - name: Run drift check across all calldata descriptors
+        if: ${{ env.ETHERSCAN_API_KEY != '' }}
+        id: drift
+        run: |
+          set +e
+          bash tools/scripts/run-drift-check-all.sh --all-chains | tee drift-report.md
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Upload drift report
+        if: ${{ env.ETHERSCAN_API_KEY != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: drift-report
+          path: drift-report.md
+          retention-days: 30
+
+      - name: Open or update sticky issue on drift
+        if: ${{ env.ETHERSCAN_API_KEY != '' && steps.drift.outputs.exit_code != '0' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TITLE="🌙 Nightly drift report"
+          BODY_FILE=drift-report.md
+          # Find an existing open issue with the same title authored by github-actions.
+          EXISTING=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --search "in:title \"$TITLE\"" \
+            --json number,title \
+            --jq ".[] | select(.title == \"$TITLE\") | .number" \
+            | head -n 1)
+          if [[ -n "$EXISTING" ]]; then
+            gh issue edit "$EXISTING" --repo "$GITHUB_REPOSITORY" --body-file "$BODY_FILE"
+            gh issue comment "$EXISTING" --repo "$GITHUB_REPOSITORY" --body "Refreshed at $(date -u +%FT%TZ) by workflow run ${{ github.run_id }}."
+          else
+            gh issue create \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$TITLE" \
+              --body-file "$BODY_FILE" \
+              --label "drift,automated" || \
+            gh issue create \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$TITLE" \
+              --body-file "$BODY_FILE"
+          fi

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -135,3 +135,91 @@ jobs:
             echo "::error::One or more files failed JSON schema validation"
             exit 1
           fi
+
+  validate_selectors_warning:
+    # Warning-only: this job never fails the PR — it surfaces likely on-chain
+    # selector drift via the job summary so reviewers can spot it. The
+    # authoritative gate is the nightly drift workflow.
+    name: ⚠️ on-chain selector check (warning)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: true
+    env:
+      ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+    steps:
+      - name: Skip when no Etherscan API key
+        if: ${{ env.ETHERSCAN_API_KEY == '' }}
+        run: |
+          echo "::notice::ETHERSCAN_API_KEY secret not available (typical for fork PRs); skipping selector check."
+
+      - name: Checkout
+        if: ${{ env.ETHERSCAN_API_KEY != '' }}
+        uses: actions/checkout@v6.0.2
+
+      - name: Get changed calldata descriptors
+        if: ${{ env.ETHERSCAN_API_KEY != '' }}
+        id: changed-calldata
+        uses: tj-actions/changed-files@v47.0.5
+        with:
+          files: |
+            registry/**/calldata-*.json
+            ercs/calldata-*.json
+          files_ignore: registry/**/tests/**
+
+      - name: Setup Node
+        if: ${{ env.ETHERSCAN_API_KEY != '' && steps.changed-calldata.outputs.any_changed == 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install JS deps
+        if: ${{ env.ETHERSCAN_API_KEY != '' && steps.changed-calldata.outputs.any_changed == 'true' }}
+        run: npm ci --no-audit --no-fund
+
+      - name: Validate selectors for changed calldata descriptors
+        if: ${{ env.ETHERSCAN_API_KEY != '' && steps.changed-calldata.outputs.any_changed == 'true' }}
+        env:
+          CHANGED_FILES: ${{ steps.changed-calldata.outputs.all_changed_files }}
+        run: |
+          set +e
+          FAIL=0
+          {
+            echo "# On-chain selector check (warning-only)"
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+          for file in $CHANGED_FILES; do
+            OUT=$(node tools/scripts/check-contract-functions.js "$file" 2>&1)
+            STATUS=$?
+            case $STATUS in
+              0)
+                echo "✅ \`$file\`" >> "$GITHUB_STEP_SUMMARY"
+                ;;
+              2)
+                FAIL=1
+                echo "::warning file=$file::Selector mismatch with on-chain ABI (see job summary)"
+                {
+                  echo "<details><summary>⚠️ \`$file\` — selector mismatch</summary>"
+                  echo
+                  echo '```'
+                  echo "$OUT"
+                  echo '```'
+                  echo "</details>"
+                } >> "$GITHUB_STEP_SUMMARY"
+                ;;
+              *)
+                FAIL=1
+                echo "::warning file=$file::Selector check errored (exit $STATUS)"
+                {
+                  echo "<details><summary>⚠️ \`$file\` — errored (exit $STATUS)</summary>"
+                  echo
+                  echo '```'
+                  echo "$OUT"
+                  echo '```'
+                  echo "</details>"
+                } >> "$GITHUB_STEP_SUMMARY"
+                ;;
+            esac
+          done
+          # Warning-only: never fail the job. The nightly drift workflow is
+          # the authoritative gate.
+          exit 0

--- a/tools/scripts/run-drift-check-all.sh
+++ b/tools/scripts/run-drift-check-all.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Run tools/scripts/check-contract-functions.js over every calldata
+# descriptor in registry/ and ercs/ and emit a markdown summary.
+#
+# Per-file exits 0 (clean), 2 (mismatches), or 1 (errors); this driver
+# never aborts on a single failure — it aggregates and reports.
+#
+# Output goes to stdout, and (when set) to $GITHUB_STEP_SUMMARY.
+#
+# Environment:
+#   ETHERSCAN_API_KEY (required by the checker)
+#
+# Usage:
+#   ETHERSCAN_API_KEY=... tools/scripts/run-drift-check-all.sh
+#   ETHERSCAN_API_KEY=... tools/scripts/run-drift-check-all.sh --all-chains
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+EXTRA_ARGS=("$@")
+
+CHECKER="tools/scripts/check-contract-functions.js"
+if [[ ! -f "$CHECKER" ]]; then
+  echo "Checker not found at $CHECKER" >&2
+  exit 1
+fi
+
+shopt -s globstar nullglob
+FILES=(registry/**/calldata-*.json ercs/calldata-*.json)
+
+# Drop anything under registry/**/tests/ (matches the rest of CI).
+FILTERED=()
+for f in "${FILES[@]}"; do
+  case "$f" in
+    registry/*/tests/*) ;;
+    *) FILTERED+=("$f") ;;
+  esac
+done
+
+TOTAL=${#FILTERED[@]}
+CLEAN=0
+MISMATCH=0
+ERROR=0
+MISMATCH_LIST=()
+ERROR_LIST=()
+
+echo "Running drift check across $TOTAL calldata descriptor(s)..." >&2
+
+for file in "${FILTERED[@]}"; do
+  OUTPUT=$(node "$CHECKER" "$file" "${EXTRA_ARGS[@]}" 2>&1)
+  STATUS=$?
+  case $STATUS in
+    0)
+      CLEAN=$((CLEAN + 1))
+      ;;
+    2)
+      MISMATCH=$((MISMATCH + 1))
+      MISMATCH_LIST+=("$file")
+      echo "::group::MISMATCH $file"
+      printf '%s\n' "$OUTPUT"
+      echo "::endgroup::"
+      ;;
+    *)
+      ERROR=$((ERROR + 1))
+      ERROR_LIST+=("$file")
+      echo "::group::ERROR ($STATUS) $file"
+      printf '%s\n' "$OUTPUT"
+      echo "::endgroup::"
+      ;;
+  esac
+done
+
+# Markdown summary.
+SUMMARY=$(cat <<EOF
+# Registry selector drift report
+
+- ✅ Clean: **$CLEAN**
+- ❌ Mismatches: **$MISMATCH**
+- ⚠️ Errors: **$ERROR**
+- Total checked: **$TOTAL**
+
+EOF
+)
+
+if (( MISMATCH > 0 )); then
+  SUMMARY+=$'\n## Descriptors with on-chain selector mismatches\n\n'
+  for f in "${MISMATCH_LIST[@]}"; do
+    SUMMARY+="- \`$f\`"$'\n'
+  done
+fi
+
+if (( ERROR > 0 )); then
+  SUMMARY+=$'\n## Descriptors that errored during validation\n\n'
+  for f in "${ERROR_LIST[@]}"; do
+    SUMMARY+="- \`$f\`"$'\n'
+  done
+fi
+
+printf '%s' "$SUMMARY"
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  printf '%s' "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
+fi
+
+# Exit non-zero if anything failed, so the workflow can decide to open an issue.
+if (( MISMATCH > 0 || ERROR > 0 )); then
+  exit 2
+fi
+exit 0


### PR DESCRIPTION
> Stacked on #2567 (nightly drift workflow). Please review that one first; this branch is based on it. Once #2567 lands, the diff here will resolve to the single new job in `pull_request.yml`.

## Summary

Adds a new job `validate_selectors_warning` to `.github/workflows/pull_request.yml` that runs `tools/scripts/check-contract-functions.js` against any `calldata-*.json` descriptors modified in the PR.

The job is **intentionally warning-only**:

- `continue-on-error: true`
- the final `exit 0` guarantees the job never reports failure
- skips cleanly when `ETHERSCAN_API_KEY` is not set (typical for fork-originating PRs without access to secrets)
- the authoritative gate stays the nightly drift workflow (#2567)

When a selector mismatch is detected, the job emits:

- a `::warning file=path/to/descriptor.json::Selector mismatch with on-chain ABI` annotation on the PR diff
- a collapsible `<details>` block in the job summary with the full checker output

## Why warning-only

- Hard-gating selector checks at PR time would block legitimate work whenever Etherscan is flaky, when the secret is rotating, or when a fork PR can't access the secret.
- It also lets maintainers see one round of real-world output before deciding to flip it to a required check later (just remove `continue-on-error` and the trailing `exit 0`).
- The nightly job already catches drift at a stable cadence — this PR-time check is purely a UX nicety that pulls forward the signal during review.

## To enable on the upstream repo

Same as #2567: add `ETHERSCAN_API_KEY` to the repo's Actions secrets. Until then the job emits a notice and skips.

## Test plan

- [x] YAML parses cleanly (`python3 -c 'import yaml; yaml.safe_load(open(...))'`).
- [ ] Open a test PR that modifies a known-good calldata descriptor and confirm the job summary shows ✅.
- [ ] Open a test PR with a deliberately broken selector and confirm the warning annotation lands on the descriptor file.
- [ ] Open a fork PR with no secret access and confirm the gate step prints the notice and the rest is skipped.