### PR TITLE
Lido – Enhance calldata intents, add wstETH transfer tests

### DIFF
--- a/registry/lido/calldata-WithdrawalQueueERC721.json
+++ b/registry/lido/calldata-WithdrawalQueueERC721.json
@@ -17,9 +17,10 @@
     "formats": {
       "requestWithdrawals(uint256[] _amounts, address _owner)": {
         "intent": "Request Withdrawal",
+        "interpolatedIntent": "Withdraw {_amounts.[]}",
         "fields": [
           {
-            "label": "Amount to withdraw",
+            "label": "Amount",
             "format": "tokenAmount",
             "path": "#._amounts.[]",
             "params": { "token": "$.metadata.constants.stETHaddress" },
@@ -36,9 +37,10 @@
       },
       "requestWithdrawalsWithPermit(uint256[] _amounts, address _owner, (uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) _permit)": {
         "intent": "Request Withdrawal",
+        "interpolatedIntent": "Withdraw {_amounts.[]}",
         "fields": [
           {
-            "label": "Amount to withdraw",
+            "label": "Amount",
             "format": "tokenAmount",
             "path": "#._amounts.[]",
             "params": { "token": "$.metadata.constants.stETHaddress" },
@@ -60,6 +62,7 @@
       },
       "requestWithdrawalsWstETH(uint256[] _amounts, address _owner)": {
         "intent": "Request withdrawal",
+        "interpolatedIntent": "Withdraw {_amounts.[]}",
         "fields": [
           {
             "label": "Amount to withdraw",
@@ -79,6 +82,7 @@
       },
       "requestWithdrawalsWstETHWithPermit(uint256[] _amounts, address _owner, (uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) _permit)": {
         "intent": "Request withdrawal",
+        "interpolatedIntent": "Withdraw {_amounts.[]}",
         "fields": [
           {
             "label": "Amount to withdraw",
@@ -98,18 +102,18 @@
         ]
       },
       "claimWithdrawal(uint256 _requestId)": {
-        "intent": "claim withdrawal",
+        "intent": "Claim withdrawal",
         "fields": [{ "label": "Request ID", "format": "raw", "path": "#._requestId", "visible": "always" }]
       },
       "claimWithdrawals(uint256[] _requestIds, uint256[] _hints)": {
-        "intent": "claim withdrawals",
+        "intent": "Claim withdrawals",
         "fields": [
           { "label": "Request ID", "format": "raw", "path": "#._requestIds.[]", "visible": "always" },
           { "label": "Hints", "path": "#._hints.[]", "visible": "never" }
         ]
       },
       "claimWithdrawalsTo(uint256[] _requestIds, uint256[] _hints, address _recipient)": {
-        "intent": "claim withdrawals",
+        "intent": "Claim withdrawals",
         "fields": [
           { "label": "Request IDs", "format": "raw", "path": "#._requestIds.[]", "visible": "always" },
           {
@@ -136,6 +140,7 @@
       },
       "safeTransferFrom(address _from, address _to, uint256 _requestId)": {
         "intent": "Transfer unstETH NFT",
+        "interpolatedIntent": "Send unstETH to {_to}",
         "fields": [
           {
             "label": "From",
@@ -156,6 +161,7 @@
       },
       "transferFrom(address _from, address _to, uint256 _requestId)": {
         "intent": "Transfer unstETH NFT",
+        "interpolatedIntent": "Send unstETH to {_to}",
         "fields": [
           {
             "label": "From",
@@ -175,7 +181,7 @@
         ]
       },
       "setApprovalForAll(address _operator, bool _approved)": {
-        "intent": "Approve unstETH NFTs",
+        "intent": "Set unstETH operator approval",
         "fields": [
           {
             "label": "Operator",

--- a/registry/lido/calldata-stETH.json
+++ b/registry/lido/calldata-stETH.json
@@ -11,6 +11,7 @@
     "formats": {
       "approve(address _spender, uint256 _amount)": {
         "intent": "Approve stETH",
+        "interpolatedIntent": "Allow to spend {_amount}",
         "fields": [
           {
             "label": "Spender",
@@ -30,13 +31,15 @@
       },
       "submit(address _referral)": {
         "intent": "Stake ETH",
+        "interpolatedIntent": "Stake {@.value} ETH",
         "fields": [
-          { "label": "Amount to stake", "format": "amount", "path": "@.value" },
+          { "label": "Amount", "format": "amount", "path": "@.value" },
           { "label": "Referral", "path": "#._referral", "visible": "never" }
         ]
       },
       "transfer(address _recipient, uint256 _amount)": {
         "intent": "Transfer stETH",
+        "interpolatedIntent": "Send {_amount} to {_recipient}",
         "fields": [
           {
             "label": "Recipient",

--- a/registry/lido/calldata-stETH.json
+++ b/registry/lido/calldata-stETH.json
@@ -24,7 +24,11 @@
             "label": "Amount",
             "format": "tokenAmount",
             "path": "#._amount",
-            "params": { "token": "$.metadata.constants.stETHaddress" },
+            "params": {
+              "token": "$.metadata.constants.stETHaddress",
+              "threshold": "0x8000000000000000000000000000000000000000000000000000000000000000",
+              "message": "Unlimited"
+            },
             "visible": "always"
           }
         ]

--- a/registry/lido/calldata-wstETH-referral-staker.json
+++ b/registry/lido/calldata-wstETH-referral-staker.json
@@ -9,6 +9,7 @@
     "formats": {
       "stakeETH(address _referral)": {
         "intent": "Stake ETH",
+        "interpolatedIntent": "Stake {@.value} ETH",
         "fields": [
           { "label": "Amount to stake", "format": "amount", "path": "@.value" },
           { "label": "Referral", "path": "#._referral", "visible": "never" }

--- a/registry/lido/calldata-wstETH.json
+++ b/registry/lido/calldata-wstETH.json
@@ -14,6 +14,7 @@
     "formats": {
       "approve(address spender, uint256 amount)": {
         "intent": "Authorize spending",
+        "interpolatedIntent": "Allow to spend {amount}",
         "fields": [
           {
             "label": "Spender",
@@ -31,8 +32,78 @@
           }
         ]
       },
+      "decreaseAllowance(address spender, uint256 subtractedValue)": {
+        "intent": "Decrease allowance",
+        "fields": [
+          {
+            "label": "Spender",
+            "format": "addressName",
+            "params": { "types": ["contract"], "sources": ["local"] },
+            "path": "#.spender",
+            "visible": "always"
+          },
+          {
+            "label": "Amount",
+            "format": "tokenAmount",
+            "path": "#.subtractedValue",
+            "params": { "token": "$.metadata.constants.wstETHaddress" },
+            "visible": "always"
+          }
+        ]
+      },
+      "increaseAllowance(address spender, uint256 addedValue)": {
+        "intent": "Increase allowance",
+        "fields": [
+          {
+            "label": "Spender",
+            "format": "addressName",
+            "params": { "types": ["contract"], "sources": ["local"] },
+            "path": "#.spender",
+            "visible": "always"
+          },
+          {
+            "label": "Amount",
+            "format": "tokenAmount",
+            "path": "#.addedValue",
+            "params": { "token": "$.metadata.constants.wstETHaddress" },
+            "visible": "always"
+          }
+        ]
+      },
+      "permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s)": {
+        "intent": "Permit spending",
+        "interpolatedIntent": "Permit {value} spending",
+        "fields": [
+          {
+            "label": "Owner",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet"], "sources": ["local", "ens"] },
+            "path": "#.owner",
+            "visible": "always"
+          },
+          {
+            "label": "Spender",
+            "format": "addressName",
+            "params": { "types": ["contract"], "sources": ["local"] },
+            "path": "#.spender",
+            "visible": "always"
+          },
+          {
+            "label": "Amount",
+            "format": "tokenAmount",
+            "path": "#.value",
+            "params": { "token": "$.metadata.constants.wstETHaddress" },
+            "visible": "always"
+          },
+          { "label": "Deadline", "format": "date", "params": { "encoding": "timestamp" }, "path": "#.deadline", "visible": "always" },
+          { "label": "V", "path": "#.v", "visible": "never" },
+          { "label": "R", "path": "#.r", "visible": "never" },
+          { "label": "S", "path": "#.s", "visible": "never" }
+        ]
+      },
       "wrap(uint256 _stETHAmount)": {
         "intent": "Wrap stETH",
+        "interpolatedIntent": "Wrap {_stETHAmount}",
         "fields": [
           {
             "label": "stETH amount",
@@ -45,6 +116,7 @@
       },
       "unwrap(uint256 _wstETHAmount)": {
         "intent": "Unwrap wstETH to stETH",
+        "interpolatedIntent": "Unwrap {_wstETHAmount}",
         "fields": [
           {
             "label": "wstETH amount",
@@ -57,7 +129,35 @@
       },
       "transfer(address recipient, uint256 amount)": {
         "intent": "Transfer wstETH",
+        "interpolatedIntent": "Send {amount} to {recipient}",
         "fields": [
+          {
+            "label": "Recipient",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet"], "sources": ["local", "ens"] },
+            "path": "#.recipient",
+            "visible": "always"
+          },
+          {
+            "label": "Amount",
+            "format": "tokenAmount",
+            "path": "#.amount",
+            "params": { "token": "$.metadata.constants.wstETHaddress" },
+            "visible": "always"
+          }
+        ]
+      },
+      "transferFrom(address sender, address recipient, uint256 amount)": {
+        "intent": "Transfer wstETH",
+        "interpolatedIntent": "Send {amount} to {recipient}",
+        "fields": [
+          {
+            "label": "Sender",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet"], "sources": ["local", "ens"] },
+            "path": "#.sender",
+            "visible": "always"
+          },
           {
             "label": "Recipient",
             "format": "addressName",

--- a/registry/lido/calldata-wstETH.json
+++ b/registry/lido/calldata-wstETH.json
@@ -27,7 +27,11 @@
             "label": "Amount",
             "format": "tokenAmount",
             "path": "#.amount",
-            "params": { "token": "$.metadata.constants.wstETHaddress" },
+            "params": {
+              "token": "$.metadata.constants.wstETHaddress",
+              "threshold": "0x8000000000000000000000000000000000000000000000000000000000000000",
+              "message": "Unlimited"
+            },
             "visible": "always"
           }
         ]
@@ -65,7 +69,11 @@
             "label": "Amount",
             "format": "tokenAmount",
             "path": "#.addedValue",
-            "params": { "token": "$.metadata.constants.wstETHaddress" },
+            "params": {
+              "token": "$.metadata.constants.wstETHaddress",
+              "threshold": "0x8000000000000000000000000000000000000000000000000000000000000000",
+              "message": "Unlimited"
+            },
             "visible": "always"
           }
         ]
@@ -92,7 +100,11 @@
             "label": "Amount",
             "format": "tokenAmount",
             "path": "#.value",
-            "params": { "token": "$.metadata.constants.wstETHaddress" },
+            "params": {
+              "token": "$.metadata.constants.wstETHaddress",
+              "threshold": "0x8000000000000000000000000000000000000000000000000000000000000000",
+              "message": "Unlimited"
+            },
             "visible": "always"
           },
           { "label": "Deadline", "format": "date", "params": { "encoding": "timestamp" }, "path": "#.deadline", "visible": "always" },

--- a/registry/lido/tests/calldata-wstETH.tests.json
+++ b/registry/lido/tests/calldata-wstETH.tests.json
@@ -42,6 +42,53 @@
         "Max fees",
         "0.0000045605908 ETH"
       ]
+    },
+    {
+      "description": "Decrease allowance - chain 1",
+      "rawTx": "0x02f8af01138477359400848b3dee0382ade2947f39c581f595b53c5cb19bd0b3f8da6c935e2ca080b844a457c2d7000000000000000000000000e951fe9a680e1249dbe463dd14a6d7061442bc9f00000000000000000000000000000000000000000000000001634549cc9c3000c080a0a57b29534519e2f8ebbe6f1f5889f4299360fa3af576f43ad9495d74e0880adda07a430809723b87417efb13c1b0f2f1995ede8681a2d913802d55261c019ae807",
+      "txHash": "0x0803495eb52ed1e5bdb65e386f603b9a1c83c20fb69365aa24fe0ce2ec93a5f2",
+      "expectedTexts": [
+        "Interaction with",
+        "Lido DAO",
+        "Spender",
+        "0xe951fe9A680e1249 DBe463DD14A6d7061 442bc9f",
+        "Amount",
+        "0.0999998 wstETH"
+      ]
+    },
+    {
+      "description": "Increase allowance - chain 1",
+      "rawTx": "0x02f8af014c84773594008483eb8ad282ae04947f39c581f595b53c5cb19bd0b3f8da6c935e2ca080b844395093510000000000000000000000005bdd5eb14d20cebd6d90b92da6eb866ee756c1220000000000000000000000000000000000000000000000000000000000000064c080a0622cfa3c9213c9ab97a962716d5fc9a63a0f9b496844184d49da140ce65e320da06e1eca8728f6b44ffa14ba31a2be7f69cc6c42bbb0942996977bae92a546af17",
+      "txHash": "0xc969f43f76513d06e6731afffe2a55387a9c0c420bcbbef5ea7007e77c598150",
+      "expectedTexts": [
+        "Interaction with",
+        "Lido DAO",
+        "Spender",
+        "0x5BDD5EB14D20CEbD 6d90B92da6eB866Ee 756C122",
+        "Amount",
+        "0.00000000000000 01 wstETH"
+      ]
+    },
+    {
+      "description": "Permit spending - chain 1",
+      "rawTx": "0x02f901520182932a831d5918850176be191b83037cc2947f39c581f595b53c5cb19bd0b3f8da6c935e2ca080b8e4d505accf00000000000000000000000008b00ceee2fb66029b53d76110b19eeaabfd1e65000000000000000000000000e66aa98b55c5a55c9af9da12fe39b8868af9a346ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000000000000000000000000000000000000000000000000000000000000001bd925c9dc4daf2b97326adca692aba99dd40a1394c841772f5a724c2dc35953867e99359d1f68b310a5c7f88d01abaf6956d58334b3ec60f8b70f32380d9474fcc080a086dc5258e055940460390ded6e39e780df41d52370b43ef0a43caa37cfd4b0e7a05f786412335c0e17ba3fa0ea7dd8158025feafa6a8a7e5c478abecc0978d960b",
+      "txHash": "0x921cbe8ffe2ae92351a33e194d6d170420d94903f636adeb04108565ca6bed86",
+      "expectedTexts": ["Interaction with", "Lido DAO", "Owner", "Spender", "Amount", "Deadline"]
+    },
+    {
+      "description": "Transfer wstETH from sender - chain 1",
+      "rawTx": "0x02f8d20182932b831d591885016d07380b8301f659947f39c581f595b53c5cb19bd0b3f8da6c935e2ca080b86423b872dd00000000000000000000000008b00ceee2fb66029b53d76110b19eeaabfd1e650000000000000000000000002aed99855fed0259e5774b50a9f589d2bc1e1597000000000000000000000000000000000000000000000000019334e70d000e9cc080a029a68b8e2e55674076776041e82a7a26c4838fa07389add5fd990fa407a593caa02cda4f8121f333419b1bb92a9009d10b06f74172e3a2310f1dd5afe2511de6a2",
+      "txHash": "0x6cb5632a279fcf9becb607354da606ba672d05151afebc5ba70450f1fd5cd790",
+      "expectedTexts": [
+        "Interaction with",
+        "Lido DAO",
+        "Sender",
+        "0x08B00CEeE2fB660 29b53D76110b19eEa ABFd1e65",
+        "Recipient",
+        "0x2aEd99855FeD0259 e5774B50A9f589D2b C1e1597",
+        "Amount",
+        "0.11349258257459 1644 wstETH"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add `interpolatedIntent` coverage for Lido calldata descriptors to improve clear-signing summaries.
- Improve Lido unstETH withdrawal queue wording for withdrawal and NFT transfer flows.
- Add missing wstETH display formats for:
  - `decreaseAllowance`
  - `increaseAllowance`
  - `permit`
  - `transferFrom`
- Extend wstETH calldata tests with real mainnet transactions for the newly covered functions.

## Validation

- `erc7730 lint registry/lido/calldata-wstETH.json`
  - passes with no issues after adding the missing wstETH formats.
- `erc7730 lint registry/lido/calldata-WithdrawalQueueERC721.json`
  - still reports existing ABI/reference warnings because the contract is a proxy and the linter compares against the proxy ABI.
- `erc7730 lint registry/lido/calldata-stETH.json`
  - still reports existing ABI/reference warnings because the contract is a proxy and the linter compares against the proxy ABI.
- JSON/schema validation for `registry/lido/tests/calldata-wstETH.tests.json`
- Confirmed the serialized transactions added as `rawTx` match their referenced `txHash` values.
