### PR TITLE
Add auditor: Patrick Collins (Cyfrin)

### DIFF
--- a/auditors/eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6/profile.json
+++ b/auditors/eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6/profile.json
@@ -1,0 +1,5 @@
+{
+  "id": "eip155:1:0x3846c3A30E62075Fa916216b35EF04B8F53931f6",
+  "name": "Patrick Collins",
+  "organization": "Cyfrin"
+}


### PR DESCRIPTION
Adds an auditor profile per auditors/README.md ("Getting listed").

- Auditor: Patrick Collins
- Organization: Cyfrin
- Identifier: eip155:1:0x3846c3A30E62075Fa916216b35EF04B8F53931f6
- File: auditors/eip155-1-0x3846c3A30E62075Fa916216b35EF04B8F53931f6/profile.json

This is the signing key used for the Cyfrin clear-signing review attestations
submitted in the accompanying attestations PR.
