### PR TITLE
feat(avvatar-labs-alia): add ALIA Quality Network descriptors (BNB te…

### DIFF
--- a/registry/avvatar-labs-alia/calldata-PillarDRouter.json
+++ b/registry/avvatar-labs-alia/calldata-PillarDRouter.json
@@ -747,15 +747,15 @@
     },
     "enums": {
       "pillarDMode": {
-        "0": "NONE (unset)",
-        "1": "Yield Boosted (quality-routed allocation)",
-        "2": "Tranching (senior/junior)",
-        "3": "Income Streaming (fixed monthly flow)"
+        "0": "NONE",
+        "1": "Yield Boosted",
+        "2": "Tranching",
+        "3": "Income Streaming"
       },
       "agilOpType": {
-        "0x6850612400000000000000000000000000000000000000000000000000000000": "DEPOSIT_PILLAR_D (3-of-5 ALIA operators)",
-        "0x05ae06ce00000000000000000000000000000000000000000000000000000000": "DEPOSIT_YIELD_MODE (3-of-5 ALIA operators)",
-        "0xd294133300000000000000000000000000000000000000000000000000000000": "REBALANCE_YIELD (3-of-5 ALIA operators)"
+        "0x6850612400000000000000000000000000000000000000000000000000000000": "DEPOSIT_PILLAR_D",
+        "0x05ae06ce00000000000000000000000000000000000000000000000000000000": "DEPOSIT_YIELD",
+        "0xd294133300000000000000000000000000000000000000000000000000000000": "REBALANCE_YIELD"
       }
     },
     "constants": {
@@ -768,14 +768,14 @@
   "display": {
     "definitions": {
       "agilOpTypeField": {
-        "label": "AGIL Operation Type",
+        "label": "Op Type",
         "format": "enum",
         "params": {
           "$ref": "$.metadata.enums.agilOpType"
         }
       },
       "agilUserField": {
-        "label": "Attestation User",
+        "label": "User",
         "format": "addressName",
         "params": {
           "types": [
@@ -785,7 +785,7 @@
         }
       },
       "agilAssetField": {
-        "label": "Attestation Asset",
+        "label": "Asset",
         "format": "addressName",
         "params": {
           "types": [
@@ -794,7 +794,7 @@
         }
       },
       "agilExpiryField": {
-        "label": "Attestation Valid Until",
+        "label": "Valid Until",
         "format": "date",
         "params": {
           "encoding": "timestamp"
@@ -804,7 +804,7 @@
     "formats": {
       "deposit(uint8,address,uint256,address,bytes32,(bytes32,address,address,uint256,bytes32,uint256,uint256,uint256),bytes[])": {
         "$id": "pillar_d_deposit",
-        "intent": "Deposit into ALIA Pillar D (AGIL-attested)",
+        "intent": "Deposit Pillar D (AGIL)",
         "fields": [
           {
             "path": "mode",
@@ -826,7 +826,7 @@
           },
           {
             "path": "amount",
-            "label": "Amount to Deposit",
+            "label": "Amount",
             "format": "tokenAmount",
             "params": {
               "tokenPath": "asset"
@@ -834,7 +834,7 @@
           },
           {
             "path": "receiver",
-            "label": "Shares Recipient (receiver)",
+            "label": "Recipient",
             "format": "addressName",
             "params": {
               "types": [
@@ -862,7 +862,7 @@
           },
           {
             "path": "agilAtt.amount",
-            "label": "Attested Amount",
+            "label": "Att. Amount",
             "format": "tokenAmount",
             "params": {
               "tokenPath": "agilAtt.asset"
@@ -870,7 +870,7 @@
           },
           {
             "path": "agilAtt.mandateId",
-            "label": "Attested Mandate",
+            "label": "Att. Mandate",
             "format": "raw"
           },
           {
@@ -884,14 +884,14 @@
           },
           {
             "path": "agilAtt.chainId",
-            "label": "Attestation Chain ID",
+            "label": "Chain ID",
             "format": "raw"
           }
         ]
       },
       "redeem(uint8,address,uint256,address)": {
         "$id": "pillar_d_redeem",
-        "intent": "Redeem from ALIA Pillar D",
+        "intent": "Redeem Pillar D",
         "fields": [
           {
             "path": "mode",
@@ -913,12 +913,12 @@
           },
           {
             "path": "shares",
-            "label": "Shares to Redeem",
+            "label": "Shares",
             "format": "raw"
           },
           {
             "path": "receiver",
-            "label": "Asset Recipient (receiver)",
+            "label": "Recipient",
             "format": "addressName",
             "params": {
               "types": [
@@ -931,12 +931,12 @@
       },
       "pause()": {
         "$id": "pillar_d_pause",
-        "intent": "Pause ALIA Pillar D Router (owner kill switch)",
+        "intent": "Pause Pillar D Router",
         "fields": []
       },
       "unpause()": {
         "$id": "pillar_d_unpause",
-        "intent": "Unpause ALIA Pillar D Router (owner)",
+        "intent": "Unpause Pillar D Router",
         "fields": []
       },
       "activateMode(uint8)": {

--- a/registry/avvatar-labs-alia/calldata-PillarDRouter.json
+++ b/registry/avvatar-labs-alia/calldata-PillarDRouter.json
@@ -741,7 +741,6 @@
   "metadata": {
     "owner": "ALIA Quality Network",
     "info": {
-      "legalName": "Avvatar Labs SAS",
       "url": "https://alia.network",
       "deploymentDate": "2026-05-15T14:17:00Z"
     },
@@ -766,43 +765,8 @@
     }
   },
   "display": {
-    "definitions": {
-      "agilOpTypeField": {
-        "label": "Op Type",
-        "format": "enum",
-        "params": {
-          "$ref": "$.metadata.enums.agilOpType"
-        }
-      },
-      "agilUserField": {
-        "label": "User",
-        "format": "addressName",
-        "params": {
-          "types": [
-            "eoa",
-            "wallet"
-          ]
-        }
-      },
-      "agilAssetField": {
-        "label": "Asset",
-        "format": "addressName",
-        "params": {
-          "types": [
-            "token"
-          ]
-        }
-      },
-      "agilExpiryField": {
-        "label": "Valid Until",
-        "format": "date",
-        "params": {
-          "encoding": "timestamp"
-        }
-      }
-    },
     "formats": {
-      "deposit(uint8,address,uint256,address,bytes32,(bytes32,address,address,uint256,bytes32,uint256,uint256,uint256),bytes[])": {
+      "deposit(uint8 mode, address asset, uint256 amount, address receiver, bytes32 mandateId, tuple agilAtt, bytes[] signatures)": {
         "$id": "pillar_d_deposit",
         "intent": "Deposit Pillar D (AGIL)",
         "fields": [
@@ -850,15 +814,32 @@
           },
           {
             "path": "agilAtt.opType",
-            "$ref": "$.display.definitions.agilOpTypeField"
+            "label": "Op Type",
+            "format": "enum",
+            "params": {
+              "$ref": "$.metadata.enums.agilOpType"
+            }
           },
           {
             "path": "agilAtt.user",
-            "$ref": "$.display.definitions.agilUserField"
+            "label": "Owner",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "eoa",
+                "wallet"
+              ]
+            }
           },
           {
             "path": "agilAtt.asset",
-            "$ref": "$.display.definitions.agilAssetField"
+            "label": "Att. Asset",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "token"
+              ]
+            }
           },
           {
             "path": "agilAtt.amount",
@@ -880,7 +861,11 @@
           },
           {
             "path": "agilAtt.expiry",
-            "$ref": "$.display.definitions.agilExpiryField"
+            "label": "Expiry",
+            "format": "date",
+            "params": {
+              "encoding": "timestamp"
+            }
           },
           {
             "path": "agilAtt.chainId",
@@ -889,7 +874,7 @@
           }
         ]
       },
-      "redeem(uint8,address,uint256,address)": {
+      "redeem(uint8 mode, address asset, uint256 shares, address receiver)": {
         "$id": "pillar_d_redeem",
         "intent": "Redeem Pillar D",
         "fields": [
@@ -939,7 +924,7 @@
         "intent": "Unpause Pillar D Router",
         "fields": []
       },
-      "activateMode(uint8)": {
+      "activateMode(uint8 mode)": {
         "$id": "pillar_d_activate_mode",
         "intent": "Activate Pillar D Mode",
         "fields": [
@@ -953,7 +938,7 @@
           }
         ]
       },
-      "deactivateMode(uint8)": {
+      "deactivateMode(uint8 mode)": {
         "$id": "pillar_d_deactivate_mode",
         "intent": "Deactivate Pillar D Mode",
         "fields": [

--- a/registry/avvatar-labs-alia/calldata-PillarDRouter.json
+++ b/registry/avvatar-labs-alia/calldata-PillarDRouter.json
@@ -1,0 +1,998 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "context": {
+    "$id": "ALIA Pillar D Router",
+    "contract": {
+      "abi": [
+        {
+          "type": "constructor",
+          "inputs": [
+            {
+              "name": "_agilVerifier",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "acceptOwnership",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "activateMode",
+          "inputs": [
+            {
+              "name": "mode",
+              "type": "uint8",
+              "internalType": "enum PillarDRouter.Mode"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "agilVerifier",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "contract AGILSignatureVerifier"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "deactivateMode",
+          "inputs": [
+            {
+              "name": "mode",
+              "type": "uint8",
+              "internalType": "enum PillarDRouter.Mode"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "deposit",
+          "inputs": [
+            {
+              "name": "mode",
+              "type": "uint8",
+              "internalType": "enum PillarDRouter.Mode"
+            },
+            {
+              "name": "asset",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "mandateId",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "agilAtt",
+              "type": "tuple",
+              "internalType": "struct AGILSignatureVerifier.AGILOperationAttestation",
+              "components": [
+                {
+                  "name": "opType",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "user",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "asset",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "amount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "mandateId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "nonce",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "expiry",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "chainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "agilSigs",
+              "type": "bytes[]",
+              "internalType": "bytes[]"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "shares",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "getModeImpl",
+          "inputs": [
+            {
+              "name": "mode",
+              "type": "uint8",
+              "internalType": "enum PillarDRouter.Mode"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "isModeActive",
+          "inputs": [
+            {
+              "name": "mode",
+              "type": "uint8",
+              "internalType": "enum PillarDRouter.Mode"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "modeActive",
+          "inputs": [
+            {
+              "name": "",
+              "type": "uint8",
+              "internalType": "enum PillarDRouter.Mode"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "modeContract",
+          "inputs": [
+            {
+              "name": "",
+              "type": "uint8",
+              "internalType": "enum PillarDRouter.Mode"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "owner",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "pause",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "paused",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "pendingOwner",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "redeem",
+          "inputs": [
+            {
+              "name": "mode",
+              "type": "uint8",
+              "internalType": "enum PillarDRouter.Mode"
+            },
+            {
+              "name": "asset",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "shares",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "assets",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "registerMode",
+          "inputs": [
+            {
+              "name": "mode",
+              "type": "uint8",
+              "internalType": "enum PillarDRouter.Mode"
+            },
+            {
+              "name": "impl",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "shareBalanceOf",
+          "inputs": [
+            {
+              "name": "mode",
+              "type": "uint8",
+              "internalType": "enum PillarDRouter.Mode"
+            },
+            {
+              "name": "asset",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "user",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "totalAssets",
+          "inputs": [
+            {
+              "name": "mode",
+              "type": "uint8",
+              "internalType": "enum PillarDRouter.Mode"
+            },
+            {
+              "name": "asset",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "transferOwnership",
+          "inputs": [
+            {
+              "name": "newOwner",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "unpause",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "upgradeMode",
+          "inputs": [
+            {
+              "name": "mode",
+              "type": "uint8",
+              "internalType": "enum PillarDRouter.Mode"
+            },
+            {
+              "name": "newImpl",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "event",
+          "name": "DepositRouted",
+          "inputs": [
+            {
+              "name": "sender",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "mode",
+              "type": "uint8",
+              "indexed": true,
+              "internalType": "enum PillarDRouter.Mode"
+            },
+            {
+              "name": "asset",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            },
+            {
+              "name": "shares",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            },
+            {
+              "name": "mandateId",
+              "type": "bytes32",
+              "indexed": false,
+              "internalType": "bytes32"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "IPNotice",
+          "inputs": [
+            {
+              "name": "license",
+              "type": "string",
+              "indexed": false,
+              "internalType": "string"
+            },
+            {
+              "name": "trademark",
+              "type": "string",
+              "indexed": false,
+              "internalType": "string"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "ModeActivated",
+          "inputs": [
+            {
+              "name": "mode",
+              "type": "uint8",
+              "indexed": true,
+              "internalType": "enum PillarDRouter.Mode"
+            },
+            {
+              "name": "timestamp",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "ModeDeactivated",
+          "inputs": [
+            {
+              "name": "mode",
+              "type": "uint8",
+              "indexed": true,
+              "internalType": "enum PillarDRouter.Mode"
+            },
+            {
+              "name": "timestamp",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "ModeRegistered",
+          "inputs": [
+            {
+              "name": "mode",
+              "type": "uint8",
+              "indexed": true,
+              "internalType": "enum PillarDRouter.Mode"
+            },
+            {
+              "name": "implementation",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "modeName",
+              "type": "string",
+              "indexed": false,
+              "internalType": "string"
+            },
+            {
+              "name": "timestamp",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "ModeUpgraded",
+          "inputs": [
+            {
+              "name": "mode",
+              "type": "uint8",
+              "indexed": true,
+              "internalType": "enum PillarDRouter.Mode"
+            },
+            {
+              "name": "oldImpl",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "newImpl",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "timestamp",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "OwnershipTransferStarted",
+          "inputs": [
+            {
+              "name": "previousOwner",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "newOwner",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "OwnershipTransferred",
+          "inputs": [
+            {
+              "name": "previousOwner",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "newOwner",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "Paused",
+          "inputs": [
+            {
+              "name": "by",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "timestamp",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "RedeemRouted",
+          "inputs": [
+            {
+              "name": "sender",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "mode",
+              "type": "uint8",
+              "indexed": true,
+              "internalType": "enum PillarDRouter.Mode"
+            },
+            {
+              "name": "asset",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "shares",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            },
+            {
+              "name": "assets",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "Unpaused",
+          "inputs": [
+            {
+              "name": "by",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "timestamp",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "error",
+          "name": "InvalidMode",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "ModeAlreadyRegistered",
+          "inputs": [
+            {
+              "name": "mode",
+              "type": "uint8",
+              "internalType": "enum PillarDRouter.Mode"
+            }
+          ]
+        },
+        {
+          "type": "error",
+          "name": "ModeNotRegistered",
+          "inputs": [
+            {
+              "name": "mode",
+              "type": "uint8",
+              "internalType": "enum PillarDRouter.Mode"
+            }
+          ]
+        },
+        {
+          "type": "error",
+          "name": "NotOwner",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "ZeroAddress",
+          "inputs": []
+        }
+      ],
+      "deployments": [
+        {
+          "chainId": 97,
+          "address": "0x1Ae62FDd0114E88CAb94eD1a56fb99Db79A48e1B"
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "ALIA Quality Network",
+    "info": {
+      "legalName": "Avvatar Labs SAS",
+      "url": "https://alia.network",
+      "deploymentDate": "2026-05-15T14:17:00Z"
+    },
+    "enums": {
+      "pillarDMode": {
+        "0": "NONE (unset)",
+        "1": "Yield Boosted (quality-routed allocation)",
+        "2": "Tranching (senior/junior)",
+        "3": "Income Streaming (fixed monthly flow)"
+      },
+      "agilOpType": {
+        "0x6850612400000000000000000000000000000000000000000000000000000000": "DEPOSIT_PILLAR_D (3-of-5 ALIA operators)",
+        "0x05ae06ce00000000000000000000000000000000000000000000000000000000": "DEPOSIT_YIELD_MODE (3-of-5 ALIA operators)",
+        "0xd294133300000000000000000000000000000000000000000000000000000000": "REBALANCE_YIELD (3-of-5 ALIA operators)"
+      }
+    },
+    "constants": {
+      "agilVerifier": "0x5866B9dbE020c4A306FefC416C04D8E1Ef779A8A",
+      "agilThreshold": "3-of-5",
+      "agilDomain": "ALIA-AGIL-Backend v1",
+      "qualityTiers": "Bronze / Silver / Gold (ALIA Score Bronze/Silver/Gold continuous)"
+    }
+  },
+  "display": {
+    "definitions": {
+      "agilOpTypeField": {
+        "label": "AGIL Operation Type",
+        "format": "enum",
+        "params": {
+          "$ref": "$.metadata.enums.agilOpType"
+        }
+      },
+      "agilUserField": {
+        "label": "Attestation User",
+        "format": "addressName",
+        "params": {
+          "types": [
+            "eoa",
+            "wallet"
+          ]
+        }
+      },
+      "agilAssetField": {
+        "label": "Attestation Asset",
+        "format": "addressName",
+        "params": {
+          "types": [
+            "token"
+          ]
+        }
+      },
+      "agilExpiryField": {
+        "label": "Attestation Valid Until",
+        "format": "date",
+        "params": {
+          "encoding": "timestamp"
+        }
+      }
+    },
+    "formats": {
+      "deposit(uint8,address,uint256,address,bytes32,(bytes32,address,address,uint256,bytes32,uint256,uint256,uint256),bytes[])": {
+        "$id": "pillar_d_deposit",
+        "intent": "Deposit into ALIA Pillar D (AGIL-attested)",
+        "fields": [
+          {
+            "path": "mode",
+            "label": "Pillar D Mode",
+            "format": "enum",
+            "params": {
+              "$ref": "$.metadata.enums.pillarDMode"
+            }
+          },
+          {
+            "path": "asset",
+            "label": "Asset",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "token"
+              ]
+            }
+          },
+          {
+            "path": "amount",
+            "label": "Amount to Deposit",
+            "format": "tokenAmount",
+            "params": {
+              "tokenPath": "asset"
+            }
+          },
+          {
+            "path": "receiver",
+            "label": "Shares Recipient (receiver)",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "eoa",
+                "wallet"
+              ]
+            }
+          },
+          {
+            "path": "mandateId",
+            "label": "Mandate ID",
+            "format": "raw"
+          },
+          {
+            "path": "agilAtt.opType",
+            "$ref": "$.display.definitions.agilOpTypeField"
+          },
+          {
+            "path": "agilAtt.user",
+            "$ref": "$.display.definitions.agilUserField"
+          },
+          {
+            "path": "agilAtt.asset",
+            "$ref": "$.display.definitions.agilAssetField"
+          },
+          {
+            "path": "agilAtt.amount",
+            "label": "Attested Amount",
+            "format": "tokenAmount",
+            "params": {
+              "tokenPath": "agilAtt.asset"
+            }
+          },
+          {
+            "path": "agilAtt.mandateId",
+            "label": "Attested Mandate",
+            "format": "raw"
+          },
+          {
+            "path": "agilAtt.nonce",
+            "label": "AGIL Nonce",
+            "format": "raw"
+          },
+          {
+            "path": "agilAtt.expiry",
+            "$ref": "$.display.definitions.agilExpiryField"
+          },
+          {
+            "path": "agilAtt.chainId",
+            "label": "Attestation Chain ID",
+            "format": "raw"
+          }
+        ],
+        "required": [
+          "mode",
+          "asset",
+          "amount",
+          "recipient",
+          "agilAtt.opType",
+          "agilAtt.amount",
+          "agilAtt.expiry"
+        ],
+        "excluded": [
+          "agilSigs"
+        ]
+      },
+      "redeem(uint8,address,uint256,address)": {
+        "$id": "pillar_d_redeem",
+        "intent": "Redeem from ALIA Pillar D",
+        "fields": [
+          {
+            "path": "mode",
+            "label": "Pillar D Mode",
+            "format": "enum",
+            "params": {
+              "$ref": "$.metadata.enums.pillarDMode"
+            }
+          },
+          {
+            "path": "asset",
+            "label": "Asset",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "token"
+              ]
+            }
+          },
+          {
+            "path": "shares",
+            "label": "Shares to Redeem",
+            "format": "raw"
+          },
+          {
+            "path": "receiver",
+            "label": "Asset Recipient (receiver)",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "eoa",
+                "wallet"
+              ]
+            }
+          }
+        ],
+        "required": [
+          "mode",
+          "asset",
+          "shares",
+          "recipient"
+        ]
+      },
+      "pause()": {
+        "$id": "pillar_d_pause",
+        "intent": "Pause ALIA Pillar D Router (owner kill switch)",
+        "fields": [],
+        "required": []
+      },
+      "unpause()": {
+        "$id": "pillar_d_unpause",
+        "intent": "Unpause ALIA Pillar D Router (owner)",
+        "fields": [],
+        "required": []
+      },
+      "activateMode(uint8)": {
+        "$id": "pillar_d_activate_mode",
+        "intent": "Activate Pillar D Mode",
+        "fields": [
+          {
+            "path": "mode",
+            "label": "Mode",
+            "format": "enum",
+            "params": {
+              "$ref": "$.metadata.enums.pillarDMode"
+            }
+          }
+        ],
+        "required": [
+          "mode"
+        ]
+      },
+      "deactivateMode(uint8)": {
+        "$id": "pillar_d_deactivate_mode",
+        "intent": "Deactivate Pillar D Mode",
+        "fields": [
+          {
+            "path": "mode",
+            "label": "Mode",
+            "format": "enum",
+            "params": {
+              "$ref": "$.metadata.enums.pillarDMode"
+            }
+          }
+        ],
+        "required": [
+          "mode"
+        ]
+      }
+    }
+  }
+}

--- a/registry/avvatar-labs-alia/calldata-PillarDRouter.json
+++ b/registry/avvatar-labs-alia/calldata-PillarDRouter.json
@@ -766,7 +766,7 @@
   },
   "display": {
     "formats": {
-      "deposit(uint8 mode, address asset, uint256 amount, address receiver, bytes32 mandateId, tuple agilAtt, bytes[] signatures)": {
+      "deposit(uint8 mode, address asset, uint256 amount, address receiver, bytes32 mandateId, (bytes32,address,address,uint256,bytes32,uint256,uint256,uint256) agilAtt, bytes[] signatures)": {
         "$id": "pillar_d_deposit",
         "intent": "Deposit Pillar D (AGIL)",
         "fields": [

--- a/registry/avvatar-labs-alia/calldata-PillarDRouter.json
+++ b/registry/avvatar-labs-alia/calldata-PillarDRouter.json
@@ -887,18 +887,6 @@
             "label": "Attestation Chain ID",
             "format": "raw"
           }
-        ],
-        "required": [
-          "mode",
-          "asset",
-          "amount",
-          "recipient",
-          "agilAtt.opType",
-          "agilAtt.amount",
-          "agilAtt.expiry"
-        ],
-        "excluded": [
-          "agilSigs"
         ]
       },
       "redeem(uint8,address,uint256,address)": {
@@ -939,25 +927,17 @@
               ]
             }
           }
-        ],
-        "required": [
-          "mode",
-          "asset",
-          "shares",
-          "recipient"
         ]
       },
       "pause()": {
         "$id": "pillar_d_pause",
         "intent": "Pause ALIA Pillar D Router (owner kill switch)",
-        "fields": [],
-        "required": []
+        "fields": []
       },
       "unpause()": {
         "$id": "pillar_d_unpause",
         "intent": "Unpause ALIA Pillar D Router (owner)",
-        "fields": [],
-        "required": []
+        "fields": []
       },
       "activateMode(uint8)": {
         "$id": "pillar_d_activate_mode",
@@ -971,9 +951,6 @@
               "$ref": "$.metadata.enums.pillarDMode"
             }
           }
-        ],
-        "required": [
-          "mode"
         ]
       },
       "deactivateMode(uint8)": {
@@ -988,9 +965,6 @@
               "$ref": "$.metadata.enums.pillarDMode"
             }
           }
-        ],
-        "required": [
-          "mode"
         ]
       }
     }

--- a/registry/avvatar-labs-alia/calldata-YieldBoostedMode.json
+++ b/registry/avvatar-labs-alia/calldata-YieldBoostedMode.json
@@ -1,0 +1,1318 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "context": {
+    "$id": "ALIA YieldBoostedMode (Pillar D V0)",
+    "contract": {
+      "abi": [
+        {
+          "type": "constructor",
+          "inputs": [
+            {
+              "name": "_allocator",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "_agilVerifier",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "acceptOwnership",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "agilVerifier",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "contract AGILSignatureVerifier"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "allocator",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "contract QualityGatedAllocator"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "convertToAssets",
+          "inputs": [
+            {
+              "name": "asset",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "shares",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "convertToShares",
+          "inputs": [
+            {
+              "name": "asset",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "currentAdapter",
+          "inputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "deposit",
+          "inputs": [
+            {
+              "name": "asset",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "mandateId",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "shares",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "depositDirect",
+          "inputs": [
+            {
+              "name": "asset",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "mandateId",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "agilAtt",
+              "type": "tuple",
+              "internalType": "struct AGILSignatureVerifier.AGILOperationAttestation",
+              "components": [
+                {
+                  "name": "opType",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "user",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "asset",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "amount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "mandateId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "nonce",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "expiry",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "chainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "agilSigs",
+              "type": "bytes[]",
+              "internalType": "bytes[]"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "shares",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "modeName",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "string",
+              "internalType": "string"
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "modeVersion",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "string",
+              "internalType": "string"
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "owner",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "pause",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "paused",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "pendingOwner",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "pillarDRouter",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "rebalance",
+          "inputs": [
+            {
+              "name": "asset",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "newAdapter",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "agilAtt",
+              "type": "tuple",
+              "internalType": "struct AGILSignatureVerifier.AGILOperationAttestation",
+              "components": [
+                {
+                  "name": "opType",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "user",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "asset",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "amount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "mandateId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "nonce",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "expiry",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "chainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "agilSigs",
+              "type": "bytes[]",
+              "internalType": "bytes[]"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "redeem",
+          "inputs": [
+            {
+              "name": "asset",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "shares",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "assets",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "redeemDirect",
+          "inputs": [
+            {
+              "name": "asset",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "shares",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "agilAtt",
+              "type": "tuple",
+              "internalType": "struct AGILSignatureVerifier.AGILOperationAttestation",
+              "components": [
+                {
+                  "name": "opType",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "user",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "asset",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "amount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "mandateId",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "nonce",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "expiry",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "chainId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "agilSigs",
+              "type": "bytes[]",
+              "internalType": "bytes[]"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "assets",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "setAllocator",
+          "inputs": [
+            {
+              "name": "newAllocator",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "setPillarDRouter",
+          "inputs": [
+            {
+              "name": "_router",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "shareBalanceOf",
+          "inputs": [
+            {
+              "name": "asset",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "user",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "totalAssets",
+          "inputs": [
+            {
+              "name": "asset",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "totalShares",
+          "inputs": [
+            {
+              "name": "asset",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "transferOwnership",
+          "inputs": [
+            {
+              "name": "newOwner",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "unpause",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "event",
+          "name": "AllocatorUpdated",
+          "inputs": [
+            {
+              "name": "oldAllocator",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "newAllocator",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "CurrentAdapterSet",
+          "inputs": [
+            {
+              "name": "asset",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "oldAdapter",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "newAdapter",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "timestamp",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "Deposit",
+          "inputs": [
+            {
+              "name": "sender",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "asset",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            },
+            {
+              "name": "shares",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            },
+            {
+              "name": "mandateId",
+              "type": "bytes32",
+              "indexed": false,
+              "internalType": "bytes32"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "IPNotice",
+          "inputs": [
+            {
+              "name": "license",
+              "type": "string",
+              "indexed": false,
+              "internalType": "string"
+            },
+            {
+              "name": "trademark",
+              "type": "string",
+              "indexed": false,
+              "internalType": "string"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "OwnershipTransferStarted",
+          "inputs": [
+            {
+              "name": "previousOwner",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "newOwner",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "OwnershipTransferred",
+          "inputs": [
+            {
+              "name": "previousOwner",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "newOwner",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "Paused",
+          "inputs": [
+            {
+              "name": "by",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "timestamp",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "Rebalanced",
+          "inputs": [
+            {
+              "name": "asset",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "fromAdapter",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "toAdapter",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "amountMoved",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            },
+            {
+              "name": "timestamp",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "Redeem",
+          "inputs": [
+            {
+              "name": "sender",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "asset",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "shares",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            },
+            {
+              "name": "assets",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "Unpaused",
+          "inputs": [
+            {
+              "name": "by",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "timestamp",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "error",
+          "name": "AdapterMismatch",
+          "inputs": [
+            {
+              "name": "current",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "routed",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "error",
+          "name": "ApprovalFailed",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "InsufficientShares",
+          "inputs": [
+            {
+              "name": "requested",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "available",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "type": "error",
+          "name": "NoCurrentAdapter",
+          "inputs": [
+            {
+              "name": "asset",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "error",
+          "name": "NotOwner",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "NotRouter",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "TransferFailed",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "ZeroAddress",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "ZeroAmount",
+          "inputs": []
+        }
+      ],
+      "deployments": [
+        {
+          "chainId": 97,
+          "address": "0x8ffaf93a765cc8442c9c309CA8E9f061ea3FbEC6"
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "ALIA Quality Network",
+    "info": {
+      "legalName": "Avvatar Labs SAS",
+      "url": "https://alia.network",
+      "deploymentDate": "2026-05-15T14:17:00Z"
+    },
+    "enums": {
+      "agilOpType": {
+        "0x6850612400000000000000000000000000000000000000000000000000000000": "DEPOSIT_PILLAR_D (3-of-5 ALIA operators)",
+        "0x05ae06ce00000000000000000000000000000000000000000000000000000000": "DEPOSIT_YIELD_MODE (3-of-5 ALIA operators)",
+        "0xd294133300000000000000000000000000000000000000000000000000000000": "REBALANCE_YIELD (3-of-5 ALIA operators)"
+      }
+    },
+    "constants": {
+      "agilVerifier": "0x5866B9dbE020c4A306FefC416C04D8E1Ef779A8A",
+      "agilThreshold": "3-of-5",
+      "modeRole": "Pillar D Mode 1 \u2014 Yield Boosted (quality-routed allocation across Aave V3 BNB / Morpho / Pendle / Venus / Kernel)",
+      "qualityGating": "QualityGatedAllocator: 4-layer gating (mandate + score Bronze/Silver/Gold + collateral + adapter approved)"
+    }
+  },
+  "display": {
+    "definitions": {
+      "agilOpTypeField": {
+        "label": "AGIL Operation Type",
+        "format": "enum",
+        "params": {
+          "$ref": "$.metadata.enums.agilOpType"
+        }
+      },
+      "agilExpiryField": {
+        "label": "Attestation Valid Until",
+        "format": "date",
+        "params": {
+          "encoding": "timestamp"
+        }
+      }
+    },
+    "formats": {
+      "deposit(address,uint256,address,bytes32)": {
+        "$id": "ybm_deposit_router",
+        "intent": "Deposit into Yield Boosted (via Pillar D Router)",
+        "fields": [
+          {
+            "path": "asset",
+            "label": "Asset",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "token"
+              ]
+            }
+          },
+          {
+            "path": "amount",
+            "label": "Amount to Deposit",
+            "format": "tokenAmount",
+            "params": {
+              "tokenPath": "asset"
+            }
+          },
+          {
+            "path": "receiver",
+            "label": "Shares Recipient (receiver)",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "eoa",
+                "wallet"
+              ]
+            }
+          },
+          {
+            "path": "mandateId",
+            "label": "Mandate ID",
+            "format": "raw"
+          }
+        ],
+        "required": [
+          "asset",
+          "amount",
+          "recipient"
+        ]
+      },
+      "depositDirect(address,uint256,address,bytes32,(bytes32,address,address,uint256,bytes32,uint256,uint256,uint256),bytes[])": {
+        "$id": "ybm_deposit_direct_agil",
+        "intent": "Deposit Direct into Yield Boosted (AGIL bypass-router)",
+        "fields": [
+          {
+            "path": "asset",
+            "label": "Asset",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "token"
+              ]
+            }
+          },
+          {
+            "path": "amount",
+            "label": "Amount to Deposit",
+            "format": "tokenAmount",
+            "params": {
+              "tokenPath": "asset"
+            }
+          },
+          {
+            "path": "receiver",
+            "label": "Shares Recipient (receiver)",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "eoa",
+                "wallet"
+              ]
+            }
+          },
+          {
+            "path": "mandateId",
+            "label": "Mandate ID",
+            "format": "raw"
+          },
+          {
+            "path": "agilAtt.opType",
+            "$ref": "$.display.definitions.agilOpTypeField"
+          },
+          {
+            "path": "agilAtt.user",
+            "label": "Attestation User",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "eoa",
+                "wallet"
+              ]
+            }
+          },
+          {
+            "path": "agilAtt.asset",
+            "label": "Attestation Asset",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "token"
+              ]
+            }
+          },
+          {
+            "path": "agilAtt.amount",
+            "label": "Attested Amount",
+            "format": "tokenAmount",
+            "params": {
+              "tokenPath": "agilAtt.asset"
+            }
+          },
+          {
+            "path": "agilAtt.nonce",
+            "label": "AGIL Nonce",
+            "format": "raw"
+          },
+          {
+            "path": "agilAtt.expiry",
+            "$ref": "$.display.definitions.agilExpiryField"
+          },
+          {
+            "path": "agilAtt.chainId",
+            "label": "Attestation Chain ID",
+            "format": "raw"
+          }
+        ],
+        "required": [
+          "asset",
+          "amount",
+          "recipient",
+          "agilAtt.opType",
+          "agilAtt.amount",
+          "agilAtt.expiry"
+        ],
+        "excluded": [
+          "agilSigs"
+        ]
+      },
+      "redeem(address,uint256,address)": {
+        "$id": "ybm_redeem_router",
+        "intent": "Redeem from Yield Boosted (via Pillar D Router)",
+        "fields": [
+          {
+            "path": "asset",
+            "label": "Asset",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "token"
+              ]
+            }
+          },
+          {
+            "path": "shares",
+            "label": "Shares to Redeem",
+            "format": "raw"
+          },
+          {
+            "path": "receiver",
+            "label": "Asset Recipient (receiver)",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "eoa",
+                "wallet"
+              ]
+            }
+          }
+        ],
+        "required": [
+          "asset",
+          "shares",
+          "recipient"
+        ]
+      },
+      "redeemDirect(address,uint256,address,(bytes32,address,address,uint256,bytes32,uint256,uint256,uint256),bytes[])": {
+        "$id": "ybm_redeem_direct_agil",
+        "intent": "Redeem Direct from Yield Boosted (AGIL bypass-router)",
+        "fields": [
+          {
+            "path": "asset",
+            "label": "Asset",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "token"
+              ]
+            }
+          },
+          {
+            "path": "shares",
+            "label": "Shares to Redeem",
+            "format": "raw"
+          },
+          {
+            "path": "receiver",
+            "label": "Asset Recipient (receiver)",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "eoa",
+                "wallet"
+              ]
+            }
+          },
+          {
+            "path": "agilAtt.opType",
+            "$ref": "$.display.definitions.agilOpTypeField"
+          },
+          {
+            "path": "agilAtt.user",
+            "label": "Attestation User",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "eoa",
+                "wallet"
+              ]
+            }
+          },
+          {
+            "path": "agilAtt.nonce",
+            "label": "AGIL Nonce",
+            "format": "raw"
+          },
+          {
+            "path": "agilAtt.expiry",
+            "$ref": "$.display.definitions.agilExpiryField"
+          }
+        ],
+        "required": [
+          "asset",
+          "shares",
+          "recipient",
+          "agilAtt.opType",
+          "agilAtt.expiry"
+        ],
+        "excluded": [
+          "agilSigs"
+        ]
+      },
+      "rebalance(address,address,(bytes32,address,address,uint256,bytes32,uint256,uint256,uint256),bytes[])": {
+        "$id": "ybm_rebalance_agil",
+        "intent": "Rebalance Yield Boosted Adapter (AGIL-attested, owner-only)",
+        "fields": [
+          {
+            "path": "asset",
+            "label": "Asset",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "token"
+              ]
+            }
+          },
+          {
+            "path": "newAdapter",
+            "label": "New Allocation Adapter",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "contract"
+              ]
+            }
+          },
+          {
+            "path": "agilAtt.opType",
+            "$ref": "$.display.definitions.agilOpTypeField"
+          },
+          {
+            "path": "agilAtt.user",
+            "label": "Attestation User (Owner)",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "eoa",
+                "wallet"
+              ]
+            }
+          },
+          {
+            "path": "agilAtt.nonce",
+            "label": "AGIL Nonce",
+            "format": "raw"
+          },
+          {
+            "path": "agilAtt.expiry",
+            "$ref": "$.display.definitions.agilExpiryField"
+          }
+        ],
+        "required": [
+          "asset",
+          "newAdapter",
+          "agilAtt.opType",
+          "agilAtt.expiry"
+        ],
+        "excluded": [
+          "agilSigs"
+        ]
+      },
+      "pause()": {
+        "$id": "ybm_pause",
+        "intent": "Pause YieldBoostedMode (owner kill switch)",
+        "fields": [],
+        "required": []
+      },
+      "unpause()": {
+        "$id": "ybm_unpause",
+        "intent": "Unpause YieldBoostedMode (owner)",
+        "fields": [],
+        "required": []
+      }
+    }
+  }
+}

--- a/registry/avvatar-labs-alia/calldata-YieldBoostedMode.json
+++ b/registry/avvatar-labs-alia/calldata-YieldBoostedMode.json
@@ -960,7 +960,6 @@
   "metadata": {
     "owner": "ALIA Quality Network",
     "info": {
-      "legalName": "Avvatar Labs SAS",
       "url": "https://alia.network",
       "deploymentDate": "2026-05-15T14:17:00Z"
     },
@@ -974,29 +973,13 @@
     "constants": {
       "agilVerifier": "0x5866B9dbE020c4A306FefC416C04D8E1Ef779A8A",
       "agilThreshold": "3-of-5",
-      "modeRole": "Pillar D Mode 1 \u2014 Yield Boosted (quality-routed allocation across Aave V3 BNB / Morpho / Pendle / Venus / Kernel)",
+      "modeRole": "Pillar D Mode 1 — Yield Boosted (quality-routed allocation across Aave V3 BNB / Morpho / Pendle / Venus / Kernel)",
       "qualityGating": "QualityGatedAllocator: 4-layer gating (mandate + score Bronze/Silver/Gold + collateral + adapter approved)"
     }
   },
   "display": {
-    "definitions": {
-      "agilOpTypeField": {
-        "label": "Op Type",
-        "format": "enum",
-        "params": {
-          "$ref": "$.metadata.enums.agilOpType"
-        }
-      },
-      "agilExpiryField": {
-        "label": "Valid Until",
-        "format": "date",
-        "params": {
-          "encoding": "timestamp"
-        }
-      }
-    },
     "formats": {
-      "deposit(address,uint256,address,bytes32)": {
+      "deposit(address asset, uint256 amount, address receiver, bytes32 mandateId)": {
         "$id": "ybm_deposit_router",
         "intent": "Deposit (via Router)",
         "fields": [
@@ -1036,7 +1019,7 @@
           }
         ]
       },
-      "depositDirect(address,uint256,address,bytes32,(bytes32,address,address,uint256,bytes32,uint256,uint256,uint256),bytes[])": {
+      "depositDirect(address asset, uint256 amount, address receiver, bytes32 mandateId, tuple agilAtt, bytes[] signatures)": {
         "$id": "ybm_deposit_direct_agil",
         "intent": "Deposit Direct (AGIL)",
         "fields": [
@@ -1076,7 +1059,11 @@
           },
           {
             "path": "agilAtt.opType",
-            "$ref": "$.display.definitions.agilOpTypeField"
+            "label": "Op Type",
+            "format": "enum",
+            "params": {
+              "$ref": "$.metadata.enums.agilOpType"
+            }
           },
           {
             "path": "agilAtt.user",
@@ -1114,7 +1101,11 @@
           },
           {
             "path": "agilAtt.expiry",
-            "$ref": "$.display.definitions.agilExpiryField"
+            "label": "Expiry",
+            "format": "date",
+            "params": {
+              "encoding": "timestamp"
+            }
           },
           {
             "path": "agilAtt.chainId",
@@ -1123,7 +1114,7 @@
           }
         ]
       },
-      "redeem(address,uint256,address)": {
+      "redeem(address asset, uint256 shares, address receiver)": {
         "$id": "ybm_redeem_router",
         "intent": "Redeem (via Router)",
         "fields": [
@@ -1155,7 +1146,7 @@
           }
         ]
       },
-      "redeemDirect(address,uint256,address,(bytes32,address,address,uint256,bytes32,uint256,uint256,uint256),bytes[])": {
+      "redeemDirect(address asset, uint256 shares, address receiver, tuple agilAtt, bytes[] signatures)": {
         "$id": "ybm_redeem_direct_agil",
         "intent": "Redeem Direct (AGIL)",
         "fields": [
@@ -1187,7 +1178,11 @@
           },
           {
             "path": "agilAtt.opType",
-            "$ref": "$.display.definitions.agilOpTypeField"
+            "label": "Op Type",
+            "format": "enum",
+            "params": {
+              "$ref": "$.metadata.enums.agilOpType"
+            }
           },
           {
             "path": "agilAtt.user",
@@ -1207,11 +1202,15 @@
           },
           {
             "path": "agilAtt.expiry",
-            "$ref": "$.display.definitions.agilExpiryField"
+            "label": "Expiry",
+            "format": "date",
+            "params": {
+              "encoding": "timestamp"
+            }
           }
         ]
       },
-      "rebalance(address,address,(bytes32,address,address,uint256,bytes32,uint256,uint256,uint256),bytes[])": {
+      "rebalance(address asset, address newAdapter, tuple agilAtt, bytes[] signatures)": {
         "$id": "ybm_rebalance_agil",
         "intent": "Rebalance (AGIL)",
         "fields": [
@@ -1237,7 +1236,11 @@
           },
           {
             "path": "agilAtt.opType",
-            "$ref": "$.display.definitions.agilOpTypeField"
+            "label": "Op Type",
+            "format": "enum",
+            "params": {
+              "$ref": "$.metadata.enums.agilOpType"
+            }
           },
           {
             "path": "agilAtt.user",
@@ -1257,7 +1260,11 @@
           },
           {
             "path": "agilAtt.expiry",
-            "$ref": "$.display.definitions.agilExpiryField"
+            "label": "Expiry",
+            "format": "date",
+            "params": {
+              "encoding": "timestamp"
+            }
           }
         ]
       },

--- a/registry/avvatar-labs-alia/calldata-YieldBoostedMode.json
+++ b/registry/avvatar-labs-alia/calldata-YieldBoostedMode.json
@@ -1034,11 +1034,6 @@
             "label": "Mandate ID",
             "format": "raw"
           }
-        ],
-        "required": [
-          "asset",
-          "amount",
-          "recipient"
         ]
       },
       "depositDirect(address,uint256,address,bytes32,(bytes32,address,address,uint256,bytes32,uint256,uint256,uint256),bytes[])": {
@@ -1126,17 +1121,6 @@
             "label": "Attestation Chain ID",
             "format": "raw"
           }
-        ],
-        "required": [
-          "asset",
-          "amount",
-          "recipient",
-          "agilAtt.opType",
-          "agilAtt.amount",
-          "agilAtt.expiry"
-        ],
-        "excluded": [
-          "agilSigs"
         ]
       },
       "redeem(address,uint256,address)": {
@@ -1169,11 +1153,6 @@
               ]
             }
           }
-        ],
-        "required": [
-          "asset",
-          "shares",
-          "recipient"
         ]
       },
       "redeemDirect(address,uint256,address,(bytes32,address,address,uint256,bytes32,uint256,uint256,uint256),bytes[])": {
@@ -1230,16 +1209,6 @@
             "path": "agilAtt.expiry",
             "$ref": "$.display.definitions.agilExpiryField"
           }
-        ],
-        "required": [
-          "asset",
-          "shares",
-          "recipient",
-          "agilAtt.opType",
-          "agilAtt.expiry"
-        ],
-        "excluded": [
-          "agilSigs"
         ]
       },
       "rebalance(address,address,(bytes32,address,address,uint256,bytes32,uint256,uint256,uint256),bytes[])": {
@@ -1290,28 +1259,17 @@
             "path": "agilAtt.expiry",
             "$ref": "$.display.definitions.agilExpiryField"
           }
-        ],
-        "required": [
-          "asset",
-          "newAdapter",
-          "agilAtt.opType",
-          "agilAtt.expiry"
-        ],
-        "excluded": [
-          "agilSigs"
         ]
       },
       "pause()": {
         "$id": "ybm_pause",
         "intent": "Pause YieldBoostedMode (owner kill switch)",
-        "fields": [],
-        "required": []
+        "fields": []
       },
       "unpause()": {
         "$id": "ybm_unpause",
         "intent": "Unpause YieldBoostedMode (owner)",
-        "fields": [],
-        "required": []
+        "fields": []
       }
     }
   }

--- a/registry/avvatar-labs-alia/calldata-YieldBoostedMode.json
+++ b/registry/avvatar-labs-alia/calldata-YieldBoostedMode.json
@@ -1019,7 +1019,7 @@
           }
         ]
       },
-      "depositDirect(address asset, uint256 amount, address receiver, bytes32 mandateId, tuple agilAtt, bytes[] signatures)": {
+      "depositDirect(address asset, uint256 amount, address receiver, bytes32 mandateId, (bytes32,address,address,uint256,bytes32,uint256,uint256,uint256) agilAtt, bytes[] signatures)": {
         "$id": "ybm_deposit_direct_agil",
         "intent": "Deposit Direct (AGIL)",
         "fields": [
@@ -1146,7 +1146,7 @@
           }
         ]
       },
-      "redeemDirect(address asset, uint256 shares, address receiver, tuple agilAtt, bytes[] signatures)": {
+      "redeemDirect(address asset, uint256 shares, address receiver, (bytes32,address,address,uint256,bytes32,uint256,uint256,uint256) agilAtt, bytes[] signatures)": {
         "$id": "ybm_redeem_direct_agil",
         "intent": "Redeem Direct (AGIL)",
         "fields": [
@@ -1210,7 +1210,7 @@
           }
         ]
       },
-      "rebalance(address asset, address newAdapter, tuple agilAtt, bytes[] signatures)": {
+      "rebalance(address asset, address newAdapter, (bytes32,address,address,uint256,bytes32,uint256,uint256,uint256) agilAtt, bytes[] signatures)": {
         "$id": "ybm_rebalance_agil",
         "intent": "Rebalance (AGIL)",
         "fields": [

--- a/registry/avvatar-labs-alia/calldata-YieldBoostedMode.json
+++ b/registry/avvatar-labs-alia/calldata-YieldBoostedMode.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../specs/erc7730-v2.schema.json",
   "context": {
-    "$id": "ALIA YieldBoostedMode (Pillar D V0)",
+    "$id": "ALIA YieldBoosted Mode",
     "contract": {
       "abi": [
         {
@@ -966,9 +966,9 @@
     },
     "enums": {
       "agilOpType": {
-        "0x6850612400000000000000000000000000000000000000000000000000000000": "DEPOSIT_PILLAR_D (3-of-5 ALIA operators)",
-        "0x05ae06ce00000000000000000000000000000000000000000000000000000000": "DEPOSIT_YIELD_MODE (3-of-5 ALIA operators)",
-        "0xd294133300000000000000000000000000000000000000000000000000000000": "REBALANCE_YIELD (3-of-5 ALIA operators)"
+        "0x6850612400000000000000000000000000000000000000000000000000000000": "DEPOSIT_PILLAR_D",
+        "0x05ae06ce00000000000000000000000000000000000000000000000000000000": "DEPOSIT_YIELD",
+        "0xd294133300000000000000000000000000000000000000000000000000000000": "REBALANCE_YIELD"
       }
     },
     "constants": {
@@ -981,14 +981,14 @@
   "display": {
     "definitions": {
       "agilOpTypeField": {
-        "label": "AGIL Operation Type",
+        "label": "Op Type",
         "format": "enum",
         "params": {
           "$ref": "$.metadata.enums.agilOpType"
         }
       },
       "agilExpiryField": {
-        "label": "Attestation Valid Until",
+        "label": "Valid Until",
         "format": "date",
         "params": {
           "encoding": "timestamp"
@@ -998,7 +998,7 @@
     "formats": {
       "deposit(address,uint256,address,bytes32)": {
         "$id": "ybm_deposit_router",
-        "intent": "Deposit into Yield Boosted (via Pillar D Router)",
+        "intent": "Deposit (via Router)",
         "fields": [
           {
             "path": "asset",
@@ -1012,7 +1012,7 @@
           },
           {
             "path": "amount",
-            "label": "Amount to Deposit",
+            "label": "Amount",
             "format": "tokenAmount",
             "params": {
               "tokenPath": "asset"
@@ -1020,7 +1020,7 @@
           },
           {
             "path": "receiver",
-            "label": "Shares Recipient (receiver)",
+            "label": "Recipient",
             "format": "addressName",
             "params": {
               "types": [
@@ -1038,7 +1038,7 @@
       },
       "depositDirect(address,uint256,address,bytes32,(bytes32,address,address,uint256,bytes32,uint256,uint256,uint256),bytes[])": {
         "$id": "ybm_deposit_direct_agil",
-        "intent": "Deposit Direct into Yield Boosted (AGIL bypass-router)",
+        "intent": "Deposit Direct (AGIL)",
         "fields": [
           {
             "path": "asset",
@@ -1052,7 +1052,7 @@
           },
           {
             "path": "amount",
-            "label": "Amount to Deposit",
+            "label": "Amount",
             "format": "tokenAmount",
             "params": {
               "tokenPath": "asset"
@@ -1060,7 +1060,7 @@
           },
           {
             "path": "receiver",
-            "label": "Shares Recipient (receiver)",
+            "label": "Recipient",
             "format": "addressName",
             "params": {
               "types": [
@@ -1080,7 +1080,7 @@
           },
           {
             "path": "agilAtt.user",
-            "label": "Attestation User",
+            "label": "User",
             "format": "addressName",
             "params": {
               "types": [
@@ -1091,7 +1091,7 @@
           },
           {
             "path": "agilAtt.asset",
-            "label": "Attestation Asset",
+            "label": "Asset",
             "format": "addressName",
             "params": {
               "types": [
@@ -1101,7 +1101,7 @@
           },
           {
             "path": "agilAtt.amount",
-            "label": "Attested Amount",
+            "label": "Att. Amount",
             "format": "tokenAmount",
             "params": {
               "tokenPath": "agilAtt.asset"
@@ -1118,14 +1118,14 @@
           },
           {
             "path": "agilAtt.chainId",
-            "label": "Attestation Chain ID",
+            "label": "Chain ID",
             "format": "raw"
           }
         ]
       },
       "redeem(address,uint256,address)": {
         "$id": "ybm_redeem_router",
-        "intent": "Redeem from Yield Boosted (via Pillar D Router)",
+        "intent": "Redeem (via Router)",
         "fields": [
           {
             "path": "asset",
@@ -1139,12 +1139,12 @@
           },
           {
             "path": "shares",
-            "label": "Shares to Redeem",
+            "label": "Shares",
             "format": "raw"
           },
           {
             "path": "receiver",
-            "label": "Asset Recipient (receiver)",
+            "label": "Recipient",
             "format": "addressName",
             "params": {
               "types": [
@@ -1157,7 +1157,7 @@
       },
       "redeemDirect(address,uint256,address,(bytes32,address,address,uint256,bytes32,uint256,uint256,uint256),bytes[])": {
         "$id": "ybm_redeem_direct_agil",
-        "intent": "Redeem Direct from Yield Boosted (AGIL bypass-router)",
+        "intent": "Redeem Direct (AGIL)",
         "fields": [
           {
             "path": "asset",
@@ -1171,12 +1171,12 @@
           },
           {
             "path": "shares",
-            "label": "Shares to Redeem",
+            "label": "Shares",
             "format": "raw"
           },
           {
             "path": "receiver",
-            "label": "Asset Recipient (receiver)",
+            "label": "Recipient",
             "format": "addressName",
             "params": {
               "types": [
@@ -1191,7 +1191,7 @@
           },
           {
             "path": "agilAtt.user",
-            "label": "Attestation User",
+            "label": "User",
             "format": "addressName",
             "params": {
               "types": [
@@ -1213,7 +1213,7 @@
       },
       "rebalance(address,address,(bytes32,address,address,uint256,bytes32,uint256,uint256,uint256),bytes[])": {
         "$id": "ybm_rebalance_agil",
-        "intent": "Rebalance Yield Boosted Adapter (AGIL-attested, owner-only)",
+        "intent": "Rebalance (AGIL)",
         "fields": [
           {
             "path": "asset",
@@ -1227,7 +1227,7 @@
           },
           {
             "path": "newAdapter",
-            "label": "New Allocation Adapter",
+            "label": "New Adapter",
             "format": "addressName",
             "params": {
               "types": [
@@ -1241,7 +1241,7 @@
           },
           {
             "path": "agilAtt.user",
-            "label": "Attestation User (Owner)",
+            "label": "Owner",
             "format": "addressName",
             "params": {
               "types": [
@@ -1263,12 +1263,12 @@
       },
       "pause()": {
         "$id": "ybm_pause",
-        "intent": "Pause YieldBoostedMode (owner kill switch)",
+        "intent": "Pause Mode",
         "fields": []
       },
       "unpause()": {
         "$id": "ybm_unpause",
-        "intent": "Unpause YieldBoostedMode (owner)",
+        "intent": "Unpause Mode",
         "fields": []
       }
     }

--- a/registry/avvatar-labs-alia/eip712-AGILOperationAttestation.json
+++ b/registry/avvatar-labs-alia/eip712-AGILOperationAttestation.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "context": {
+    "$id": "ALIA AGIL Operation Attestation",
+    "eip712": {
+      "schemas": [
+        {
+          "types": {
+            "EIP712Domain": [
+              { "name": "name", "type": "string" },
+              { "name": "version", "type": "string" },
+              { "name": "chainId", "type": "uint256" },
+              { "name": "verifyingContract", "type": "address" }
+            ],
+            "AGILOperationAttestation": [
+              { "name": "opType", "type": "bytes32" },
+              { "name": "user", "type": "address" },
+              { "name": "asset", "type": "address" },
+              { "name": "amount", "type": "uint256" },
+              { "name": "mandateId", "type": "bytes32" },
+              { "name": "nonce", "type": "uint256" },
+              { "name": "expiry", "type": "uint256" },
+              { "name": "chainId", "type": "uint256" }
+            ]
+          },
+          "primaryType": "AGILOperationAttestation"
+        }
+      ],
+      "domain": {
+        "name": "ALIA-AGIL-Backend",
+        "version": "1"
+      },
+      "deployments": [
+        {
+          "chainId": 97,
+          "address": "0x5866B9dbE020c4A306FefC416C04D8E1Ef779A8A"
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "ALIA Quality Network",
+    "info": {
+      "legalName": "Avvatar Labs SAS",
+      "url": "https://alia.network",
+      "deploymentDate": "2026-05-15T14:17:00Z"
+    },
+    "enums": {
+      "opType": {
+        "0x6850612400000000000000000000000000000000000000000000000000000000": "DEPOSIT_PILLAR_D",
+        "0x05ae06ce00000000000000000000000000000000000000000000000000000000": "DEPOSIT_YIELD_MODE",
+        "0xd294133300000000000000000000000000000000000000000000000000000000": "REBALANCE_YIELD"
+      }
+    },
+    "constants": {
+      "thresholdScheme": "3-of-5 ALIA AGIL operators (threshold ECDSA secp256k1)",
+      "attestationStructure": "EIP-712 typed multi-party threshold attestation. Backend signs off-chain via 3 of 5 registered operators; user submits attestation + 3 signatures on-chain; AGILSignatureVerifier validates threshold + nonce monotonicity + expiry + chainId before allowing operation"
+    }
+  },
+  "display": {
+    "formats": {
+      "AGILOperationAttestation": {
+        "$id": "agil_operation_attestation",
+        "intent": "Sign ALIA AGIL Operation Attestation (3-of-5 threshold)",
+        "fields": [
+          {
+            "path": "opType",
+            "label": "Operation Type",
+            "format": "enum",
+            "params": {
+              "$ref": "$.metadata.enums.opType"
+            }
+          },
+          {
+            "path": "user",
+            "label": "User",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "wallet"]
+            }
+          },
+          {
+            "path": "asset",
+            "label": "Asset",
+            "format": "addressName",
+            "params": {
+              "types": ["token"]
+            }
+          },
+          {
+            "path": "amount",
+            "label": "Amount",
+            "format": "tokenAmount",
+            "params": {
+              "tokenPath": "asset"
+            }
+          },
+          {
+            "path": "mandateId",
+            "label": "Mandate ID",
+            "format": "raw"
+          },
+          {
+            "path": "nonce",
+            "label": "AGIL Nonce (monotonic per signer)",
+            "format": "raw"
+          },
+          {
+            "path": "expiry",
+            "label": "Expiry",
+            "format": "date",
+            "params": {
+              "encoding": "timestamp"
+            }
+          },
+          {
+            "path": "chainId",
+            "label": "Chain ID (replay protection)",
+            "format": "raw"
+          }
+        ],
+        "required": ["opType", "user", "asset", "amount", "nonce", "expiry", "chainId"]
+      }
+    }
+  }
+}

--- a/registry/avvatar-labs-alia/eip712-AGILOperationAttestation.json
+++ b/registry/avvatar-labs-alia/eip712-AGILOperationAttestation.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../specs/erc7730-v2.schema.json",
   "context": {
-    "$id": "ALIA AGIL Operation Attestation",
+    "$id": "ALIA AGIL Attestation",
     "eip712": {
       "schemas": [
         {
@@ -97,7 +97,7 @@
     "formats": {
       "AGILOperationAttestation": {
         "$id": "agil_operation_attestation",
-        "intent": "Sign ALIA AGIL Operation Attestation (3-of-5 threshold)",
+        "intent": "Sign AGIL Attestation",
         "fields": [
           {
             "path": "opType",
@@ -143,7 +143,7 @@
           },
           {
             "path": "nonce",
-            "label": "AGIL Nonce (monotonic per signer)",
+            "label": "AGIL Nonce",
             "format": "raw"
           },
           {
@@ -156,7 +156,7 @@
           },
           {
             "path": "chainId",
-            "label": "Chain ID (replay protection)",
+            "label": "Chain ID",
             "format": "raw"
           }
         ]

--- a/registry/avvatar-labs-alia/eip712-AGILOperationAttestation.json
+++ b/registry/avvatar-labs-alia/eip712-AGILOperationAttestation.json
@@ -77,7 +77,6 @@
   "metadata": {
     "owner": "ALIA Quality Network",
     "info": {
-      "legalName": "Avvatar Labs SAS",
       "url": "https://alia.network",
       "deploymentDate": "2026-05-15T14:17:00Z"
     },
@@ -95,7 +94,7 @@
   },
   "display": {
     "formats": {
-      "AGILOperationAttestation": {
+      "AGILOperationAttestation(bytes32 opType,address user,address asset,uint256 amount,bytes32 mandateId,uint256 nonce,uint256 expiry,uint256 chainId)": {
         "$id": "agil_operation_attestation",
         "intent": "Sign AGIL Attestation",
         "fields": [

--- a/registry/avvatar-labs-alia/eip712-AGILOperationAttestation.json
+++ b/registry/avvatar-labs-alia/eip712-AGILOperationAttestation.json
@@ -7,20 +7,56 @@
         {
           "types": {
             "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
+              {
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "name": "version",
+                "type": "string"
+              },
+              {
+                "name": "chainId",
+                "type": "uint256"
+              },
+              {
+                "name": "verifyingContract",
+                "type": "address"
+              }
             ],
             "AGILOperationAttestation": [
-              { "name": "opType", "type": "bytes32" },
-              { "name": "user", "type": "address" },
-              { "name": "asset", "type": "address" },
-              { "name": "amount", "type": "uint256" },
-              { "name": "mandateId", "type": "bytes32" },
-              { "name": "nonce", "type": "uint256" },
-              { "name": "expiry", "type": "uint256" },
-              { "name": "chainId", "type": "uint256" }
+              {
+                "name": "opType",
+                "type": "bytes32"
+              },
+              {
+                "name": "user",
+                "type": "address"
+              },
+              {
+                "name": "asset",
+                "type": "address"
+              },
+              {
+                "name": "amount",
+                "type": "uint256"
+              },
+              {
+                "name": "mandateId",
+                "type": "bytes32"
+              },
+              {
+                "name": "nonce",
+                "type": "uint256"
+              },
+              {
+                "name": "expiry",
+                "type": "uint256"
+              },
+              {
+                "name": "chainId",
+                "type": "uint256"
+              }
             ]
           },
           "primaryType": "AGILOperationAttestation"
@@ -76,7 +112,10 @@
             "label": "User",
             "format": "addressName",
             "params": {
-              "types": ["eoa", "wallet"]
+              "types": [
+                "eoa",
+                "wallet"
+              ]
             }
           },
           {
@@ -84,7 +123,9 @@
             "label": "Asset",
             "format": "addressName",
             "params": {
-              "types": ["token"]
+              "types": [
+                "token"
+              ]
             }
           },
           {
@@ -118,8 +159,7 @@
             "label": "Chain ID (replay protection)",
             "format": "raw"
           }
-        ],
-        "required": ["opType", "user", "asset", "amount", "nonce", "expiry", "chainId"]
+        ]
       }
     }
   }

--- a/registry/avvatar-labs-alia/eip712-ScoreAttestation.json
+++ b/registry/avvatar-labs-alia/eip712-ScoreAttestation.json
@@ -73,20 +73,19 @@
   "metadata": {
     "owner": "ALIA Quality Network",
     "info": {
-      "legalName": "Avvatar Labs SAS",
       "url": "https://alia.network",
       "deploymentDate": "2026-05-15T11:15:00Z"
     },
     "constants": {
       "source": "ScoreEngineV2 mainnet Base (chainId 8453, 0x295CCcDE8Fb06148d4FB6Bfc06B6c332E42aCb43)",
-      "thresholdScheme": "Threshold ECDSA secp256k1 \u2014 3-of-5 ALIA validators sign each score attestation",
+      "thresholdScheme": "Threshold ECDSA secp256k1 — 3-of-5 ALIA validators sign each score attestation",
       "freshnessGuard": "maxAttestationAge 1h (rejects stale attestations)",
       "replayProtection": "nonce monotonic per asset + processedAttestations dedup map"
     }
   },
   "display": {
     "formats": {
-      "ScoreAttestation": {
+      "ScoreAttestation(address asset,uint256 score,uint256 confidence,uint256 sourceTimestamp,uint256 sourceBlockNumber,uint256 nonce,uint256 sourceChainId,address sourceContract)": {
         "$id": "score_attestation",
         "intent": "ALIA Score Attestation",
         "fields": [

--- a/registry/avvatar-labs-alia/eip712-ScoreAttestation.json
+++ b/registry/avvatar-labs-alia/eip712-ScoreAttestation.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "context": {
+    "$id": "ALIA ScoreEngineV2BNBMirror Cross-Chain Score Attestation",
+    "eip712": {
+      "schemas": [
+        {
+          "types": {
+            "EIP712Domain": [
+              { "name": "name", "type": "string" },
+              { "name": "version", "type": "string" },
+              { "name": "chainId", "type": "uint256" },
+              { "name": "verifyingContract", "type": "address" }
+            ],
+            "ScoreAttestation": [
+              { "name": "asset", "type": "address" },
+              { "name": "score", "type": "uint256" },
+              { "name": "confidence", "type": "uint256" },
+              { "name": "sourceTimestamp", "type": "uint256" },
+              { "name": "sourceBlockNumber", "type": "uint256" },
+              { "name": "nonce", "type": "uint256" },
+              { "name": "sourceChainId", "type": "uint256" },
+              { "name": "sourceContract", "type": "address" }
+            ]
+          },
+          "primaryType": "ScoreAttestation"
+        }
+      ],
+      "deployments": [
+        {
+          "chainId": 97,
+          "address": "0x2Ed898038F6605879f746985741650eBf4220571"
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "ALIA Quality Network",
+    "info": {
+      "legalName": "Avvatar Labs SAS",
+      "url": "https://alia.network",
+      "deploymentDate": "2026-05-15T11:15:00Z"
+    },
+    "constants": {
+      "source": "ScoreEngineV2 mainnet Base (chainId 8453, 0x295CCcDE8Fb06148d4FB6Bfc06B6c332E42aCb43)",
+      "thresholdScheme": "Threshold ECDSA secp256k1 — 3-of-5 ALIA validators sign each score attestation",
+      "freshnessGuard": "maxAttestationAge 1h (rejects stale attestations)",
+      "replayProtection": "nonce monotonic per asset + processedAttestations dedup map"
+    }
+  },
+  "display": {
+    "formats": {
+      "ScoreAttestation": {
+        "$id": "score_attestation",
+        "intent": "ALIA Score Cross-Chain Attestation (3-of-5 validators)",
+        "fields": [
+          {
+            "path": "asset",
+            "label": "Asset Scored",
+            "format": "addressName",
+            "params": {
+              "types": ["token", "contract"]
+            }
+          },
+          {
+            "path": "score",
+            "label": "ALIA Score (0-10000 bps)",
+            "format": "raw"
+          },
+          {
+            "path": "confidence",
+            "label": "Score Confidence (calibrated by Brier RL)",
+            "format": "raw"
+          },
+          {
+            "path": "sourceTimestamp",
+            "label": "Source Timestamp",
+            "format": "date",
+            "params": {
+              "encoding": "timestamp"
+            }
+          },
+          {
+            "path": "sourceBlockNumber",
+            "label": "Source Block Number",
+            "format": "raw"
+          },
+          {
+            "path": "nonce",
+            "label": "Score Nonce (monotonic per asset)",
+            "format": "raw"
+          },
+          {
+            "path": "sourceChainId",
+            "label": "Source Chain ID",
+            "format": "raw"
+          },
+          {
+            "path": "sourceContract",
+            "label": "Source ScoreEngine Contract",
+            "format": "addressName",
+            "params": {
+              "types": ["contract"]
+            }
+          }
+        ],
+        "required": ["asset", "score", "confidence", "nonce", "sourceTimestamp", "sourceChainId", "sourceContract"]
+      }
+    }
+  }
+}

--- a/registry/avvatar-labs-alia/eip712-ScoreAttestation.json
+++ b/registry/avvatar-labs-alia/eip712-ScoreAttestation.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../specs/erc7730-v2.schema.json",
   "context": {
-    "$id": "ALIA ScoreEngineV2BNBMirror Cross-Chain Score Attestation",
+    "$id": "ALIA Score Attestation",
     "eip712": {
       "schemas": [
         {
@@ -88,7 +88,7 @@
     "formats": {
       "ScoreAttestation": {
         "$id": "score_attestation",
-        "intent": "ALIA Score Cross-Chain Attestation (3-of-5 validators)",
+        "intent": "ALIA Score Attestation",
         "fields": [
           {
             "path": "asset",
@@ -103,12 +103,12 @@
           },
           {
             "path": "score",
-            "label": "ALIA Score (0-10000 bps)",
+            "label": "Score (bps)",
             "format": "raw"
           },
           {
             "path": "confidence",
-            "label": "Score Confidence (calibrated by Brier RL)",
+            "label": "Confidence",
             "format": "raw"
           },
           {
@@ -126,7 +126,7 @@
           },
           {
             "path": "nonce",
-            "label": "Score Nonce (monotonic per asset)",
+            "label": "Score Nonce",
             "format": "raw"
           },
           {
@@ -136,7 +136,7 @@
           },
           {
             "path": "sourceContract",
-            "label": "Source ScoreEngine Contract",
+            "label": "Source Contract",
             "format": "addressName",
             "params": {
               "types": [

--- a/registry/avvatar-labs-alia/eip712-ScoreAttestation.json
+++ b/registry/avvatar-labs-alia/eip712-ScoreAttestation.json
@@ -7,20 +7,56 @@
         {
           "types": {
             "EIP712Domain": [
-              { "name": "name", "type": "string" },
-              { "name": "version", "type": "string" },
-              { "name": "chainId", "type": "uint256" },
-              { "name": "verifyingContract", "type": "address" }
+              {
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "name": "version",
+                "type": "string"
+              },
+              {
+                "name": "chainId",
+                "type": "uint256"
+              },
+              {
+                "name": "verifyingContract",
+                "type": "address"
+              }
             ],
             "ScoreAttestation": [
-              { "name": "asset", "type": "address" },
-              { "name": "score", "type": "uint256" },
-              { "name": "confidence", "type": "uint256" },
-              { "name": "sourceTimestamp", "type": "uint256" },
-              { "name": "sourceBlockNumber", "type": "uint256" },
-              { "name": "nonce", "type": "uint256" },
-              { "name": "sourceChainId", "type": "uint256" },
-              { "name": "sourceContract", "type": "address" }
+              {
+                "name": "asset",
+                "type": "address"
+              },
+              {
+                "name": "score",
+                "type": "uint256"
+              },
+              {
+                "name": "confidence",
+                "type": "uint256"
+              },
+              {
+                "name": "sourceTimestamp",
+                "type": "uint256"
+              },
+              {
+                "name": "sourceBlockNumber",
+                "type": "uint256"
+              },
+              {
+                "name": "nonce",
+                "type": "uint256"
+              },
+              {
+                "name": "sourceChainId",
+                "type": "uint256"
+              },
+              {
+                "name": "sourceContract",
+                "type": "address"
+              }
             ]
           },
           "primaryType": "ScoreAttestation"
@@ -43,7 +79,7 @@
     },
     "constants": {
       "source": "ScoreEngineV2 mainnet Base (chainId 8453, 0x295CCcDE8Fb06148d4FB6Bfc06B6c332E42aCb43)",
-      "thresholdScheme": "Threshold ECDSA secp256k1 — 3-of-5 ALIA validators sign each score attestation",
+      "thresholdScheme": "Threshold ECDSA secp256k1 \u2014 3-of-5 ALIA validators sign each score attestation",
       "freshnessGuard": "maxAttestationAge 1h (rejects stale attestations)",
       "replayProtection": "nonce monotonic per asset + processedAttestations dedup map"
     }
@@ -59,7 +95,10 @@
             "label": "Asset Scored",
             "format": "addressName",
             "params": {
-              "types": ["token", "contract"]
+              "types": [
+                "token",
+                "contract"
+              ]
             }
           },
           {
@@ -100,11 +139,12 @@
             "label": "Source ScoreEngine Contract",
             "format": "addressName",
             "params": {
-              "types": ["contract"]
+              "types": [
+                "contract"
+              ]
             }
           }
-        ],
-        "required": ["asset", "score", "confidence", "nonce", "sourceTimestamp", "sourceChainId", "sourceContract"]
+        ]
       }
     }
   }


### PR DESCRIPTION
## ALIA Quality Network — 4 ERC-7730 v2 descriptors (BNB testnet)

This PR adds the first batch of ERC-7730 descriptors for the ALIA Quality Network AGIL-protected Pillar D Yield Boosted stack, live on BNB Chain testnet since 2026-05-15.

### Descriptors

| File | Contract | Chain | Address |
|---|---|---|---|
| `calldata-PillarDRouter.json` | PillarDRouter | BNB testnet (97) | `0x1Ae62FDd0114E88CAb94eD1a56fb99Db79A48e1B` |
| `calldata-YieldBoostedMode.json` | YieldBoostedMode | BNB testnet (97) | `0x8ffaf93a765cc8442c9c309CA8E9f061ea3FbEC6` |
| `eip712-AGILOperationAttestation.json` | AGILSignatureVerifier | BNB testnet (97) | `0x5866B9dbE020c4A306FefC416C04D8E1Ef779A8A` |
| `eip712-ScoreAttestation.json` | ScoreEngineV2BNBMirror | BNB testnet (97) | `0x2Ed898038F6605879f746985741650eBf4220571` |

### Sourcify verification

All 4 contracts are Sourcify-verified with `exact_match` (creation + runtime):

- AGILSignatureVerifier: https://sourcify.dev/server/v2/contract/97/0x5866B9dbE020c4A306FefC416C04D8E1Ef779A8A
- PillarDRouter: https://sourcify.dev/server/v2/contract/97/0x1Ae62FDd0114E88CAb94eD1a56fb99Db79A48e1B
- YieldBoostedMode: https://sourcify.dev/server/v2/contract/97/0x8ffaf93a765cc8442c9c309CA8E9f061ea3FbEC6
- ScoreEngineV2BNBMirror: https://sourcify.dev/server/v2/contract/97/0x2Ed898038F6605879f746985741650eBf4220571

### Notable feature

`eip712-AGILOperationAttestation.json` describes a multi-party threshold (3-of-5) EIP-712 attestation pattern. Backend operators sign the attestation off-chain; the user submits the attestation plus 3 signatures on-chain; the verifier validates the threshold, nonce monotonicity, expiry, and chainId before allowing the protected operation.

### Maintainer

Avvatar Labs SAS — patrick@avvatar.io
Public spec repo: https://github.com/alia-core/alia-contracts-spec

