### PR TITLE
Sync PR labels on changes

### DIFF
--- a/.github/workflows/pull_request_labels.yml
+++ b/.github/workflows/pull_request_labels.yml
@@ -1,4 +1,4 @@
-name: ✨ pull request setup
+name: 🏷️ pull request labels
 
 on:
   pull_request_target:
@@ -24,6 +24,8 @@ jobs:
       - name: Add labels
         timeout-minutes: 5
         uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6
+        with:
+          sync-labels: true
 
       - name: Enforce labels
         timeout-minutes: 5


### PR DESCRIPTION

- Rename `pull_request_setup.yml` → `pull_request_labels.yml` (and the workflow name) to reflect that it applies and enforces PR labels.
- Set `sync-labels: true` so labels are reconciled on every push — managed labels are now removed when their globs stop matching, not only added.
