### PR TITLE
fix(permit): correct EIP-712 domains to match on-chain tokens

### DIFF
--- a/registry/permit/eip712-permit-arbitrum-bridged-usdc.json
+++ b/registry/permit/eip712-permit-arbitrum-bridged-usdc.json
@@ -4,7 +4,7 @@
   "context": {
     "eip712": {
       "deployments": [{ "chainId": 42161, "address": "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8" }],
-      "domain": { "name": "USD Coin", "version": "2" }
+      "domain": { "name": "USD Coin (Arb1)", "version": "1" }
     }
   },
   "metadata": { "owner": "USDC (bridged)" }

--- a/registry/permit/eip712-permit-arbitrum-dai.json
+++ b/registry/permit/eip712-permit-arbitrum-dai.json
@@ -4,7 +4,7 @@
   "context": {
     "eip712": {
       "deployments": [{ "chainId": 42161, "address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1" }],
-      "domain": { "name": "Dai Stablecoin", "version": "1" }
+      "domain": { "name": "Dai Stablecoin", "version": "2" }
     }
   },
   "metadata": { "owner": "Dai Stablecoin" }

--- a/registry/permit/eip712-permit-arbitrum-usds.json
+++ b/registry/permit/eip712-permit-arbitrum-usds.json
@@ -4,7 +4,7 @@
   "context": {
     "eip712": {
       "deployments": [{ "chainId": 42161, "address": "0x6491c05A82219b8D1479057361ff1654749b876b" }],
-      "domain": { "name": "Gains Network", "version": "1" }
+      "domain": { "name": "USDS Stablecoin", "version": "1" }
     }
   },
   "metadata": { "owner": "USDS" }

--- a/registry/permit/eip712-permit-arbitrum-usdt.json
+++ b/registry/permit/eip712-permit-arbitrum-usdt.json
@@ -4,7 +4,7 @@
   "context": {
     "eip712": {
       "deployments": [{ "chainId": 42161, "address": "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9" }],
-      "domain": { "name": "Tether USD", "version": "1" }
+      "domain": { "name": "USD₮0", "version": "1" }
     }
   },
   "metadata": { "owner": "USDT" }

--- a/registry/permit/eip712-permit-arbitrum-wsteth.json
+++ b/registry/permit/eip712-permit-arbitrum-wsteth.json
@@ -4,7 +4,7 @@
   "context": {
     "eip712": {
       "deployments": [{ "chainId": 42161, "address": "0x9cfB13E6c11054ac9fcB92BA89644F30775436e4" }],
-      "domain": { "name": "Wrapped stETH", "version": "1" }
+      "domain": { "name": "Axelar Wrapped wstETH", "version": "1" }
     }
   },
   "metadata": { "owner": "Wrapped liquid staked Ether 2.0" }

--- a/registry/permit/eip712-permit-avalanche_c_chain-pangolin.json
+++ b/registry/permit/eip712-permit-avalanche_c_chain-pangolin.json
@@ -4,7 +4,7 @@
   "context": {
     "eip712": {
       "deployments": [{ "chainId": 43114, "address": "0x60781c2586d68229fde47564546784ab3faca982" }],
-      "domain": { "name": "Pangolin", "version": "1" }
+      "domain": { "name": "Pangolin" }
     }
   },
   "metadata": { "owner": "Pangolin" }

--- a/registry/permit/eip712-permit-avalanche_c_chain-usdt.json
+++ b/registry/permit/eip712-permit-avalanche_c_chain-usdt.json
@@ -4,7 +4,7 @@
   "context": {
     "eip712": {
       "deployments": [{ "chainId": 43114, "address": "0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7" }],
-      "domain": { "name": "Tether USD", "version": "1" }
+      "domain": { "name": "TetherToken", "version": "1" }
     }
   },
   "metadata": { "owner": "USDT" }

--- a/registry/permit/eip712-permit-base-aero.json
+++ b/registry/permit/eip712-permit-base-aero.json
@@ -4,7 +4,7 @@
   "context": {
     "eip712": {
       "deployments": [{ "chainId": 8453, "address": "0x940181a94A35A4569E4529A3CDfB74e38FD98631" }],
-      "domain": { "name": "Aero", "version": "1" }
+      "domain": { "name": "Aerodrome", "version": "1" }
     }
   },
   "metadata": { "owner": "AERO" }

--- a/registry/permit/eip712-permit-ethereum-aave.json
+++ b/registry/permit/eip712-permit-ethereum-aave.json
@@ -4,7 +4,7 @@
   "context": {
     "eip712": {
       "deployments": [{ "chainId": 1, "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9" }],
-      "domain": { "name": "Aave Token", "version": "1" }
+      "domain": { "name": "Aave token V3", "version": "2" }
     }
   },
   "metadata": { "owner": "Aave" }

--- a/registry/permit/eip712-permit-ethereum-lido-wsteth.json
+++ b/registry/permit/eip712-permit-ethereum-lido-wsteth.json
@@ -4,7 +4,7 @@
   "context": {
     "eip712": {
       "deployments": [{ "chainId": 1, "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0" }],
-      "domain": { "name": "Wrapped stETH", "version": "1" }
+      "domain": { "name": "Wrapped liquid staked Ether 2.0", "version": "1" }
     }
   },
   "metadata": { "owner": "Lido DAO" }

--- a/registry/permit/eip712-permit-ethereum-usds.json
+++ b/registry/permit/eip712-permit-ethereum-usds.json
@@ -4,7 +4,7 @@
   "context": {
     "eip712": {
       "deployments": [{ "chainId": 1, "address": "0xdC035D45d973E3EC169d2276DDab16f1e407384F" }],
-      "domain": { "name": "USDe", "version": "1" }
+      "domain": { "name": "USDS Stablecoin", "version": "1" }
     }
   },
   "metadata": { "owner": "USDS" }

--- a/registry/permit/eip712-permit-fantom-mimatic.json
+++ b/registry/permit/eip712-permit-fantom-mimatic.json
@@ -4,7 +4,7 @@
   "context": {
     "eip712": {
       "deployments": [{ "chainId": 250, "address": "0xfb98b335551a418cd0737375a2ea0ded62ea213b" }],
-      "domain": { "name": "Beefy", "version": "1" }
+      "domain": { "name": "miMATIC", "version": "1" }
     }
   },
   "metadata": { "owner": "miMATIC" }

--- a/registry/permit/eip712-permit-fantom-wootrade.json
+++ b/registry/permit/eip712-permit-fantom-wootrade.json
@@ -4,7 +4,7 @@
   "context": {
     "eip712": {
       "deployments": [{ "chainId": 250, "address": "0x6626c47c00f1d87902fc13eecfac3ed06d5e8d8a" }],
-      "domain": { "name": "Geist Finance", "version": "1" }
+      "domain": { "name": "Wootrade Network", "version": "1" }
     }
   },
   "metadata": { "owner": "Wootrade Network" }

--- a/registry/permit/eip712-permit-linea-usdc.json
+++ b/registry/permit/eip712-permit-linea-usdc.json
@@ -4,7 +4,7 @@
   "context": {
     "eip712": {
       "deployments": [{ "chainId": 59144, "address": "0x176211869cA2b568f2A7D4EE941E073a821EE1ff" }],
-      "domain": { "name": "USD Coin", "version": "1" }
+      "domain": { "name": "USDC", "version": "2" }
     }
   },
   "metadata": { "owner": "USD Coin" }

--- a/registry/permit/eip712-permit-linea-usdt.json
+++ b/registry/permit/eip712-permit-linea-usdt.json
@@ -4,7 +4,7 @@
   "context": {
     "eip712": {
       "deployments": [{ "chainId": 59144, "address": "0xA219439258ca9da29E9Cc4cE5596924745e12B93" }],
-      "domain": { "name": "Tether USD", "version": "2" }
+      "domain": { "name": "Tether USD", "version": "1" }
     }
   },
   "metadata": { "owner": "Tether USD" }

--- a/registry/permit/eip712-permit-optimism-dai.json
+++ b/registry/permit/eip712-permit-optimism-dai.json
@@ -4,7 +4,7 @@
   "context": {
     "eip712": {
       "deployments": [{ "chainId": 10, "address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1" }],
-      "domain": { "name": "Dai Stablecoin", "version": "1" }
+      "domain": { "name": "Dai Stablecoin", "version": "2" }
     }
   },
   "metadata": { "owner": "Dai Stablecoin" }

--- a/registry/permit/eip712-permit-optimism-wsteth.json
+++ b/registry/permit/eip712-permit-optimism-wsteth.json
@@ -4,7 +4,7 @@
   "context": {
     "eip712": {
       "deployments": [{ "chainId": 10, "address": "0x9cfB13E6c11054ac9fcB92BA89644F30775436e4" }],
-      "domain": { "name": "Wrapped stETH", "version": "1" }
+      "domain": { "name": "Axelar Wrapped wstETH", "version": "1" }
     }
   },
   "metadata": { "owner": "Wrapped liquid staked Ether 2.0" }

--- a/registry/permit/eip712-permit-polygon-quick.json
+++ b/registry/permit/eip712-permit-polygon-quick.json
@@ -4,7 +4,7 @@
   "context": {
     "eip712": {
       "deployments": [{ "chainId": 137, "address": "0xB5C064F955D8e7F38fE0460C556a72987494eE17" }],
-      "domain": { "name": "Quickswap", "version": "1" }
+      "domain": { "name": "QuickSwap" }
     }
   },
   "metadata": { "owner": "QuickSwap" }

--- a/registry/permit/tests/eip712-permit-arbitrum-dai.tests.json
+++ b/registry/permit/tests/eip712-permit-arbitrum-dai.tests.json
@@ -22,7 +22,7 @@
         "primaryType": "Permit",
         "domain": {
           "name": "Dai Stablecoin",
-          "version": "1",
+          "version": "2",
           "chainId": 42161,
           "verifyingContract": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1"
         },

--- a/registry/permit/tests/eip712-permit-arbitrum-usds.tests.json
+++ b/registry/permit/tests/eip712-permit-arbitrum-usds.tests.json
@@ -21,7 +21,7 @@
         },
         "primaryType": "Permit",
         "domain": {
-          "name": "Gains Network",
+          "name": "USDS Stablecoin",
           "version": "1",
           "chainId": 42161,
           "verifyingContract": "0x6491c05A82219b8D1479057361ff1654749b876b"

--- a/registry/permit/tests/eip712-permit-arbitrum-usdt.tests.json
+++ b/registry/permit/tests/eip712-permit-arbitrum-usdt.tests.json
@@ -21,7 +21,7 @@
         },
         "primaryType": "Permit",
         "domain": {
-          "name": "Tether USD",
+          "name": "USD₮0",
           "version": "1",
           "chainId": 42161,
           "verifyingContract": "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"

--- a/registry/permit/tests/eip712-permit-arbitrum-wsteth.tests.json
+++ b/registry/permit/tests/eip712-permit-arbitrum-wsteth.tests.json
@@ -21,7 +21,7 @@
         },
         "primaryType": "Permit",
         "domain": {
-          "name": "Wrapped stETH",
+          "name": "Axelar Wrapped wstETH",
           "version": "1",
           "chainId": 42161,
           "verifyingContract": "0x9cfB13E6c11054ac9fcB92BA89644F30775436e4"

--- a/registry/permit/tests/eip712-permit-avalanche_c_chain-usdt.tests.json
+++ b/registry/permit/tests/eip712-permit-avalanche_c_chain-usdt.tests.json
@@ -21,7 +21,7 @@
         },
         "primaryType": "Permit",
         "domain": {
-          "name": "Tether USD",
+          "name": "TetherToken",
           "version": "1",
           "chainId": 43114,
           "verifyingContract": "0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7"

--- a/registry/permit/tests/eip712-permit-ethereum-aave.tests.json
+++ b/registry/permit/tests/eip712-permit-ethereum-aave.tests.json
@@ -20,7 +20,7 @@
           ]
         },
         "primaryType": "Permit",
-        "domain": { "name": "Aave Token", "version": "1", "chainId": 1, "verifyingContract": "0x7Fc66500c84A76Ad7e9C93437bFc5Ac33E2DdAe9" },
+        "domain": { "name": "Aave token V3", "version": "2", "chainId": 1, "verifyingContract": "0x7Fc66500c84A76Ad7e9C93437bFc5Ac33E2DdAe9" },
         "message": {
           "owner": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
           "spender": "0xE592427A0AEce92De3Edee1F18E0157C05861564",

--- a/registry/permit/tests/eip712-permit-ethereum-usds.tests.json
+++ b/registry/permit/tests/eip712-permit-ethereum-usds.tests.json
@@ -21,7 +21,7 @@
         },
         "primaryType": "Permit",
         "domain": {
-          "name": "Clear Signing Token",
+          "name": "USDS Stablecoin",
           "version": "1",
           "chainId": 1,
           "verifyingContract": "0xdC035D45d973E3EC169d2276DDab16f1e407384F"

--- a/registry/permit/tests/eip712-permit-fantom-mimatic.tests.json
+++ b/registry/permit/tests/eip712-permit-fantom-mimatic.tests.json
@@ -20,7 +20,7 @@
           ]
         },
         "primaryType": "Permit",
-        "domain": { "name": "Beefy", "version": "1", "chainId": 250, "verifyingContract": "0xfb98b335551a418cd0737375a2ea0ded62ea213b" },
+        "domain": { "name": "miMATIC", "version": "1", "chainId": 250, "verifyingContract": "0xfb98b335551a418cd0737375a2ea0ded62ea213b" },
         "message": {
           "owner": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
           "spender": "0x1111111254EEB25477B68fb85Ed929f73A960582",

--- a/registry/permit/tests/eip712-permit-fantom-wootrade.tests.json
+++ b/registry/permit/tests/eip712-permit-fantom-wootrade.tests.json
@@ -21,7 +21,7 @@
         },
         "primaryType": "Permit",
         "domain": {
-          "name": "Geist Finance",
+          "name": "Wootrade Network",
           "version": "1",
           "chainId": 250,
           "verifyingContract": "0x6626c47c00f1d87902fc13eecfac3ed06d5e8d8a"

--- a/registry/permit/tests/eip712-permit-linea-usdc.tests.json
+++ b/registry/permit/tests/eip712-permit-linea-usdc.tests.json
@@ -20,7 +20,7 @@
           ]
         },
         "primaryType": "Permit",
-        "domain": { "name": "USD Coin", "version": "1", "chainId": 59144, "verifyingContract": "0x176211869cA2b568f2A7D4EE941E073a821EE1ff" },
+        "domain": { "name": "USDC", "version": "2", "chainId": 59144, "verifyingContract": "0x176211869cA2b568f2A7D4EE941E073a821EE1ff" },
         "message": {
           "owner": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826",
           "spender": "0x8617E340B3D01FA5F11F306F4090FD50E238070D",

--- a/registry/permit/tests/eip712-permit-linea-usdt.tests.json
+++ b/registry/permit/tests/eip712-permit-linea-usdt.tests.json
@@ -22,7 +22,7 @@
         "primaryType": "Permit",
         "domain": {
           "name": "Tether USD",
-          "version": "2",
+          "version": "1",
           "chainId": 59144,
           "verifyingContract": "0xA219439258ca9da29E9Cc4cE5596924745e12B93"
         },

--- a/registry/permit/tests/eip712-permit-optimism-dai.tests.json
+++ b/registry/permit/tests/eip712-permit-optimism-dai.tests.json
@@ -22,7 +22,7 @@
         "primaryType": "Permit",
         "domain": {
           "name": "Dai Stablecoin",
-          "version": "1",
+          "version": "2",
           "chainId": 10,
           "verifyingContract": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1"
         },

--- a/registry/permit/tests/eip712-permit-optimism-wsteth.tests.json
+++ b/registry/permit/tests/eip712-permit-optimism-wsteth.tests.json
@@ -21,7 +21,7 @@
         },
         "primaryType": "Permit",
         "domain": {
-          "name": "Wrapped stETH",
+          "name": "Axelar Wrapped wstETH",
           "version": "1",
           "chainId": 10,
           "verifyingContract": "0x9cfB13E6c11054ac9fcB92BA89644F30775436e4"

--- a/registry/permit/tests/eip712-permit-polygon-quick.tests.json
+++ b/registry/permit/tests/eip712-permit-polygon-quick.tests.json
@@ -21,7 +21,7 @@
         },
         "primaryType": "Permit",
         "domain": {
-          "name": "Clear Signing ERC20",
+          "name": "QuickSwap",
           "version": "1",
           "chainId": 137,
           "verifyingContract": "0xB5C064F955D8e7F38fE0460C556a72987494eE17"

--- a/registry/permit/testsv2/eip712-permit-arbitrum-bridged-usdc.tests.json
+++ b/registry/permit/testsv2/eip712-permit-arbitrum-bridged-usdc.tests.json
@@ -21,7 +21,7 @@
           ]
         },
         "primaryType": "Permit",
-        "domain": { "name": "USD Coin", "version": "2", "chainId": 42161, "verifyingContract": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8" },
+        "domain": { "name": "USD Coin (Arb1)", "version": "1", "chainId": 42161, "verifyingContract": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8" },
         "message": {
           "owner": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
           "spender": "0xE592427A0AEce92De3Edee1F18E0157C05861564",

--- a/registry/permit/testsv2/eip712-permit-arbitrum-dai.tests.json
+++ b/registry/permit/testsv2/eip712-permit-arbitrum-dai.tests.json
@@ -23,7 +23,7 @@
         "primaryType": "Permit",
         "domain": {
           "name": "Dai Stablecoin",
-          "version": "1",
+          "version": "2",
           "chainId": 42161,
           "verifyingContract": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1"
         },

--- a/registry/permit/testsv2/eip712-permit-arbitrum-usds.tests.json
+++ b/registry/permit/testsv2/eip712-permit-arbitrum-usds.tests.json
@@ -22,7 +22,7 @@
         },
         "primaryType": "Permit",
         "domain": {
-          "name": "Gains Network",
+          "name": "USDS Stablecoin",
           "version": "1",
           "chainId": 42161,
           "verifyingContract": "0x6491c05A82219b8D1479057361ff1654749b876b"

--- a/registry/permit/testsv2/eip712-permit-arbitrum-usdt.tests.json
+++ b/registry/permit/testsv2/eip712-permit-arbitrum-usdt.tests.json
@@ -22,7 +22,7 @@
         },
         "primaryType": "Permit",
         "domain": {
-          "name": "Tether USD",
+          "name": "USD₮0",
           "version": "1",
           "chainId": 42161,
           "verifyingContract": "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"

--- a/registry/permit/testsv2/eip712-permit-arbitrum-wsteth.tests.json
+++ b/registry/permit/testsv2/eip712-permit-arbitrum-wsteth.tests.json
@@ -22,7 +22,7 @@
         },
         "primaryType": "Permit",
         "domain": {
-          "name": "Wrapped stETH",
+          "name": "Axelar Wrapped wstETH",
           "version": "1",
           "chainId": 42161,
           "verifyingContract": "0x9cfB13E6c11054ac9fcB92BA89644F30775436e4"

--- a/registry/permit/testsv2/eip712-permit-avalanche_c_chain-usdt.tests.json
+++ b/registry/permit/testsv2/eip712-permit-avalanche_c_chain-usdt.tests.json
@@ -22,7 +22,7 @@
         },
         "primaryType": "Permit",
         "domain": {
-          "name": "Tether USD",
+          "name": "TetherToken",
           "version": "1",
           "chainId": 43114,
           "verifyingContract": "0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7"

--- a/registry/permit/testsv2/eip712-permit-base-aero.tests.json
+++ b/registry/permit/testsv2/eip712-permit-base-aero.tests.json
@@ -21,7 +21,7 @@
           ]
         },
         "primaryType": "Permit",
-        "domain": { "name": "Aero", "version": "1", "chainId": 8453, "verifyingContract": "0x940181a94A35A4569E4529A3CDfB74e38FD98631" },
+        "domain": { "name": "Aerodrome", "version": "1", "chainId": 8453, "verifyingContract": "0x940181a94A35A4569E4529A3CDfB74e38FD98631" },
         "message": {
           "owner": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
           "spender": "0x000000000022D473030F116dDEE9F6B43aC78BA3",

--- a/registry/permit/testsv2/eip712-permit-ethereum-aave.tests.json
+++ b/registry/permit/testsv2/eip712-permit-ethereum-aave.tests.json
@@ -21,7 +21,7 @@
           ]
         },
         "primaryType": "Permit",
-        "domain": { "name": "Aave Token", "version": "1", "chainId": 1, "verifyingContract": "0x7Fc66500c84A76Ad7e9C93437bFc5Ac33E2DdAe9" },
+        "domain": { "name": "Aave token V3", "version": "2", "chainId": 1, "verifyingContract": "0x7Fc66500c84A76Ad7e9C93437bFc5Ac33E2DdAe9" },
         "message": {
           "owner": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
           "spender": "0xE592427A0AEce92De3Edee1F18E0157C05861564",

--- a/registry/permit/testsv2/eip712-permit-ethereum-lido-wsteth.tests.json
+++ b/registry/permit/testsv2/eip712-permit-ethereum-lido-wsteth.tests.json
@@ -21,7 +21,7 @@
           ]
         },
         "primaryType": "Permit",
-        "domain": { "name": "Wrapped stETH", "version": "1", "chainId": 1, "verifyingContract": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0" },
+        "domain": { "name": "Wrapped liquid staked Ether 2.0", "version": "1", "chainId": 1, "verifyingContract": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0" },
         "message": {
           "owner": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
           "spender": "0x111111125421cA6dc452d289314280a0f8842A65",

--- a/registry/permit/testsv2/eip712-permit-ethereum-usds.tests.json
+++ b/registry/permit/testsv2/eip712-permit-ethereum-usds.tests.json
@@ -21,7 +21,7 @@
           ]
         },
         "primaryType": "Permit",
-        "domain": { "name": "USDe", "version": "1", "chainId": 1, "verifyingContract": "0xdC035D45d973E3EC169d2276DDab16f1e407384F" },
+        "domain": { "name": "USDS Stablecoin", "version": "1", "chainId": 1, "verifyingContract": "0xdC035D45d973E3EC169d2276DDab16f1e407384F" },
         "message": {
           "owner": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
           "spender": "0x000000000022D473030F116dDEE9F6B43aC78BA3",

--- a/registry/permit/testsv2/eip712-permit-fantom-mimatic.tests.json
+++ b/registry/permit/testsv2/eip712-permit-fantom-mimatic.tests.json
@@ -21,7 +21,7 @@
           ]
         },
         "primaryType": "Permit",
-        "domain": { "name": "Beefy", "version": "1", "chainId": 250, "verifyingContract": "0xfb98b335551a418cd0737375a2ea0ded62ea213b" },
+        "domain": { "name": "miMATIC", "version": "1", "chainId": 250, "verifyingContract": "0xfb98b335551a418cd0737375a2ea0ded62ea213b" },
         "message": {
           "owner": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
           "spender": "0x1111111254EEB25477B68fb85Ed929f73A960582",

--- a/registry/permit/testsv2/eip712-permit-fantom-wootrade.tests.json
+++ b/registry/permit/testsv2/eip712-permit-fantom-wootrade.tests.json
@@ -22,7 +22,7 @@
         },
         "primaryType": "Permit",
         "domain": {
-          "name": "Geist Finance",
+          "name": "Wootrade Network",
           "version": "1",
           "chainId": 250,
           "verifyingContract": "0x6626c47c00f1d87902fc13eecfac3ed06d5e8d8a"

--- a/registry/permit/testsv2/eip712-permit-linea-usdc.tests.json
+++ b/registry/permit/testsv2/eip712-permit-linea-usdc.tests.json
@@ -21,7 +21,7 @@
           ]
         },
         "primaryType": "Permit",
-        "domain": { "name": "USD Coin", "version": "1", "chainId": 59144, "verifyingContract": "0x176211869cA2b568f2A7D4EE941E073a821EE1ff" },
+        "domain": { "name": "USDC", "version": "2", "chainId": 59144, "verifyingContract": "0x176211869cA2b568f2A7D4EE941E073a821EE1ff" },
         "message": {
           "owner": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826",
           "spender": "0x8617E340B3D01FA5F11F306F4090FD50E238070D",

--- a/registry/permit/testsv2/eip712-permit-linea-usdt.tests.json
+++ b/registry/permit/testsv2/eip712-permit-linea-usdt.tests.json
@@ -23,7 +23,7 @@
         "primaryType": "Permit",
         "domain": {
           "name": "Tether USD",
-          "version": "2",
+          "version": "1",
           "chainId": 59144,
           "verifyingContract": "0xA219439258ca9da29E9Cc4cE5596924745e12B93"
         },

--- a/registry/permit/testsv2/eip712-permit-optimism-dai.tests.json
+++ b/registry/permit/testsv2/eip712-permit-optimism-dai.tests.json
@@ -23,7 +23,7 @@
         "primaryType": "Permit",
         "domain": {
           "name": "Dai Stablecoin",
-          "version": "1",
+          "version": "2",
           "chainId": 10,
           "verifyingContract": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1"
         },

--- a/registry/permit/testsv2/eip712-permit-optimism-wsteth.tests.json
+++ b/registry/permit/testsv2/eip712-permit-optimism-wsteth.tests.json
@@ -22,7 +22,7 @@
         },
         "primaryType": "Permit",
         "domain": {
-          "name": "Wrapped stETH",
+          "name": "Axelar Wrapped wstETH",
           "version": "1",
           "chainId": 10,
           "verifyingContract": "0x9cfB13E6c11054ac9fcB92BA89644F30775436e4"

--- a/registry/permit/testsv2/eip712-permit-polygon-quick.tests.json
+++ b/registry/permit/testsv2/eip712-permit-polygon-quick.tests.json
@@ -21,7 +21,7 @@
           ]
         },
         "primaryType": "Permit",
-        "domain": { "name": "Quickswap", "version": "1", "chainId": 137, "verifyingContract": "0xB5C064F955D8e7F38fE0460C556a72987494eE17" },
+        "domain": { "name": "QuickSwap", "version": "1", "chainId": 137, "verifyingContract": "0xB5C064F955D8e7F38fE0460C556a72987494eE17" },
         "message": {
           "owner": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
           "spender": "0x1111111254EEB25477B68fb85Ed929f73A960582",


### PR DESCRIPTION
Corrects the declared EIP-712 `domain` on 18 permit descriptors so they match the token's real on-chain domain. Previously the domain constraint failed, so the descriptor never engaged for the real permit and the user fell back to a raw screen. Each descriptor's `tests/` and `testsv2/` vectors are updated to match.

| Descriptor | Was | Now |
|---|---|---|
| arbitrum-bridged-usdc | `USD Coin` v2 | `USD Coin (Arb1)` v1 |
| arbitrum-dai | `Dai Stablecoin` v1 | `Dai Stablecoin` v2 |
| arbitrum-usds | `Gains Network` v1 | `USDS Stablecoin` v1 |
| arbitrum-usdt | `Tether USD` v1 | `USD₮0` v1 |
| arbitrum-wsteth | `Wrapped stETH` v1 | `Axelar Wrapped wstETH` v1 |
| avalanche-pangolin | `Pangolin` v1 | `Pangolin` (no version) |
| avalanche-usdt | `Tether USD` v1 | `TetherToken` v1 |
| base-aero | `Aero` v1 | `Aerodrome` v1 |
| ethereum-aave | `Aave Token` v1 | `Aave token V3` v2 |
| ethereum-lido-wsteth | `Wrapped stETH` v1 | `Wrapped liquid staked Ether 2.0` v1 |
| ethereum-usds | `USDe` v1 | `USDS Stablecoin` v1 |
| fantom-mimatic | `Beefy` v1 | `miMATIC` v1 |
| fantom-wootrade | `Geist Finance` v1 | `Wootrade Network` v1 |
| linea-usdc | `USD Coin` v1 | `USDC` v2 |
| linea-usdt | `Tether USD` v2 | `Tether USD` v1 |
| optimism-dai | `Dai Stablecoin` v1 | `Dai Stablecoin` v2 |
| optimism-wsteth | `Wrapped stETH` v1 | `Axelar Wrapped wstETH` v1 |
| polygon-quick | `Quickswap` v1 | `QuickSwap` (no version) |

Two related tokens (polygon-bridged-usdc, polygon-usdt) use a salt-based domain that ERC-7730 cannot currently express; they are tracked separately under `needs-further-review`.

Closes #2728, #2729, #2734, #2735, #2738, #2741, #2744, #2748, #2763, #2768, #2771, #2772, #2773, #2777, #2778, #2783, #2791, #2797