### PR TITLE
Fix broken sync-specs and format workflows

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -7,7 +7,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  id-token: write
+  contents: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -19,7 +20,7 @@ env:
 jobs:
   format:
     name: format descriptors
-    runs-on: unbuntu-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - name: Checkout
@@ -57,13 +58,13 @@ jobs:
         timeout-minutes: 10
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
-          token: ${{ secrets.CI_BOT_TOKEN }}
-          author: ${{ secrets.CI_BOT_USERNAME }} <${{ secrets.CI_BOT_USERNAME }}@users.noreply.github.com>
+          token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ env.BRANCH }}-format-descriptors
           base: ${{ env.BRANCH }}
           delete-branch: false
           commit-message: "chore: format descriptors - ${{ env.CURRENT_DATE }}"
           title: "chore: format descriptors - ${{ env.CURRENT_DATE }}"
-          body: ${{ steps.submodules.outputs.prBody }}
+          body: |
+            Automated `erc7730 format` of the registry descriptors - ${{ env.CURRENT_DATE }}.
           draft: false
           signoff: false

--- a/.github/workflows/sync-specs.yml
+++ b/.github/workflows/sync-specs.yml
@@ -7,7 +7,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  id-token: write
+  contents: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -31,13 +32,13 @@ jobs:
         run: echo "CURRENT_DATE=$(date +"%Y-%m-%d %H:%M")" >> $GITHUB_ENV
 
       # File mapping (upstream -> local):
-      #   ERCS/erc-7734.md                          -> specs/erc-7730.md
+      #   ERCS/erc-7730.md                          -> specs/erc-7730.md
       #   assets/erc-7730/erc7730-v2.schema.json     -> specs/erc7730-v2.schema.json
       #   assets/erc-7730/erc7730-v1.schema.json     -> specs/erc7730-v1.schema.json
       - name: Fetch upstream spec files
         timeout-minutes: 10
         run: |
-          curl -fsSL "https://raw.githubusercontent.com/ethereum/ERCs/master/ERCS/erc-7734.md" \
+          curl -fsSL "https://raw.githubusercontent.com/ethereum/ERCs/master/ERCS/erc-7730.md" \
             -o specs/erc-7730.md
           curl -fsSL "https://raw.githubusercontent.com/ethereum/ERCs/master/assets/erc-7730/erc7730-v2.schema.json" \
             -o specs/erc7730-v2.schema.json
@@ -56,8 +57,7 @@ jobs:
         timeout-minutes: 10
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
-          token: ${{ secrets.CI_BOT_TOKEN }}
-          author: ${{ secrets.CI_BOT_USERNAME }} <${{ secrets.CI_BOT_USERNAME }}@users.noreply.github.com>
+          token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ env.BRANCH }}-sync-specs
           base: ${{ env.BRANCH }}
           delete-branch: false
@@ -67,7 +67,7 @@ jobs:
             Automated sync of spec files from [ethereum/ERCs](https://github.com/ethereum/ERCs).
 
             Files synced:
-            - `ERCS/erc-7734.md` -> `specs/erc-7730.md`
+            - `ERCS/erc-7730.md` -> `specs/erc-7730.md`
             - `assets/erc-7730/erc7730-v2.schema.json` -> `specs/erc7730-v2.schema.json`
             - `assets/erc-7730/erc7730-v1.schema.json` -> `specs/erc7730-v1.schema.json`
           draft: false

--- a/specs/README.md
+++ b/specs/README.md
@@ -8,7 +8,7 @@ The following files are automatically synced from the [ethereum/ERCs](https://gi
 
 | Local file | Upstream source |
 |---|---|
-| `erc-7730.md` | [ERCS/erc-7734.md](https://github.com/ethereum/ERCs/blob/master/ERCS/erc-7734.md) |
+| `erc-7730.md` | [ERCS/erc-7730.md](https://github.com/ethereum/ERCs/blob/master/ERCS/erc-7730.md) |
 | `erc7730-v2.schema.json` | [assets/erc-7730/erc7730-v2.schema.json](https://github.com/ethereum/ERCs/blob/master/assets/erc-7730/erc7730-v2.schema.json) |
 | `erc7730-v1.schema.json` | [assets/erc-7730/erc7730-v1.schema.json](https://github.com/ethereum/ERCs/blob/master/assets/erc-7730/erc7730-v1.schema.json) |
 


### PR DESCRIPTION
See #2628 

Fix two scheduled CI jobs left broken after the EF handover — both now use `GITHUB_TOKEN` instead of the unavailable `CI_BOT_TOKEN`, with the `contents`/`pull-requests` write permissions it needs.

- **sync-specs:** fetch the spec doc from the correct `ERCS/erc-7730.md` (was `erc-7734.md`, an unrelated ERC).
- **format:** fix `runs-on: unbuntu-latest` typo (job was queuing 24h then cancelling) and the empty PR body.

## Note

Requires the "Allow GitHub Actions to create and approve pull requests" setting enabled; PRs these open won't auto-trigger validation.
