### PR TITLE
ci: check that the index can still be built on pull requests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -144,3 +144,47 @@ jobs:
             echo "::error::One or more files failed JSON schema validation"
             exit 1
           fi
+
+  validate_index:
+    name: 🔎 validate index
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        timeout-minutes: 10
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Get all changed descriptor files
+        timeout-minutes: 5
+        id: changed-files
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
+        with:
+          files: |
+            registry/**/*.json
+            ercs/**/*.json
+          files_ignore: |
+            registry/**/tests/**
+            registry/**/testsv2/**
+
+      - name: Setup node
+        timeout-minutes: 10
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        timeout-minutes: 10
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: npm ci
+
+      - name: Check that the index can still be built
+        timeout-minutes: 10
+        if: steps.changed-files.outputs.any_changed == 'true'
+        # Each (chainId, address) maps to exactly one calldata descriptor, and
+        # two descriptors cannot register the same EIP-712 encodeType at one
+        # address. A pull request that breaks either would leave the index
+        # ungeneratable, which only surfaces after the merge, in the
+        # sync-indexes workflow — by then the conflict is already on master.
+        run: node tools/scripts/generate-index.js --validate

--- a/tools/scripts/generate-index.js
+++ b/tools/scripts/generate-index.js
@@ -9,9 +9,15 @@
  * downstream libraries, so a stale index silently breaks clear signing for the
  * affected contracts.
  *
- * Usage: node tools/scripts/generate-index.js [--check]
- *   default   rewrites both index files in place
- *   --check   exits 1 if the committed files differ from the generated ones
+ * Usage: node tools/scripts/generate-index.js [--check|--validate]
+ *   default     rewrites both index files in place
+ *   --check     exits 1 if the committed files differ from the generated ones
+ *   --validate  builds the indexes in memory and exits 1 if that is not
+ *               possible — two descriptors claiming one index key, or a
+ *               descriptor whose "includes" cannot be resolved. Writes and
+ *               compares nothing, so it can run on a pull request, where the
+ *               committed index files are still the pre-merge ones (they are
+ *               regenerated on master by the sync-indexes workflow).
  */
 
 const fs = require('fs');
@@ -35,8 +41,8 @@ const EXCLUDED_DIRS = new Set(['tests', 'testsv2']);
  * prefix and are therefore never indexed in their own right — they only
  * contribute through the descriptors that include them.
  *
- * Sorting matters: it makes the "first descriptor wins" tie-break below
- * deterministic when two descriptors claim the same chain and address.
+ * Sorting matters: it keeps the generated arrays, and the collision messages
+ * below, identical from one run to the next.
  */
 function findDescriptors(dir, found = []) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -192,11 +198,32 @@ function serialize(index) {
 
 function main() {
   const check = process.argv.includes('--check');
-  const { calldata, eip712, errors } = generateIndexes();
+  const validate = process.argv.includes('--validate');
+
+  // indexDescriptor() throws when two descriptors claim one index key. Report
+  // that as a plain message rather than a stack trace — it is a registry
+  // problem for a contributor to fix, not a bug in this script.
+  let calldata;
+  let eip712;
+  let errors;
+  try {
+    ({ calldata, eip712, errors } = generateIndexes());
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exit(1);
+  }
 
   if (errors.length) {
     for (const error of errors) process.stderr.write(`Failed to resolve ${error}\n`);
     process.exit(1);
+  }
+
+  if (validate) {
+    process.stdout.write(
+      `Index is buildable (${Object.keys(calldata).length} calldata, ` +
+        `${Object.keys(eip712).length} eip712 entries).\n`,
+    );
+    return;
   }
 
   let stale = false;


### PR DESCRIPTION
## Problem

The index files encode two uniqueness rules:

- each `(chainId, address)` maps to exactly one calldata descriptor
- two descriptors cannot register the same EIP-712 `encodeType` at one address

`tools/scripts/generate-index.js` already refuses to build an index that violates either — but nothing ran it on a pull request. A collision therefore only surfaced *after* the merge, in the `sync-indexes` workflow on `master`: that run fails, no index update PR is opened, and the committed index files quietly stop tracking the registry. The conflict is on `master` by the time anyone notices.

This is the open point from [#2634 (comment)](https://github.com/ethereum/clear-signing-erc7730-registry/pull/2634#issuecomment-5069144028). The generator has since been changed to throw rather than silently drop the second descriptor; what was still missing was a pull-request-time gate.

## Fix

A new `--validate` mode builds both indexes in memory and exits non-zero if that is not possible — a key collision, or a descriptor whose `includes` cannot be resolved. It writes nothing and compares nothing.

It deliberately is **not** `--check`. `--check` diffs the committed index files against freshly generated ones, and those files are regenerated on `master` after the merge by `sync-indexes`, so on a pull request they are expected to be out of date — every descriptor addition would fail it.

A new `validate_index` job runs it whenever a pull request touches `registry/**` or `ercs/**` JSON, excluding test fixtures.

A collision now also aborts with a plain message naming both descriptors instead of an uncaught exception with a stack trace, since it is a registry problem for a contributor to fix.

## Verified locally

| Case | Result |
|---|---|
| Current registry | `Index is buildable (776 calldata, 199 eip712 entries)`, exit 0 |
| Current registry + all 181 attestations from #2765 | identical counts, exit 0 |
| Calldata collision (a second descriptor given `eip155:1:0xae7a…`) | exit 1, names both descriptors and the key |
| Duplicate EIP-712 `encodeType` at one address | exit 1, names both descriptors, the address and the primary type |
| Descriptor with an unresolvable `includes` | exit 1, `Include not found` |
| `--check` and the default write mode | unchanged; `--validate` touches no files |

## Notes

- No ordering dependency on #2865 or #2765: the generator walks `sigs/` attestations but `indexDescriptor` returns early for documents without a `context` key, so they contribute nothing and the entry counts are unchanged.
- Ownership transfers (a descriptor is deleted and another takes over its address) stay unflagged — that is legitimate maintenance, not a collision.
- The `findDescriptors` doc comment still described a "first descriptor wins" tie-break that was removed when collision-throwing was introduced; corrected here since it sits directly above the collision handling.
