### PR TITLE
Add Layerswap ERC-7730 descriptor & tests

### DIFF
--- a/registry/layerswap/calldata-LayerswapDepository.json
+++ b/registry/layerswap/calldata-LayerswapDepository.json
@@ -1,0 +1,210 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "context": {
+    "$id": "LayerswapDepository",
+    "contract": {
+      "deployments": [
+        { "chainId": 1, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 10, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 56, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 100, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 130, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 137, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 143, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 146, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 169, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 185, "address": "0x74C3019613E917ede3Aa079270e9030f01215a06" },
+        { "chainId": 196, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 204, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 252, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 324, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 360, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 480, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 690, "address": "0x74C3019613E917ede3Aa079270e9030f01215a06" },
+        { "chainId": 999, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 1101, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 1135, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 1329, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 1625, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 1868, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 1890, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 1923, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 2020, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 2741, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 2818, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 5000, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 5330, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 8217, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 8453, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 9745, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 9999, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 13371, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 34443, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 42161, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 42170, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 42220, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 43114, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 48900, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 55244, "address": "0x74C3019613E917ede3Aa079270e9030f01215a06" },
+        { "chainId": 57073, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 59144, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 60808, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 80094, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 81457, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 167000, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 534352, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 543210, "address": "0x1b16c320210d913C399500c61A6749946AD42aa8" },
+        { "chainId": 660279, "address": "0x74C3019613E917ede3Aa079270e9030f01215a06" },
+        { "chainId": 747474, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 7777777, "address": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f" },
+        { "chainId": 11155111, "address": "0x805463C27E8D59FEe436f3160904e52ca26bA74b" },
+        { "chainId": 888888888, "address": "0x74C3019613E917ede3Aa079270e9030f01215a06" },
+        { "chainId": 1380012617, "address": "0x74C3019613E917ede3Aa079270e9030f01215a06" }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "Layerswap",
+    "contractName": "LayerswapDepository",
+    "info": {
+      "url": "https://layerswap.io",
+      "deploymentDate": "2026-05-13T00:00:00Z"
+    }
+  },
+  "display": {
+    "formats": {
+      "depositNative(bytes32 id,address receiver)": {
+        "$id": "depositNative",
+        "intent": "Swap ETH",
+        "interpolatedIntent": "Swap {@.value}",
+        "fields": [
+          { "path": "#.id", "label": "Swap ID", "format": "raw", "visible": "always" },
+          {
+            "path": "#.receiver",
+            "label": "Solver",
+            "format": "addressName",
+            "params": { "types": ["wallet", "contract"] },
+            "visible": "always"
+          },
+          { "path": "@.value", "label": "Amount", "format": "amount", "visible": "always" }
+        ]
+      },
+      "depositERC20(bytes32 id,address token,address receiver,uint256 amount)": {
+        "$id": "depositERC20",
+        "intent": "Swap token",
+        "interpolatedIntent": "Swap {#.amount}",
+        "fields": [
+          { "path": "#.id", "label": "Swap ID", "format": "raw", "visible": "always" },
+          {
+            "path": "#.token",
+            "label": "Token to swap",
+            "format": "addressName",
+            "params": { "types": ["contract"] },
+            "visible": "always"
+          },
+          {
+            "path": "#.receiver",
+            "label": "Solver",
+            "format": "addressName",
+            "params": { "types": ["wallet", "contract"] },
+            "visible": "always"
+          },
+          {
+            "path": "#.amount",
+            "label": "Amount",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "#.token" },
+            "visible": "always"
+          }
+        ]
+      },
+      "addToWhitelist(address addr)": {
+        "$id": "addToWhitelist",
+        "intent": "Add solver",
+        "interpolatedIntent": "Whitelist {#.addr} as solver",
+        "fields": [
+          {
+            "path": "#.addr",
+            "label": "Solver to whitelist",
+            "format": "addressName",
+            "params": { "types": ["wallet", "contract"] },
+            "visible": "always"
+          }
+        ]
+      },
+      "removeFromWhitelist(address addr)": {
+        "$id": "removeFromWhitelist",
+        "intent": "Remove solver",
+        "interpolatedIntent": "Remove {#.addr} from whitelist",
+        "fields": [
+          {
+            "path": "#.addr",
+            "label": "Solver to remove",
+            "format": "addressName",
+            "params": { "types": ["wallet", "contract"] },
+            "visible": "always"
+          }
+        ]
+      },
+      "updateWhitelistedAddress(address oldAddr,address newAddr)": {
+        "$id": "updateWhitelistedAddress",
+        "intent": "Replace solver",
+        "interpolatedIntent": "Swap solver to {#.newAddr}",
+        "fields": [
+          {
+            "path": "#.oldAddr",
+            "label": "Existing solver",
+            "format": "addressName",
+            "params": { "types": ["wallet", "contract"] },
+            "visible": "always"
+          },
+          {
+            "path": "#.newAddr",
+            "label": "Replacement solver",
+            "format": "addressName",
+            "params": { "types": ["wallet", "contract"] },
+            "visible": "always"
+          }
+        ]
+      },
+      "pause()": {
+        "$id": "pause",
+        "intent": "Pause",
+        "interpolatedIntent": "Pause Layerswap swaps",
+        "fields": []
+      },
+      "unpause()": {
+        "$id": "unpause",
+        "intent": "Resume",
+        "interpolatedIntent": "Resume Layerswap swaps",
+        "fields": []
+      },
+      "transferOwnership(address newOwner)": {
+        "$id": "transferOwnership",
+        "intent": "Transfer ownership",
+        "interpolatedIntent": "Propose new owner {#.newOwner}",
+        "fields": [
+          {
+            "path": "#.newOwner",
+            "label": "Proposed new owner",
+            "format": "addressName",
+            "params": { "types": ["wallet", "contract"] },
+            "visible": "always"
+          }
+        ]
+      },
+      "acceptOwnership()": {
+        "$id": "acceptOwnership",
+        "intent": "Accept ownership",
+        "interpolatedIntent": "Accept depository ownership",
+        "fields": []
+      },
+      "renounceOwnership()": {
+        "$id": "renounceOwnership",
+        "intent": "Renounce ownership",
+        "interpolatedIntent": "Renounce ownership: FINAL",
+        "fields": []
+      }
+    }
+  }
+}

--- a/registry/layerswap/tests/calldata-LayerswapDepository.tests.json
+++ b/registry/layerswap/tests/calldata-LayerswapDepository.tests.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "../../../specs/erc7730-tests.schema.json",
+  "tests": [
+    {
+      "description": "Layerswap: LayerswapDepository: depositNative - 0.1 ETH",
+      "rawTx": "0x02f8bc83aa36a7808459682f008506fc23ac0083030d4094805463c27e8d59fee436f3160904e52ca26ba74b88016345785d8a0000b84480a6de927468697369737465737469647468697369737465737469647468697369737469000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045c080a0e839959ad4ede2fcc69e72a80ace8fb7a5091ac59c358b1dba5e652476a3c74aa0216ef5f7a178a43f4eab716d2717f0e7e4bd2fc7bf692e55d9e668fac6a2b4c9",
+      "expectedTexts": [
+        "Swap ETH",
+        "Swap 0.1 ETH",
+        "Swap ID",
+        "Solver",
+        "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+        "Amount",
+        "0.1 ETH"
+      ]
+    },
+    {
+      "description": "Layerswap: LayerswapDepository: depositERC20 - 1 USDC",
+      "rawTx": "0x02f8f483aa36a7018459682f008506fc23ac0083030d4094805463c27e8d59fee436f3160904e52ca26ba74b80b884f4371f637468697369737465737469647468697369737465737469647468697369737469000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000f4240c001a08b4cba5c96c8654c1d221174876707e9809f6881e9168f0a95a924b74494d05ba001fddafc0bcddcb84a83c5ebb2bcd9a1cbf7085b7a4d2ecdf586423e088fbdca",
+      "expectedTexts": [
+        "Swap token",
+        "Swap ID",
+        "Token to swap",
+        "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        "Solver",
+        "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+        "Amount",
+        "1 USDC"
+      ]
+    },
+    {
+      "description": "Layerswap: LayerswapDepository: addToWhitelist",
+      "rawTx": "0x02f89383aa36a7028459682f008506fc23ac0083030d4094805463c27e8d59fee436f3160904e52ca26ba74b80a4e43252d7000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045c001a00fe8741ac69c6c5b1be2ac6322a022ca9d851adb061ffc89802450ab4f22aeaba05ab1676b746510b5064a39b77547c1db968086ab81981ab0f01df41e1800964f",
+      "expectedTexts": [
+        "Add solver",
+        "Solver to whitelist",
+        "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+      ]
+    },
+    {
+      "description": "Layerswap: LayerswapDepository: removeFromWhitelist",
+      "rawTx": "0x02f89283aa36a7038459682f008506fc23ac0083030d4094805463c27e8d59fee436f3160904e52ca26ba74b80a48ab1d681000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045c0019ffa6be78852428ed9365972ea41dffcbd586fb3b5c71de50ec60684a26efee0a052892c0a73f6fa3679c7a522abb9be7c23242c892fa0328646cfde7786c46ba8",
+      "expectedTexts": [
+        "Remove solver",
+        "Solver to remove",
+        "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+      ]
+    },
+    {
+      "description": "Layerswap: LayerswapDepository: updateWhitelistedAddress",
+      "rawTx": "0x02f8b483aa36a7048459682f008506fc23ac0083030d4094805463c27e8d59fee436f3160904e52ca26ba74b80b84486d11066000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000ab5801a7d398351b8be11c439e05c5b3259aec9bc080a0e403002045f48b63f71e28750f63232e28b9a2161ef7cf2a8e55a22d87c7fc4ea009019f7ce32e891172b3f862ca0e29dd7b187e663494a96f02dd78b88341ce2c",
+      "expectedTexts": [
+        "Replace solver",
+        "Existing solver",
+        "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+        "Replacement solver",
+        "0xaB5801a7D398351b8bE11C439e05C5B3259aeC9B"
+      ]
+    },
+    {
+      "description": "Layerswap: LayerswapDepository: pause",
+      "rawTx": "0x02f87383aa36a7058459682f008506fc23ac0083030d4094805463c27e8d59fee436f3160904e52ca26ba74b80848456cb59c080a073ab7e5a077d901c60fe2f05d138591ef8877763ff180a95f8605cb6186da8d5a0116214c923d22a80f982a21b16cf17a8bbc2977fd30fec201726f85a3ec64268",
+      "expectedTexts": ["Pause", "Pause Layerswap swaps"]
+    },
+    {
+      "description": "Layerswap: LayerswapDepository: unpause",
+      "rawTx": "0x02f87383aa36a7068459682f008506fc23ac0083030d4094805463c27e8d59fee436f3160904e52ca26ba74b80843f4ba83ac001a0b0a641e82eb3a2858d9cdfbee8300ba07288ab92274275b539f2aea7d864f067a0302aa6a65b9c516698d8905b4f8bbcb42e65fa54b9c20cb0b3c13c7bdad2d620",
+      "expectedTexts": ["Resume", "Resume Layerswap swaps"]
+    },
+    {
+      "description": "Layerswap: LayerswapDepository: transferOwnership",
+      "rawTx": "0x02f89383aa36a7078459682f008506fc23ac0083030d4094805463c27e8d59fee436f3160904e52ca26ba74b80a4f2fde38b000000000000000000000000ab5801a7d398351b8be11c439e05c5b3259aec9bc080a0e64af93b9e901a5f90126f085019eac34dbd991df14fab0ea4a48161d26c5e16a038bdb5a2ed308248978725f1f259be427cb2b3db217b37ad3e425c2b4c55c51a",
+      "expectedTexts": [
+        "Transfer ownership",
+        "Propose new owner",
+        "Proposed new owner",
+        "0xaB5801a7D398351b8bE11C439e05C5B3259aeC9B"
+      ]
+    },
+    {
+      "description": "Layerswap: LayerswapDepository: acceptOwnership",
+      "rawTx": "0x02f87383aa36a7088459682f008506fc23ac0083030d4094805463c27e8d59fee436f3160904e52ca26ba74b808479ba5097c080a0dfe548c5bdc8d6224a32f0cd12cf024be76a91a633fd3a6dd44d9500e14a43cfa067f8970a7f683e726b6b3e406c435d4b18e3ba21afb9e1e6fab55250b6fc193c",
+      "expectedTexts": ["Accept ownership", "Accept depository ownership"]
+    },
+    {
+      "description": "Layerswap: LayerswapDepository: renounceOwnership",
+      "rawTx": "0x02f87383aa36a7098459682f008506fc23ac0083030d4094805463c27e8d59fee436f3160904e52ca26ba74b8084715018a6c080a02334c9415e22fda81d737638b446a55d502b3739f3727e3c31edadd96cd804b9a041ba869b2800da1d8a62af93848b3f677c3134a0b12f91576339f39b105b39fb",
+      "expectedTexts": [
+        "Renounce ownership",
+        "Renounce ownership: FINAL"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds a new `registry/layerswap/` entity covering the **LayerswapDepository** contract, deployed across 56 EVM chains via deterministic deployer.

**Contract:** `LayerswapDepository`

**Functions covered:** `depositNative`, `depositERC20`, `addToWhitelist`, `removeFromWhitelist`, `updateWhitelistedAddress`, `pause`, `unpause`, `transferOwnership`, `acceptOwnership`, `renounceOwnership`

**Tests:** Fixtures in `tests/` cover each described function.