### PR TITLE
ci: pin sync PR commits to github-actions[bot]

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -59,6 +59,8 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           branch: ${{ env.BRANCH }}-format-descriptors
           base: ${{ env.BRANCH }}
           delete-branch: false

--- a/.github/workflows/sync-specs.yml
+++ b/.github/workflows/sync-specs.yml
@@ -58,6 +58,8 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           branch: ${{ env.BRANCH }}-sync-specs
           base: ${{ env.BRANCH }}
           delete-branch: false


### PR DESCRIPTION
## What

- Set `author` and `committer` explicitly to `github-actions[bot]` in the `sync-specs` and `format` create-pull-request steps.

## Why

- After moving to `GITHUB_TOKEN`, the dropped `author` defaulted to `github.actor`, attributing scheduled sync commits to whoever last touched the workflow (e.g. `fsamier`). Now they're stable and impersonal, matching the PR opener.
- See https://github.com/ethereum/clear-signing-erc7730-registry/pull/2652 and https://github.com/ethereum/clear-signing-erc7730-registry/pull/2650