### PR TITLE
ci: run tests and lint for descriptors affected by shared file changes

### DIFF
--- a/.github/scripts/list-affected-descriptors.js
+++ b/.github/scripts/list-affected-descriptors.js
@@ -33,11 +33,16 @@ const path = require('path');
 
 const repoRoot = process.cwd();
 
+const EXCLUDED_DIRS = new Set(['tests', 'testsv2', 'sigs']);
+
 function isDescriptorBasename(name) {
   return /^(calldata|eip712)-.*\.json$/.test(name) && !name.endsWith('.tests.json');
 }
 
-/** Recursively collect descriptor files under a directory, skipping test dirs. */
+/**
+ * Recursively collect descriptor files under a directory, skipping the test
+ * fixtures and the auditor attestations.
+ */
 function collectDescriptors(dir, out) {
   let entries;
   try {
@@ -48,7 +53,7 @@ function collectDescriptors(dir, out) {
   for (const entry of entries) {
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      if (entry.name === 'tests' || entry.name === 'testsv2') continue;
+      if (EXCLUDED_DIRS.has(entry.name)) continue;
       collectDescriptors(full, out);
     } else if (entry.isFile() && isDescriptorBasename(entry.name)) {
       out.push(full);

--- a/.github/scripts/list-affected-descriptors.js
+++ b/.github/scripts/list-affected-descriptors.js
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+/**
+ * Lists ERC-7730 descriptors affected by a set of changed files, following
+ * "includes" references transitively.
+ *
+ * A descriptor (registry/<entity>/{calldata,eip712}-*.json) is affected when:
+ * - the descriptor file itself changed, or
+ * - its testsv2 file (registry/<entity>/testsv2/<name>.tests.json) changed, or
+ * - any file in its transitive "includes" chain changed — e.g. a shared
+ *   ercs/*.json file, or an entity-local common file (which may itself
+ *   include another shared file).
+ *
+ * Changed files are passed whitespace-separated via the CHANGED_FILES
+ * environment variable and/or as CLI arguments, as paths relative to the
+ * repository root (the current working directory). Deleted files may be
+ * passed too: a descriptor whose includes chain references a now-missing
+ * changed file is still reported as affected.
+ *
+ * Prints a JSON object to stdout:
+ *   {
+ *     "affected_descriptors": [...],  // repo-relative descriptor paths, sorted
+ *     "matrix": [{"descriptor", "test_file", "entity", "descriptor_name"}, ...],
+ *     "has_affected": true|false,     // at least one affected descriptor
+ *     "has_tests": true|false         // at least one matrix entry
+ *   }
+ *
+ * "matrix" only contains affected descriptors that have an existing testsv2
+ * file, in the shape consumed by the clear-signing-tests workflow.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = process.cwd();
+
+function isDescriptorBasename(name) {
+  return /^(calldata|eip712)-.*\.json$/.test(name) && !name.endsWith('.tests.json');
+}
+
+/** Recursively collect descriptor files under a directory, skipping test dirs. */
+function collectDescriptors(dir, out) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'tests' || entry.name === 'testsv2') continue;
+      collectDescriptors(full, out);
+    } else if (entry.isFile() && isDescriptorBasename(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** Repo-relative path with forward slashes. */
+function rel(absPath) {
+  return path.relative(repoRoot, absPath).split(path.sep).join('/');
+}
+
+/**
+ * Transitive closure of "includes" references of a file, as repo-relative
+ * paths. Missing include targets are still part of the closure (a dangling
+ * include means the includer is affected by the target's change/deletion);
+ * unreadable files and external URLs terminate the chain with a warning.
+ */
+function includeClosure(absFile) {
+  const closure = new Set();
+  const visited = new Set([absFile]);
+  const stack = [absFile];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (current !== absFile) closure.add(rel(current));
+    let doc;
+    try {
+      doc = JSON.parse(fs.readFileSync(current, 'utf8'));
+    } catch (e) {
+      process.stderr.write(`warning: cannot read ${rel(current)}: ${e.message}\n`);
+      continue;
+    }
+    const ref = doc.includes;
+    if (typeof ref !== 'string' || ref === '') continue;
+    if (/^https?:\/\//.test(ref)) {
+      process.stderr.write(`warning: external include not followed in ${rel(current)}: ${ref}\n`);
+      continue;
+    }
+    const target = path.resolve(path.dirname(current), ref);
+    if (!visited.has(target)) {
+      visited.add(target);
+      stack.push(target);
+    }
+  }
+  return closure;
+}
+
+function main() {
+  const changed = new Set(
+    [...process.argv.slice(2), ...(process.env.CHANGED_FILES || '').split(/\s+/)]
+      .map((f) => f.trim().replace(/^\.\//, ''))
+      .filter((f) => f !== '')
+  );
+
+  const descriptors = collectDescriptors(path.join(repoRoot, 'registry'), [])
+    .map(rel)
+    .sort();
+  const descriptorSet = new Set(descriptors);
+
+  const affected = new Set();
+  const changedShared = [];
+
+  for (const file of changed) {
+    if (!file.endsWith('.json')) continue;
+    if (/(^|\/)tests\//.test(file)) continue; // legacy tests/ fixtures — not covered here
+    const testMatch = file.match(/^(.*)\/testsv2\/([^/]+)\.tests\.json$/);
+    if (testMatch) {
+      const descriptor = `${testMatch[1]}/${testMatch[2]}.json`;
+      if (descriptorSet.has(descriptor)) affected.add(descriptor);
+      continue;
+    }
+    if (file.endsWith('.tests.json')) continue;
+    if (descriptorSet.has(file)) {
+      affected.add(file);
+    } else {
+      // Not a descriptor: potentially a shared file included by descriptors.
+      changedShared.push(file);
+    }
+  }
+
+  if (changedShared.length > 0) {
+    for (const descriptor of descriptors) {
+      if (affected.has(descriptor)) continue;
+      const closure = includeClosure(path.join(repoRoot, descriptor));
+      if (changedShared.some((f) => closure.has(f))) affected.add(descriptor);
+    }
+  }
+
+  const affectedSorted = [...affected].sort();
+  const matrix = [];
+  for (const descriptor of affectedSorted) {
+    const descriptorName = path.posix.basename(descriptor, '.json');
+    const testFile = `${path.posix.dirname(descriptor)}/testsv2/${descriptorName}.tests.json`;
+    if (!fs.existsSync(path.join(repoRoot, testFile))) continue;
+    matrix.push({
+      descriptor,
+      test_file: testFile,
+      entity: descriptor.split('/')[1],
+      descriptor_name: descriptorName,
+    });
+  }
+
+  process.stdout.write(
+    JSON.stringify({
+      affected_descriptors: affectedSorted,
+      matrix,
+      has_affected: affectedSorted.length > 0,
+      has_tests: matrix.length > 0,
+    })
+  );
+}
+
+if (require.main === module) {
+  main();
+}

--- a/.github/workflows/clear-signing-tests.yml
+++ b/.github/workflows/clear-signing-tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "registry/**/*.json"
+      - "ercs/**/*.json"
 
   pull_request_target:
     types: [labeled]
@@ -265,71 +266,50 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       has_tests: ${{ steps.detect.outputs.has_tests }}
+      has_affected: ${{ steps.detect.outputs.has_affected }}
       test_matrix: ${{ steps.detect.outputs.test_matrix }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Get changed descriptors and testsv2 files
+      - name: Checkout base scripts
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base-scripts
+          sparse-checkout: .github/scripts
+
+      - name: Get changed descriptor, shared and testsv2 files
         id: changed-files
         uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
         with:
           files: |
-            registry/**/calldata-*.json
-            registry/**/eip712-*.json
+            registry/**/*.json
+            ercs/**/*.json
           files_ignore: |
             registry/**/tests/**
             registry/**/sigs/**
 
-      - name: Detect testsv2 files for changed descriptors
+      - name: Detect testsv2 files for affected descriptors
         id: detect
         env:
           CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+          DELETED_FILES: ${{ steps.changed-files.outputs.deleted_files }}
         run: |
-          TEST_ENTRIES=()
-          HAS_TESTS="false"
-          declare -A SEEN
-
-          for file in $CHANGED_FILES; do
-            # Map either a changed descriptor or a changed shared-test file to (descriptor, test_file)
-            if [[ "$file" == */testsv2/*.tests.json ]]; then
-              test_file="$file"
-              descriptor_name=$(basename "$file" .tests.json)
-              entity_dir=$(dirname "$(dirname "$file")")
-              descriptor="${entity_dir}/${descriptor_name}.json"
-            else
-              descriptor="$file"
-              descriptor_name=$(basename "$file" .json)
-              entity_dir=$(dirname "$file")
-              test_file="${entity_dir}/testsv2/${descriptor_name}.tests.json"
-            fi
-
-            # Filter on descriptor prefix
-            case "$descriptor_name" in
-              calldata-*|eip712-*) ;;
-              *) continue ;;
-            esac
-
-            # Dedupe (PR may change both descriptor and test file)
-            [[ -n "${SEEN[$descriptor]:-}" ]] && continue
-            SEEN[$descriptor]=1
-
-            # Skip if either file is missing on disk
-            [[ -f "$descriptor" && -f "$test_file" ]] || continue
-
-            HAS_TESTS="true"
-            entity=$(echo "$entity_dir" | sed 's|registry/||' | cut -d'/' -f1)
-            TEST_ENTRIES+=("{\"descriptor\":\"$descriptor\",\"test_file\":\"$test_file\",\"entity\":\"$entity\",\"descriptor_name\":\"$descriptor_name\"}")
-          done
-
-          if [ "$HAS_TESTS" == "true" ]; then
-            MATRIX_JSON=$(printf '%s\n' "${TEST_ENTRIES[@]}" | jq -sc '.')
-            echo "test_matrix=$MATRIX_JSON" >> $GITHUB_OUTPUT
-          else
-            echo "test_matrix=[]" >> $GITHUB_OUTPUT
-          fi
-          echo "has_tests=$HAS_TESTS" >> $GITHUB_OUTPUT
+          # Expand changed files to affected descriptors, following "includes"
+          # references transitively: a change to a shared file (ercs/*.json or
+          # an entity-local common file) must run the tests of every descriptor
+          # that includes it. Deleted files are passed too, so removing a
+          # shared file still runs (and fails) its includers' tests.
+          # The script is taken from the base ref: under pull_request_target,
+          # only base-controlled code may execute.
+          RESULT=$(CHANGED_FILES="$CHANGED_FILES $DELETED_FILES" \
+            node base-scripts/.github/scripts/list-affected-descriptors.js)
+          echo "$RESULT" | jq .
+          echo "test_matrix=$(echo "$RESULT" | jq -c '.matrix')" >> $GITHUB_OUTPUT
+          echo "has_tests=$(echo "$RESULT" | jq -r '.has_tests')" >> $GITHUB_OUTPUT
+          echo "has_affected=$(echo "$RESULT" | jq -r '.has_affected')" >> $GITHUB_OUTPUT
 
   sourcify-tests:
     name: Sourcify tests for ${{ matrix.test.entity }}/${{ matrix.test.descriptor_name }}
@@ -588,29 +568,15 @@ jobs:
     if: needs.check-permissions.outputs.can_run_tests == 'true' && needs.detect-testsv2.outputs.has_tests == 'false'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Check for changed descriptors
-        id: check
-        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
-        with:
-          files: |
-            registry/**/calldata-*.json
-            registry/**/eip712-*.json
-          files_ignore: |
-            registry/**/tests/**
-            registry/**/testsv2/**
-            registry/**/sigs/**
-
       - name: Post comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          ANY_CHANGED: ${{ steps.check.outputs.any_changed }}
+          # Affected descriptors = directly changed ones, plus descriptors
+          # whose transitive "includes" chain contains a changed shared file.
+          ANY_AFFECTED: ${{ needs.detect-testsv2.outputs.has_affected }}
         with:
           script: |
-            const anyChanged = process.env.ANY_CHANGED === 'true';
+            const anyAffected = process.env.ANY_AFFECTED === 'true';
 
             // Same comment as post-implementation-results — exactly one
             // "## Clear Signing Tests" comment per PR, in either warning or
@@ -620,18 +586,18 @@ jobs:
             });
             const existing = comments.find(c => c.user.type === 'Bot' && c.body.startsWith('## Clear Signing Tests'));
 
-            if (anyChanged) {
-              const body = `## Clear Signing Tests\n\nNo testsv2 files found for the changed descriptors.\n\nCreate a test file at \`registry/<entity>/testsv2/<descriptor-name>.tests.json\`\n\nSee [testing documentation](../blob/master/README.md#reference-test-cases) for details.`;
+            if (anyAffected) {
+              const body = `## Clear Signing Tests\n\nNo testsv2 files found for the affected descriptors (directly changed, or including a changed shared file).\n\nCreate a test file at \`registry/<entity>/testsv2/<descriptor-name>.tests.json\`\n\nSee [testing documentation](../blob/master/README.md#reference-test-cases) for details.`;
               const params = { owner: context.repo.owner, repo: context.repo.repo, body };
               if (existing) {
                 await github.rest.issues.updateComment({ ...params, comment_id: existing.id });
               } else {
                 await github.rest.issues.createComment({ ...params, issue_number: context.issue.number });
               }
-              // Block the PR — descriptor changed without a matching testsv2 file.
-              core.setFailed('Missing testsv2 file(s) for changed descriptors.');
+              // Block the PR — descriptor affected without a matching testsv2 file.
+              core.setFailed('Missing testsv2 file(s) for affected descriptors.');
             } else if (existing) {
-              // No descriptors changed and no testsv2 either — nothing to say. Clear any stale comment.
+              // No descriptors affected and no testsv2 either — nothing to say. Clear any stale comment.
               await github.rest.issues.deleteComment({
                 owner: context.repo.owner, repo: context.repo.repo, comment_id: existing.id
               });

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,23 +24,42 @@ jobs:
         timeout-minutes: 10
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Get all changed descriptor files
+      - name: Get all changed descriptor and shared files
         timeout-minutes: 5
         id: changed-descriptor-files
         uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
         with:
           files: |
-            registry/**/eip712-*.json
-            registry/**/calldata-*.json
+            registry/**/*.json
+            ercs/**/*.json
           files_ignore: |
             registry/**/tests/**
             registry/**/testsv2/**
             registry/**/sigs/**
             registry/**/*.tests.json
 
+      - name: Resolve affected descriptors
+        timeout-minutes: 5
+        id: affected-descriptors
+        if: steps.changed-descriptor-files.outputs.any_changed == 'true'
+        env:
+          CHANGED_FILES: ${{ steps.changed-descriptor-files.outputs.all_changed_files }}
+          DELETED_FILES: ${{ steps.changed-descriptor-files.outputs.deleted_files }}
+        run: |
+          # A changed shared file (ercs/*.json or an entity-local common file)
+          # affects every descriptor whose "includes" chain contains it, so
+          # those descriptors must be linted too. Shared files are not linted
+          # standalone — they are partial descriptors, validated through their
+          # includers.
+          RESULT=$(CHANGED_FILES="$CHANGED_FILES $DELETED_FILES" \
+            node .github/scripts/list-affected-descriptors.js)
+          echo "$RESULT" | jq .
+          echo "descriptors=$(echo "$RESULT" | jq -r '.affected_descriptors | join(" ")')" >> $GITHUB_OUTPUT
+          echo "any_affected=$(echo "$RESULT" | jq -r '.has_affected')" >> $GITHUB_OUTPUT
+
       - name: Setup python
         timeout-minutes: 10
-        if: steps.changed-descriptor-files.outputs.any_changed == 'true'
+        if: steps.affected-descriptors.outputs.any_affected == 'true'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
@@ -48,15 +67,15 @@ jobs:
 
       - name: Install ERC-7730 library
         timeout-minutes: 10
-        if: steps.changed-descriptor-files.outputs.any_changed == 'true'
+        if: steps.affected-descriptors.outputs.any_affected == 'true'
         run: pip install erc7730
 
-      - name: Validate ERC-7730 descriptors changed in pull request
+      - name: Validate ERC-7730 descriptors affected by pull request
         timeout-minutes: 120
-        if: steps.changed-descriptor-files.outputs.any_changed == 'true'
+        if: steps.affected-descriptors.outputs.any_affected == 'true'
         env:
-          CHANGED_FILES: ${{ steps.changed-descriptor-files.outputs.all_changed_files }}
-        run: erc7730 lint $CHANGED_FILES --gha
+          AFFECTED_FILES: ${{ steps.affected-descriptors.outputs.descriptors }}
+        run: erc7730 lint $AFFECTED_FILES --gha
 
   validate_schemas:
     name: 🔎 validate JSON schemas


### PR DESCRIPTION
## Problem

A change to a shared descriptor file ran no clear-signing tests and no lint for the descriptors that include it:

- `clear-signing-tests.yml` was not triggered at all for `ercs/**` changes (the `pull_request` paths filter only covered `registry/**/*.json`), and even when triggered via the `run-tests` label, the `detect-testsv2` job only matched changed files named `registry/**/{calldata,eip712}-*.json`. A change to `ercs/eip712-erc2612-permit.json` (included by 74 descriptors) or to an entity-local common file like `registry/safe/common-Safe.json` therefore selected no tests. Example: on #2853 "Sourcify tests" / "Rust tests" were skipped although all 74 affected permit descriptors have testsv2 files.
- The `notify-missing-tests` guard used the same filename filter, so it passed silently instead of warning.
- `pull_request.yml`'s `validate_descriptors` job only linted directly changed descriptors, so shared-file changes were never linted at PR time (shared files cannot be linted standalone — they are partial descriptors).

Includes are transitive: kiln descriptors → `common-KilnVaults.json` → `ercs/calldata-erc4626-vaults.json`.

## Fix

New `.github/scripts/list-affected-descriptors.js` expands the changed-files list to the affected descriptors by following `includes` references transitively (cycle-safe; deleted shared files still mark their includers as affected; external URLs and malformed JSON degrade with a warning). It outputs the affected descriptor list, the testsv2 matrix, and `has_affected`/`has_tests` flags.

- `clear-signing-tests.yml`: now also triggers on `ercs/**/*.json`; `detect-testsv2` consumes the script's matrix; `notify-missing-tests` keys off the `has_affected` output instead of a second (blind) changed-files filter. The script is executed from the base ref, matching the existing rule that only base-controlled code runs under `pull_request_target`.
- `pull_request.yml`: `validate_descriptors` lints all affected descriptors instead of only the directly changed ones.

## Behavior after this change (validated locally against the real registry)

| change | before | after |
|---|---|---|
| `ercs/eip712-erc2612-permit.json` | no tests | 74 affected descriptors, 74 tested |
| `ercs/calldata-erc4626-vaults.json` | no tests | 133 affected (105 direct + 28 kiln via `common-KilnVaults.json`), 80 tested |
| `registry/safe/common-Safe.json` | no tests | 6 includers tested/linted |
| direct descriptor / testsv2 change | tested | unchanged |

Notes:

- An ercs/common change where zero affected descriptors have testsv2 files now fails CI with the missing-testsv2 comment (previously silent green).
- `analyze.yml` and the commented-out Ledger jobs are intentionally left unchanged.
- Known limitation: a pure rename of a shared file is not detected (tj-actions does not report the old path in `deleted_files`).
