### PR TITLE
Add heyAura login clear-signing metadata

### DIFF
--- a/index.eip712.json
+++ b/index.eip712.json
@@ -2641,6 +2641,16 @@
       }
     ]
   },
+  "eip155:1:0xd5d42c2ba3e702e7cda5deb805bedb35218a3792": {
+    "LoginInfo": [
+      {
+        "path": "registry/heyaura/eip712-LoginInfo.json",
+        "encodeTypeHashes": [
+          "0x7bf780edd9b9ccdcdb650dc5ba334ef4c1e9bed2d331421176a1eef84a39f175"
+        ]
+      }
+    ]
+  },
   "eip155:1:0xd9db270c1b5e3bd161e8c8503c55ceabee709552": {
     "SafeTx": [
       {

--- a/registry/heyaura/eip712-LoginInfo.json
+++ b/registry/heyaura/eip712-LoginInfo.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "context": {
+    "eip712": {
+      "domain": { "name": "heyAura AI Assistant", "version": "1" },
+      "deployments": [{ "chainId": 1, "address": "0xd5D42C2BA3e702e7CdA5deb805bEDB35218A3792" }]
+    }
+  },
+  "metadata": { "owner": "heyAura", "contractName": "heyAura Login Domain", "info": { "url": "https://www.heyaura.com/" } },
+  "display": {
+    "formats": {
+      "LoginInfo(address wallet,string purpose,string requestedAt)": {
+        "intent": "Log in to heyAura",
+        "fields": [
+          {
+            "path": "wallet",
+            "label": "Wallet",
+            "format": "addressName",
+            "params": { "types": ["wallet", "eoa"], "sources": ["local", "ens"] },
+            "visible": "always"
+          },
+          { "path": "purpose", "label": "Purpose", "format": "raw", "visible": "always" },
+          { "path": "requestedAt", "label": "Requested at", "format": "raw", "visible": "always" }
+        ]
+      }
+    }
+  }
+}

--- a/registry/heyaura/testsv2/eip712-LoginInfo.tests.json
+++ b/registry/heyaura/testsv2/eip712-LoginInfo.tests.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "../../../specs/erc7730-tests-v2.schema.json",
+  "descriptor": "../eip712-LoginInfo.json",
+  "dataProvider": {},
+  "tests": [
+    {
+      "description": "Log in to heyAura",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            {
+              "name": "name",
+              "type": "string"
+            },
+            {
+              "name": "version",
+              "type": "string"
+            },
+            {
+              "name": "chainId",
+              "type": "uint256"
+            },
+            {
+              "name": "verifyingContract",
+              "type": "address"
+            }
+          ],
+          "LoginInfo": [
+            {
+              "name": "wallet",
+              "type": "address"
+            },
+            {
+              "name": "purpose",
+              "type": "string"
+            },
+            {
+              "name": "requestedAt",
+              "type": "string"
+            }
+          ]
+        },
+        "primaryType": "LoginInfo",
+        "domain": {
+          "name": "heyAura AI Assistant",
+          "version": "1",
+          "chainId": 1,
+          "verifyingContract": "0xd5D42C2BA3e702e7CdA5deb805bEDB35218A3792"
+        },
+        "message": {
+          "wallet": "0x2aecF52ABe359820c48986046959B4136AfDfbe2",
+          "purpose": "Wallet login verification",
+          "requestedAt": "2026-07-13T08:30:04.602Z"
+        }
+      },
+      "expected": {
+        "intent": "Log in to heyAura",
+        "owner": "heyAura",
+        "fields": [
+          {
+            "label": "Wallet",
+            "value": "0x2aecF52ABe359820c48986046959B4136AfDfbe2"
+          },
+          {
+            "label": "Purpose",
+            "value": "Wallet login verification"
+          },
+          {
+            "label": "Requested at",
+            "value": "2026-07-13T08:30:04.602Z"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds ERC-7730 clear-signing metadata for heyAura wallet login messages.

- Domain: `heyAura AI Assistant`, version `1`
- Primary type: `LoginInfo(address wallet,string purpose,string requestedAt)`
- Network: Ethereum mainnet
- Verifying contract: `0xd5D42C2BA3e702e7CdA5deb805bEDB35218A3792`
- Includes the EIP-712 descriptor, registry index entry, and reference fixture