### PR TITLE
feat(usd8): add USD8 Booster clear-signing descriptors

### DIFF
--- a/registry/usd8/calldata-USD8Booster.json
+++ b/registry/usd8/calldata-USD8Booster.json
@@ -1,0 +1,282 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "context": {
+    "$id": "USD8Booster",
+    "contract": {
+      "abi": "https://api.etherscan.io/api?module=contract&action=getabi&address=0x6f74ce39bb1d75c56e2fe5f349a6a5f51ce6f12d&format=raw",
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x6f74ce39bb1d75c56e2fe5f349a6a5f51ce6f12d"
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "USD8",
+    "info": {
+      "legalName": "USD8 (usd8.fi)",
+      "url": "https://usd8.fi",
+      "deploymentDate": "2026-05-03"
+    },
+    "enums": {
+      "tokenId": {
+        "1": "1% Cover Booster"
+      }
+    },
+    "constants": {
+      "boosterAdmin": "0x977cc5a8504ab467b73259dcc2288dd1869efa41"
+    }
+  },
+  "display": {
+    "formats": {
+      "claim(address receiver,uint256 nonce,uint256 tokenId,uint256 amount,bytes signature)": {
+        "$id": "claim",
+        "intent": "Claim USD8 Booster NFT",
+        "fields": [
+          {
+            "label": "Receiver",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet"] },
+            "path": "#.receiver"
+          },
+          {
+            "label": "Booster type",
+            "format": "enum",
+            "params": { "$ref": "$.metadata.enums.tokenId" },
+            "path": "#.tokenId"
+          },
+          {
+            "label": "Amount",
+            "format": "raw",
+            "path": "#.amount"
+          },
+          {
+            "label": "Nonce",
+            "format": "raw",
+            "path": "#.nonce"
+          },
+          {
+            "label": "Auth signature",
+            "format": "raw",
+            "path": "#.signature",
+            "visible": "never"
+          }
+        ]
+      },
+      "mint(address to,uint256 tokenId,uint256 amount)": {
+        "$id": "mint",
+        "intent": "Admin mint USD8 Booster",
+        "fields": [
+          {
+            "label": "Recipient",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet"] },
+            "path": "#.to"
+          },
+          {
+            "label": "Booster type",
+            "format": "enum",
+            "params": { "$ref": "$.metadata.enums.tokenId" },
+            "path": "#.tokenId"
+          },
+          {
+            "label": "Amount",
+            "format": "raw",
+            "path": "#.amount"
+          }
+        ]
+      },
+      "mintBatch(address[] recipients,uint256[] tokenIds,uint256[] amounts)": {
+        "$id": "mintBatch",
+        "intent": "Admin batch mint USD8 Boosters",
+        "fields": [
+          {
+            "label": "Recipients",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet"] },
+            "path": "#.recipients.[]"
+          },
+          {
+            "label": "Booster types",
+            "format": "enum",
+            "params": { "$ref": "$.metadata.enums.tokenId" },
+            "path": "#.tokenIds.[]"
+          },
+          {
+            "label": "Amounts",
+            "format": "raw",
+            "path": "#.amounts.[]"
+          }
+        ]
+      },
+      "safeTransferFrom(address from,address to,uint256 id,uint256 value,bytes data)": {
+        "$id": "safeTransferFrom",
+        "intent": "Transfer USD8 Booster",
+        "fields": [
+          {
+            "label": "From",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet"] },
+            "path": "#.from"
+          },
+          {
+            "label": "To",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet"] },
+            "path": "#.to"
+          },
+          {
+            "label": "Booster type",
+            "format": "enum",
+            "params": { "$ref": "$.metadata.enums.tokenId" },
+            "path": "#.id"
+          },
+          {
+            "label": "Amount",
+            "format": "raw",
+            "path": "#.value"
+          },
+          {
+            "label": "Data",
+            "format": "raw",
+            "path": "#.data",
+            "visible": "never"
+          }
+        ]
+      },
+      "safeBatchTransferFrom(address from,address to,uint256[] ids,uint256[] values,bytes data)": {
+        "$id": "safeBatchTransferFrom",
+        "intent": "Batch transfer USD8 Boosters",
+        "fields": [
+          {
+            "label": "From",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet"] },
+            "path": "#.from"
+          },
+          {
+            "label": "To",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet"] },
+            "path": "#.to"
+          },
+          {
+            "label": "Booster types",
+            "format": "enum",
+            "params": { "$ref": "$.metadata.enums.tokenId" },
+            "path": "#.ids.[]"
+          },
+          {
+            "label": "Amounts",
+            "format": "raw",
+            "path": "#.values.[]"
+          },
+          {
+            "label": "Data",
+            "format": "raw",
+            "path": "#.data",
+            "visible": "never"
+          }
+        ]
+      },
+      "setApprovalForAll(address operator,bool approved)": {
+        "$id": "setApprovalForAll",
+        "intent": "Approve operator",
+        "fields": [
+          {
+            "label": "Operator",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet", "contract"] },
+            "path": "#.operator"
+          },
+          {
+            "label": "Approved",
+            "format": "raw",
+            "path": "#.approved"
+          }
+        ]
+      },
+      "burn(address account,uint256 id,uint256 value)": {
+        "$id": "burn",
+        "intent": "Burn USD8 Booster",
+        "fields": [
+          {
+            "label": "From",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet"] },
+            "path": "#.account"
+          },
+          {
+            "label": "Booster type",
+            "format": "enum",
+            "params": { "$ref": "$.metadata.enums.tokenId" },
+            "path": "#.id"
+          },
+          {
+            "label": "Amount",
+            "format": "raw",
+            "path": "#.value"
+          }
+        ]
+      },
+      "burnBatch(address account,uint256[] ids,uint256[] values)": {
+        "$id": "burnBatch",
+        "intent": "Batch burn USD8 Boosters",
+        "fields": [
+          {
+            "label": "From",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet"] },
+            "path": "#.account"
+          },
+          {
+            "label": "Booster types",
+            "format": "enum",
+            "params": { "$ref": "$.metadata.enums.tokenId" },
+            "path": "#.ids.[]"
+          },
+          {
+            "label": "Amounts",
+            "format": "raw",
+            "path": "#.values.[]"
+          }
+        ]
+      },
+      "setSigner(address newSigner)": {
+        "$id": "setSigner",
+        "intent": "Rotate claim signer",
+        "fields": [
+          {
+            "label": "New signer",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet"] },
+            "path": "#.newSigner"
+          }
+        ]
+      },
+      "setURI(string newuri)": {
+        "$id": "setURI",
+        "intent": "Update metadata URI",
+        "fields": [
+          {
+            "label": "New URI",
+            "format": "raw",
+            "path": "#.newuri"
+          }
+        ]
+      },
+      "invalidateNonce(uint256 nonce)": {
+        "$id": "invalidateNonce",
+        "intent": "Invalidate claim nonce",
+        "fields": [
+          {
+            "label": "Nonce",
+            "format": "raw",
+            "path": "#.nonce"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/registry/usd8/eip712-USD8BoosterClaim.json
+++ b/registry/usd8/eip712-USD8BoosterClaim.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "context": {
+    "$id": "USD8BoosterClaim",
+    "eip712": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x6f74ce39bb1d75c56e2fe5f349a6a5f51ce6f12d"
+        }
+      ],
+      "domain": {
+        "name": "USD8Booster",
+        "version": "1",
+        "chainId": 1,
+        "verifyingContract": "0x6f74ce39bb1d75c56e2fe5f349a6a5f51ce6f12d"
+      },
+      "schemas": [
+        {
+          "primaryType": "Claim",
+          "types": {
+            "Claim": [
+              { "name": "receiver", "type": "address" },
+              { "name": "nonce", "type": "uint256" },
+              { "name": "tokenId", "type": "uint256" },
+              { "name": "amount", "type": "uint256" }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "USD8",
+    "info": {
+      "legalName": "USD8 (usd8.fi)",
+      "url": "https://usd8.fi"
+    },
+    "enums": {
+      "tokenId": {
+        "1": "1% Cover Booster"
+      }
+    }
+  },
+  "display": {
+    "formats": {
+      "Claim": {
+        "$id": "claim",
+        "intent": "Authorize USD8 Booster claim",
+        "fields": [
+          {
+            "label": "Receiver",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet"] },
+            "path": "receiver"
+          },
+          {
+            "label": "Booster type",
+            "format": "enum",
+            "params": { "$ref": "$.metadata.enums.tokenId" },
+            "path": "tokenId"
+          },
+          {
+            "label": "Amount",
+            "format": "raw",
+            "path": "amount"
+          },
+          {
+            "label": "Nonce",
+            "format": "raw",
+            "path": "nonce"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/registry/usd8/tests/eip712-USD8BoosterClaim.tests.json
+++ b/registry/usd8/tests/eip712-USD8BoosterClaim.tests.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "../../../specs/erc7730-tests.schema.json",
+  "tests": [
+    {
+      "description": "Single 1% Cover Booster claim signed by admin/signer",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "Claim": [
+            { "name": "receiver", "type": "address" },
+            { "name": "nonce", "type": "uint256" },
+            { "name": "tokenId", "type": "uint256" },
+            { "name": "amount", "type": "uint256" }
+          ]
+        },
+        "primaryType": "Claim",
+        "domain": {
+          "name": "USD8Booster",
+          "version": "1",
+          "chainId": 1,
+          "verifyingContract": "0x6f74ce39bb1d75c56e2fe5f349a6a5f51ce6f12d"
+        },
+        "message": {
+          "receiver": "0x977cc5A8504Ab467B73259dcC2288dd1869EfA41",
+          "nonce": "1",
+          "tokenId": "1",
+          "amount": "10"
+        }
+      },
+      "expectedTexts": [
+        "Authorize USD8 Booster claim",
+        "Receiver",
+        "0x977cc5A8504Ab467B73259dcC2288dd1869EfA41",
+        "Booster type",
+        "1% Cover Booster",
+        "Amount",
+        "10",
+        "Nonce",
+        "1"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds ERC-7730 clear-signing descriptors for the USD8 Booster ERC-1155 contract.

- **Contract**: `0x6f74ce39bb1d75c56e2fe5f349a6a5f51ce6f12d` (mainnet, verified)
- **Source**: https://github.com/Usd8-fi/usd8-boosters-NFT
- **Project**: https://usd8.fi

### Files added under `registry/usd8/`

- `calldata-USD8Booster.json` — calldata clear-signing for `claim`, `mint`, `mintBatch`, `safeTransferFrom`, `safeBatchTransferFrom`, `setApprovalForAll`, `burn`, `burnBatch`, `setSigner`, `setURI`, `invalidateNonce`
- `eip712-USD8BoosterClaim.json` — EIP-712 typed-data clear-signing for `Claim(address receiver,uint256 nonce,uint256 tokenId,uint256 amount)`
- `tests/eip712-USD8BoosterClaim.tests.json` — reference test vector

### Validation

`erc7730 lint registry/usd8/calldata-USD8Booster.json registry/usd8/eip712-USD8BoosterClaim.json` passes locally. The only non-blocking output is the Etherscan ABI-fetch warning (CI has the API key secret).

### Scope

Touches only `registry/usd8/` — single entity per registry rules.