### PR TITLE
Add Allowance.eth — AI agent spending policy clear signing descriptor

### DIFF
--- a/registry/allowance-eth/calldata-PolicyGuard.json
+++ b/registry/allowance-eth/calldata-PolicyGuard.json
@@ -89,13 +89,6 @@
     "info": {
       "url": "https://github.com/dankot12/allowance.eth",
       "deploymentDate": "2026-06-14T00:00:00Z"
-    },
-    "enums": {
-      "KnownTarget": {
-        "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45": "Uniswap V3 SwapRouter02",
-        "0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD": "Uniswap Universal Router",
-        "0x6Ae43d3271ff6888e7Fc43Fd7321a503ff738951": "Aave V3 Pool (Sepolia)"
-      }
     }
   },
 

--- a/registry/allowance-eth/calldata-PolicyGuard.json
+++ b/registry/allowance-eth/calldata-PolicyGuard.json
@@ -88,7 +88,6 @@
     "owner": "Allowance.eth",
     "info": {
       "url": "https://github.com/dankot12/allowance.eth",
-      "legalName": "Allowance.eth — AI Agent Spending Policies",
       "deploymentDate": "2026-06-14T00:00:00Z"
     },
     "enums": {
@@ -122,7 +121,7 @@
         ]
       },
 
-      "checkWithHumanApproval(bytes32 namehash_, address target, uint256 value, bytes data, (((uint256,bool),(uint256,bool),(uint256,bool),(uint32,uint32,bool),address[],bool)) policy, string policyJson, bytes humanSig)": {
+      "checkWithHumanApproval(bytes32 namehash_, address target, uint256 value, bytes data, ((uint256,bool),(uint256,bool),(uint256,bool),(uint32,uint32,bool),address[],bool) policy, string policyJson, bytes humanSig)": {
         "$id": "checkWithHumanApproval",
         "intent": "Approve Agent Transaction",
         "fields": [

--- a/registry/allowance-eth/calldata-PolicyGuard.json
+++ b/registry/allowance-eth/calldata-PolicyGuard.json
@@ -1,0 +1,217 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+
+  "context": {
+    "$id": "PolicyGuard",
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 11155111,
+          "address": "0x6912A1247952dd082839d93c79f6e64c5898F939"
+        }
+      ],
+      "abi": [
+        {
+          "name": "updatePolicy",
+          "type": "function",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            { "name": "namehash_",  "type": "bytes32" },
+            { "name": "policyHash", "type": "bytes32" }
+          ],
+          "outputs": []
+        },
+        {
+          "name": "checkWithHumanApproval",
+          "type": "function",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            { "name": "namehash_", "type": "bytes32" },
+            { "name": "target",    "type": "address" },
+            { "name": "value",     "type": "uint256" },
+            { "name": "data",      "type": "bytes" },
+            {
+              "name": "policy",
+              "type": "tuple",
+              "components": [
+                { "name": "dailyCap", "type": "tuple", "components": [
+                    { "name": "amount",  "type": "uint256" },
+                    { "name": "enabled", "type": "bool" }
+                ]},
+                { "name": "approvalThreshold", "type": "tuple", "components": [
+                    { "name": "amount",  "type": "uint256" },
+                    { "name": "enabled", "type": "bool" }
+                ]},
+                { "name": "perCounterpartyCap", "type": "tuple", "components": [
+                    { "name": "amount",  "type": "uint256" },
+                    { "name": "enabled", "type": "bool" }
+                ]},
+                { "name": "timeWindow", "type": "tuple", "components": [
+                    { "name": "start",   "type": "uint32" },
+                    { "name": "end",     "type": "uint32" },
+                    { "name": "enabled", "type": "bool" }
+                ]},
+                { "name": "allowlist",        "type": "address[]" },
+                { "name": "allowlistEnabled", "type": "bool" }
+              ]
+            },
+            { "name": "policyJson", "type": "string" },
+            { "name": "humanSig",   "type": "bytes"  }
+          ],
+          "outputs": [{ "name": "", "type": "bool" }]
+        },
+        {
+          "name": "transferPolicyOwnership",
+          "type": "function",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            { "name": "namehash_", "type": "bytes32" },
+            { "name": "newOwner",  "type": "address" }
+          ],
+          "outputs": []
+        },
+        {
+          "name": "setHumanApprover",
+          "type": "function",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            { "name": "namehash_", "type": "bytes32" },
+            { "name": "approver",  "type": "address" }
+          ],
+          "outputs": []
+        }
+      ]
+    }
+  },
+
+  "metadata": {
+    "owner": "Allowance.eth",
+    "info": {
+      "url": "https://github.com/dankot12/allowance.eth",
+      "legalName": "Allowance.eth — AI Agent Spending Policies",
+      "deploymentDate": "2026-06-14T00:00:00Z"
+    },
+    "enums": {
+      "KnownTarget": {
+        "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45": "Uniswap V3 SwapRouter02",
+        "0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD": "Uniswap Universal Router",
+        "0x6Ae43d3271ff6888e7Fc43Fd7321a503ff738951": "Aave V3 Pool (Sepolia)"
+      }
+    }
+  },
+
+  "display": {
+    "formats": {
+
+      "updatePolicy(bytes32 namehash_, bytes32 policyHash)": {
+        "$id": "updatePolicy",
+        "intent": "Register Spending Policy",
+        "fields": [
+          {
+            "path": "namehash_",
+            "label": "ENS Name Hash",
+            "format": "raw",
+            "visible": "always"
+          },
+          {
+            "path": "policyHash",
+            "label": "Policy Hash (keccak256 of JSON)",
+            "format": "raw",
+            "visible": "always"
+          }
+        ]
+      },
+
+      "checkWithHumanApproval(bytes32 namehash_, address target, uint256 value, bytes data, (((uint256,bool),(uint256,bool),(uint256,bool),(uint32,uint32,bool),address[],bool)) policy, string policyJson, bytes humanSig)": {
+        "$id": "checkWithHumanApproval",
+        "intent": "Approve Agent Transaction",
+        "fields": [
+          {
+            "path": "target",
+            "label": "Destination",
+            "format": "addressName",
+            "params": {
+              "types": ["contract"],
+              "sources": ["local", "ens"]
+            },
+            "visible": "always"
+          },
+          {
+            "path": "value",
+            "label": "Amount",
+            "format": "tokenAmount",
+            "params": {
+              "token": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
+            },
+            "visible": "always"
+          },
+          {
+            "path": "policy.dailyCap.amount",
+            "label": "Daily Cap",
+            "format": "tokenAmount",
+            "params": {
+              "token": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
+            },
+            "visible": "always"
+          },
+          {
+            "path": "policy.approvalThreshold.amount",
+            "label": "Approval Threshold",
+            "format": "tokenAmount",
+            "params": {
+              "token": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
+            },
+            "visible": "always"
+          }
+        ]
+      },
+
+      "transferPolicyOwnership(bytes32 namehash_, address newOwner)": {
+        "$id": "transferPolicyOwnership",
+        "intent": "Transfer Policy Control",
+        "fields": [
+          {
+            "path": "namehash_",
+            "label": "ENS Name Hash",
+            "format": "raw",
+            "visible": "always"
+          },
+          {
+            "path": "newOwner",
+            "label": "New Owner",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens"]
+            },
+            "visible": "always"
+          }
+        ]
+      },
+
+      "setHumanApprover(bytes32 namehash_, address approver)": {
+        "$id": "setHumanApprover",
+        "intent": "Authorize Ledger for Human Approvals",
+        "fields": [
+          {
+            "path": "namehash_",
+            "label": "ENS Name Hash",
+            "format": "raw",
+            "visible": "always"
+          },
+          {
+            "path": "approver",
+            "label": "Ledger Approver Address",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa"],
+              "sources": ["local", "ens"]
+            },
+            "visible": "always"
+          }
+        ]
+      }
+
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds an ERC-7730 v2 calldata descriptor for **PolicyGuard.sol**, the on-chain spending enforcement contract from [Allowance.eth](https://github.com/dankot12/allowance.eth), built for EthGlobal NYC 2026.

**Allowance.eth** lets you write spending rules for AI agents in plain English, anchored to an ENS name. The agent calls `checkWithHumanApproval` when a transaction exceeds the approval threshold — this is where Ledger clear signing matters: the device shows a readable summary instead of raw calldata.

## Covered functions

| Function | Intent |
|---|---|
| `updatePolicy` | Register a new spending policy (ENS namehash + keccak256 hash) |
| `checkWithHumanApproval` | Human override for above-threshold agent transactions |
| `transferPolicyOwnership` | Transfer agent identity to a new wallet |
| `setHumanApprover` | Authorize a Ledger device address as the human approver |

## Deployment

- **Network:** Sepolia testnet (chainId 11155111) — hackathon deployment
- **Contract:** `0x6912A1247952dd082839d93c79f6e64c5898F939`

> Note: This is a testnet deployment for a hackathon project. The descriptor is submitted to demonstrate integration intent and for EthGlobal judges to review. A mainnet deployment would follow the same descriptor unchanged.

## Test plan

- [ ] JSON validates against `erc7730-v2.schema.json`
- [ ] Function signatures match ABI
- [ ] Field paths resolve correctly for tuple types (`policy.dailyCap.amount`, etc.)