### PR TITLE
ci: update clear-signing test runner pins

### DIFF
--- a/.github/actions/run-rust-tests/action.yml
+++ b/.github/actions/run-rust-tests/action.yml
@@ -21,7 +21,7 @@ runs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: llbartekll/clear-signing
-        ref: 0809971c81182ea93271759c62c04d1935415eff # main @ 2026-06-19
+        ref: 7aea31da1a5a0363fcbe1e0ea089c7294e29229f # main @ 2026-06-22
         path: cs-runner
         persist-credentials: false
 

--- a/.github/actions/run-sourcify-tests/action.yml
+++ b/.github/actions/run-sourcify-tests/action.yml
@@ -20,7 +20,7 @@ runs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: sourcifyeth/clear-signing-test-runner
-        ref: dae3cdabd0eab26173d7f7a31a2ca7e75bf07daf # main @ 2026-08-06
+        ref: dae3cdabd0eab26173d7f7a31a2ca7e75bf07daf # v0.2.2 main @ 2026-08-06 
         path: sourcify-test-runner
         persist-credentials: false
 

--- a/.github/actions/run-sourcify-tests/action.yml
+++ b/.github/actions/run-sourcify-tests/action.yml
@@ -20,7 +20,7 @@ runs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: sourcifyeth/clear-signing-test-runner
-        ref: 3006d68e79c34278008000dff95a439d2b7c7665 # main @ 2026-06-08
+        ref: dae3cdabd0eab26173d7f7a31a2ca7e75bf07daf # main @ 2026-08-06
         path: sourcify-test-runner
         persist-credentials: false
 

--- a/registry/flyingtulip/testsv2/calldata-PftNft.tests.json
+++ b/registry/flyingtulip/testsv2/calldata-PftNft.tests.json
@@ -25,7 +25,7 @@
         "owner": "Flying Tulip",
         "fields": [
           { "label": "Operator", "value": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" },
-          { "label": "Access rights", "value": "true" }
+          { "label": "Access rights", "value": "Grant all" }
         ],
         "interpolatedIntent": "Set operator 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
       }


### PR DESCRIPTION
Moves both clear-signing test runners to their current `main`.

| runner | old pin | new pin | picks up |
|---|---|---|---|
| [sourcifyeth/clear-signing-test-runner](https://github.com/sourcifyeth/clear-signing-test-runner) | `3006d68e` (2026-06-08) | `dae3cdab` (2026-08-06) | `@ethereum-sourcify/clear-signing` **0.2.0 → 0.2.2**, a docs fix, and `fix: render optional owner as ommited` |
| [llbartekll/clear-signing](https://github.com/llbartekll/clear-signing) | `0809971c` (2026-06-19) | `7aea31da` (2026-06-22) | `refactor: surface descriptor load failures and remove library expect` |

The library bump spans two releases: [v0.2.1](https://github.com/sourcifyeth/clear-signing/releases/tag/v0.2.1) (bool values in the enum format, descriptor generation from a trusted token list) and [v0.2.2](https://github.com/sourcifyeth/clear-signing/releases/tag/v0.2.2) (ERC-7730 encryption schemes, child array paths in interpolated intents, separator handling in rendered values).

## Effect on the registry

The Sourcify runner was run at both pins over all 270 `testsv2/` files (507 cases). **Exactly one result changes**, and it is a fix:

`registry/flyingtulip/testsv2/calldata-PftNft.tests.json` → "Approve pFT operator", field `Access rights`:

```diff
-  { "label": "Access rights", "value": "true" }
+  { "label": "Access rights", "value": "Grant all" }
```

`calldata-PftNft.json` declares that field as

```json
{ "path": "approved", "label": "Access rights", "format": "enum",
  "params": { "$ref": "$.metadata.enums.rights" } }
```

where `approved` is a `bool` and `metadata.enums.rights` maps `"True"` to `"Grant all"`. The old library did not apply the enum format to bool values and rendered the raw boolean instead; `feat(enum): support bool values in the enum format` in [v0.2.1](https://github.com/sourcifyeth/clear-signing/releases/tag/v0.2.1) fixes exactly that, so the fixture's expected value is corrected here to match what the descriptor asks for.

Nothing else moves: no cases are added or removed, and the `render optional owner as ommited` change produces no difference anywhere in the registry — `owner` still renders in all 507 cases. The one pre-existing failure (`registry/rarible/testsv2/eip712-rarible-exchange-v2-meta-tx.tests.json`, unsupported EIP-712 domain) is unchanged before and after.

## Note for reviewers: the clear-signing check on this PR will be red

The test jobs load the runner action from the **base** ref:

```yaml
uses: ./base-scripts/.github/actions/run-sourcify-tests
```

so this PR's own runs still use the old pin from `master`. The corrected flyingtulip expectation therefore fails here (`expected "Grant all", got "true"`) and only goes green once this is merged and the new pin is on `master`. Verified locally: with the new pin, both flyingtulip cases pass.
