### PR TITLE
Add Zama Sepolia shield descriptors

### DIFF
--- a/registry/zama/calldata-czamamock-sepolia.json
+++ b/registry/zama/calldata-czamamock-sepolia.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "context": {
+    "$id": "cZAMAMock Sepolia",
+    "contract": { "deployments": [{ "chainId": 11155111, "address": "0xf2D628d2598aF4eAF94CB76a437Ff86CA78FfbFB" }] }
+  },
+  "metadata": { "owner": "Zama", "info": { "url": "https://www.zama.org/" }, "contractName": "cZAMAMock" },
+  "display": {
+    "formats": {
+      "wrap(address to, uint256 amount)": {
+        "intent": "Shield",
+        "interpolatedIntent": "Shield {amount} to {to}",
+        "fields": [
+          {
+            "path": "amount",
+            "label": "Send",
+            "format": "tokenAmount",
+            "params": { "token": "0x75355a85c6FB9df5f0C80FF54e8747EEe9a0BF57", "chainId": 11155111 },
+            "visible": "always"
+          },
+          { "value": "cZAMAMock confidential balance", "label": "Receive", "format": "raw", "visible": "always" },
+          { "path": "to", "label": "Recipient", "format": "addressName", "params": { "types": ["eoa", "wallet"] }, "visible": "always" },
+          { "value": "cZAMAMock", "label": "Wrapper", "format": "raw", "visible": "always" }
+        ]
+      }
+    }
+  }
+}

--- a/registry/zama/calldata-zamamock-sepolia.json
+++ b/registry/zama/calldata-zamamock-sepolia.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "context": {
+    "$id": "ZAMAMock Sepolia",
+    "contract": { "deployments": [{ "chainId": 11155111, "address": "0x75355a85c6FB9df5f0C80FF54e8747EEe9a0BF57" }] }
+  },
+  "metadata": {
+    "owner": "Zama",
+    "info": { "url": "https://www.zama.org/" },
+    "token": { "ticker": "ZAMAMock", "name": "ZAMAMock", "decimals": 18 },
+    "contractName": "ZAMAMock"
+  },
+  "display": {
+    "formats": {
+      "approve(address spender, uint256 amount)": {
+        "intent": "Approve token spending",
+        "interpolatedIntent": "Approve {amount} for {spender}",
+        "fields": [
+          {
+            "path": "spender",
+            "label": "Spender",
+            "format": "raw",
+            "visible": "always"
+          },
+          {
+            "path": "amount",
+            "label": "Approval amount",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "@.to", "chainId": 11155111 },
+            "visible": "always"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/registry/zama/tests/calldata-czamamock-sepolia.tests.json
+++ b/registry/zama/tests/calldata-czamamock-sepolia.tests.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../specs/erc7730-tests.schema.json",
+  "tests": [
+    {
+      "description": "Shield ZAMAMock into cZAMAMock on Sepolia",
+      "rawTx": "0x02f8b483aa36a782013a830f424084046a6f9283066e8394f2d628d2598af4eaf94cb76a437ff86ca78ffbfb80b844bf376c7a00000000000000000000000072059f5569b6c7ab165bf05a280f2f870c73b4f80000000000000000000000000000000000000000000000000de0b6b3a7640000c001a0f878be05dae514c145f862c20a332e877796bf3681f90caea34af75376b91244a0111fc06a3bfde3e45417323638e0dcd8a44eda8291f1b35a3fc072ab2fb0fcb0",
+      "txHash": "0xe659dc7a87b6c5ab4e1a3514d30db5696bcae8ec6a8443d8e99a33ab82807d10",
+      "expectedTexts": [
+        "Shield",
+        "Send",
+        "1 ZAMAMock",
+        "Receive",
+        "cZAMAMock confidential balance",
+        "Recipient",
+        "Wrapper",
+        "cZAMAMock"
+      ]
+    }
+  ]
+}

--- a/registry/zama/tests/calldata-zamamock-sepolia.tests.json
+++ b/registry/zama/tests/calldata-zamamock-sepolia.tests.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../specs/erc7730-tests.schema.json",
+  "tests": [
+    {
+      "description": "Approve ZAMAMock spender on Sepolia",
+      "rawTx": "0x02f8b383aa36a7820139830f424084046a6f92828aed9475355a85c6fb9df5f0c80ff54e8747eee9a0bf5780b844095ea7b3000000000000000000000000f2d628d2598af4eaf94cb76a437ff86ca78ffbfb0000000000000000000000000000000000000000000000000de0b6b3a7640000c001a0157b22c169627de46e0f9df6b09b69c0409f47479b759e22605499065e879fb6a01d7bb94041d6a612963eeeaa5bc10836ad3547c2d0c2fea524a5c719d1d43954",
+      "txHash": "0x3c105f83e898dfb66c7ea10c5f9dacb691c54795b35d78954a6b5b83397285e5",
+      "expectedTexts": [
+        "Approve token spending",
+        "Spender",
+        "0xf2D628d2598aF4eAF94CB76a437Ff86CA78FfbFB",
+        "Approval amount",
+        "1 ZAMAMock"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Sepolia ERC-7730 descriptors for ZAMAMock approval and cZAMAMock shielding
- include reference tests using real Sepolia transactions for approve and wrap
- scope is limited to the verified ZAMAMock/cZAMAMock pair

This initial submission covers the approve + wrap shielding path only.

## Validation
- uvx erc7730 lint registry/zama/calldata-zamamock-sepolia.json registry/zama/calldata-czamamock-sepolia.json
- uvx check-jsonschema --schemafile specs/erc7730-v2.schema.json registry/zama/calldata-zamamock-sepolia.json registry/zama/calldata-czamamock-sepolia.json
- uvx check-jsonschema --schemafile specs/erc7730-tests.schema.json registry/zama/tests/calldata-zamamock-sepolia.tests.json registry/zama/tests/calldata-czamamock-sepolia.tests.json