### PR TITLE
Add vault-inc descriptors

### DIFF
--- a/registry/vault-inc/calldata-Vault.json
+++ b/registry/vault-inc/calldata-Vault.json
@@ -242,8 +242,7 @@
           {
             "path": "$.value",
             "label": "Amount",
-            "format": "amount",
-            "params": {}
+            "format": "amount"
           }
         ]
       },
@@ -252,7 +251,7 @@
         "fields": [
           {
             "path": "to",
-            "label": "To",
+            "label": "Recipient",
             "format": "addressName",
             "params": {
               "types": [
@@ -265,8 +264,7 @@
           {
             "path": "amount",
             "label": "Amount",
-            "format": "amount",
-            "params": {}
+            "format": "amount"
           }
         ]
       },
@@ -286,7 +284,7 @@
           },
           {
             "path": "to",
-            "label": "To",
+            "label": "Recipient",
             "format": "addressName",
             "params": {
               "types": [
@@ -299,12 +297,11 @@
           {
             "path": "amount",
             "label": "Amount",
-            "format": "amount",
-            "params": {}
+            "format": "amount"
           },
           {
             "path": "deadline",
-            "label": "Valid Until",
+            "label": "Expires On",
             "format": "date",
             "params": {
               "encoding": "timestamp"

--- a/registry/vault-inc/calldata-Vault.json
+++ b/registry/vault-inc/calldata-Vault.json
@@ -237,17 +237,17 @@
   "display": {
     "formats": {
       "deposit()": {
-        "intent": "Deposit ETH into your vault balance",
+        "intent": "Deposit ETH to vault",
         "fields": [
           {
-            "path": "$.value",
+            "path": "@.value",
             "label": "Amount",
             "format": "amount"
           }
         ]
       },
       "withdraw(address to, uint256 amount)": {
-        "intent": "Withdraw ETH from your vault balance",
+        "intent": "Withdraw ETH from vault",
         "fields": [
           {
             "path": "to",
@@ -269,11 +269,11 @@
         ]
       },
       "withdrawWithPermit(address owner, address to, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s)": {
-        "intent": "Withdraw ETH from an account's vault balance using a permit",
+        "intent": "Permit withdraw from vault",
         "fields": [
           {
             "path": "owner",
-            "label": "Owner",
+            "label": "From",
             "format": "addressName",
             "params": {
               "types": [
@@ -301,7 +301,7 @@
           },
           {
             "path": "deadline",
-            "label": "Expires On",
+            "label": "Expires",
             "format": "date",
             "params": {
               "encoding": "timestamp"

--- a/registry/vault-inc/calldata-Vault.json
+++ b/registry/vault-inc/calldata-Vault.json
@@ -1,0 +1,317 @@
+{
+  "$schema": "https://eips.ethereum.org/assets/eip-7730/erc7730-v2.schema.json",
+  "context": {
+    "$id": "Vault",
+    "contract": {
+      "abi": [
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "account",
+              "type": "address"
+            },
+            {
+              "indexed": false,
+              "internalType": "uint256",
+              "name": "amount",
+              "type": "uint256"
+            }
+          ],
+          "name": "Deposited",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "account",
+              "type": "address"
+            },
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "to",
+              "type": "address"
+            },
+            {
+              "indexed": false,
+              "internalType": "uint256",
+              "name": "amount",
+              "type": "uint256"
+            }
+          ],
+          "name": "Withdrawn",
+          "type": "event"
+        },
+        {
+          "inputs": [],
+          "name": "DOMAIN_SEPARATOR",
+          "outputs": [
+            {
+              "internalType": "bytes32",
+              "name": "",
+              "type": "bytes32"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "DOMAIN_TYPEHASH",
+          "outputs": [
+            {
+              "internalType": "bytes32",
+              "name": "",
+              "type": "bytes32"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "WITHDRAWAL_PERMIT_TYPEHASH",
+          "outputs": [
+            {
+              "internalType": "bytes32",
+              "name": "",
+              "type": "bytes32"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "",
+              "type": "address"
+            }
+          ],
+          "name": "balanceOf",
+          "outputs": [
+            {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "deposit",
+          "outputs": [],
+          "stateMutability": "payable",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "name",
+          "outputs": [
+            {
+              "internalType": "string",
+              "name": "",
+              "type": "string"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "",
+              "type": "address"
+            }
+          ],
+          "name": "nonces",
+          "outputs": [
+            {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "version",
+          "outputs": [
+            {
+              "internalType": "string",
+              "name": "",
+              "type": "string"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "to",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amount",
+              "type": "uint256"
+            }
+          ],
+          "name": "withdraw",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "owner",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "to",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amount",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "deadline",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint8",
+              "name": "v",
+              "type": "uint8"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "r",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "s",
+              "type": "bytes32"
+            }
+          ],
+          "name": "withdrawWithPermit",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        }
+      ],
+      "deployments": [
+        {
+          "chainId": 31337,
+          "address": "0x5FbDB2315678afecb367f032d93F642f64180aa3"
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "Vault Inc.",
+    "info": {
+      "url": "https://vault.example"
+    }
+  },
+  "display": {
+    "formats": {
+      "deposit()": {
+        "intent": "Deposit ETH into your vault balance",
+        "fields": [
+          {
+            "path": "$.value",
+            "label": "Amount",
+            "format": "amount",
+            "params": {}
+          }
+        ]
+      },
+      "withdraw(address to, uint256 amount)": {
+        "intent": "Withdraw ETH from your vault balance",
+        "fields": [
+          {
+            "path": "to",
+            "label": "To",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "wallet",
+                "eoa",
+                "contract"
+              ]
+            }
+          },
+          {
+            "path": "amount",
+            "label": "Amount",
+            "format": "amount",
+            "params": {}
+          }
+        ]
+      },
+      "withdrawWithPermit(address owner, address to, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s)": {
+        "intent": "Withdraw ETH from an account's vault balance using a permit",
+        "fields": [
+          {
+            "path": "owner",
+            "label": "Owner",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "wallet",
+                "eoa"
+              ]
+            }
+          },
+          {
+            "path": "to",
+            "label": "To",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "wallet",
+                "eoa",
+                "contract"
+              ]
+            }
+          },
+          {
+            "path": "amount",
+            "label": "Amount",
+            "format": "amount",
+            "params": {}
+          },
+          {
+            "path": "deadline",
+            "label": "Valid Until",
+            "format": "date",
+            "params": {
+              "encoding": "timestamp"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/registry/vault-inc/eip712-Vault.json
+++ b/registry/vault-inc/eip712-Vault.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://eips.ethereum.org/assets/eip-7730/erc7730-v2.schema.json",
+  "context": {
+    "$id": "Vault",
+    "eip712": {
+      "domain": {
+        "name": "Vault",
+        "version": "1",
+        "chainId": 31337,
+        "verifyingContract": "0x5FbDB2315678afecb367f032d93F642f64180aa3"
+      },
+      "deployments": [
+        {
+          "chainId": 31337,
+          "address": "0x5FbDB2315678afecb367f032d93F642f64180aa3"
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "Vault Inc.",
+    "info": {
+      "url": "https://vault.example"
+    }
+  },
+  "display": {
+    "formats": {
+      "WithdrawalPermit(address owner,address to,uint256 amount,uint256 nonce,uint256 deadline)": {
+        "intent": "Authorize a withdrawal of ETH from your Vault balance",
+        "fields": [
+          {
+            "path": "owner",
+            "label": "From Account",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "wallet",
+                "eoa"
+              ]
+            }
+          },
+          {
+            "path": "to",
+            "label": "To Recipient",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "wallet",
+                "eoa",
+                "contract"
+              ]
+            }
+          },
+          {
+            "path": "amount",
+            "label": "Amount",
+            "format": "amount",
+            "params": {}
+          },
+          {
+            "path": "nonce",
+            "label": "Nonce",
+            "format": "raw",
+            "params": {}
+          },
+          {
+            "path": "deadline",
+            "label": "Valid Until",
+            "format": "date",
+            "params": {
+              "encoding": "timestamp"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/registry/vault-inc/eip712-Vault.json
+++ b/registry/vault-inc/eip712-Vault.json
@@ -26,8 +26,7 @@
   "display": {
     "formats": {
       "WithdrawalPermit(address owner,address to,uint256 amount,uint256 nonce,uint256 deadline)": {
-        "intent": "Allow {owner} to withdraw {amount} ETH from your Vault balance to {to}",
-        "interpolatedIntent": "Allow {fields.owner} to withdraw {fields.amount} ETH from your Vault balance to {fields.to}",
+        "intent": "Permit Withdrawal",
         "fields": [
           {
             "path": "owner",
@@ -36,7 +35,8 @@
             "params": {
               "types": [
                 "wallet",
-                "eoa"
+                "eoa",
+                "contract"
               ]
             }
           },
@@ -64,7 +64,7 @@
           },
           {
             "path": "deadline",
-            "label": "Valid Until",
+            "label": "Expires",
             "format": "date",
             "params": {
               "encoding": "timestamp"

--- a/registry/vault-inc/eip712-Vault.json
+++ b/registry/vault-inc/eip712-Vault.json
@@ -26,11 +26,12 @@
   "display": {
     "formats": {
       "WithdrawalPermit(address owner,address to,uint256 amount,uint256 nonce,uint256 deadline)": {
-        "intent": "Authorize a withdrawal of ETH from your Vault balance",
+        "intent": "Allow {owner} to withdraw {amount} ETH from your Vault balance to {to}",
+        "interpolatedIntent": "Allow {fields.owner} to withdraw {fields.amount} ETH from your Vault balance to {fields.to}",
         "fields": [
           {
             "path": "owner",
-            "label": "From Account",
+            "label": "Owner",
             "format": "addressName",
             "params": {
               "types": [
@@ -41,7 +42,7 @@
           },
           {
             "path": "to",
-            "label": "To Recipient",
+            "label": "Recipient",
             "format": "addressName",
             "params": {
               "types": [
@@ -54,14 +55,12 @@
           {
             "path": "amount",
             "label": "Amount",
-            "format": "amount",
-            "params": {}
+            "format": "amount"
           },
           {
             "path": "nonce",
             "label": "Nonce",
-            "format": "raw",
-            "params": {}
+            "format": "raw"
           },
           {
             "path": "deadline",


### PR DESCRIPTION
Adds ERC-7730 descriptors for **Vault Inc.**.

Generated with [hardhat-descriptor](https://github.com/hangleang/hardhat-descriptor).
Each file is LLM-authored and has been reviewed for clear-signing correctness before submission.

Files in this PR:
- `registry/vault-inc/calldata-Vault.json`
- `registry/vault-inc/eip712-Vault.json`