### PR TITLE
ci: remove pull_request triggers from Analyze workflow

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -1,12 +1,6 @@
 name: Analyze
 
 on:
-  pull_request:
-    types: [ready_for_review, synchronize]
-    paths:
-      - 'registry/**/calldata-*.json'
-      # Auditor attestations share the descriptor name prefix — never analyze them.
-      - '!registry/**/sigs/**'
   workflow_dispatch:
     inputs:
       analysis_mode:
@@ -57,7 +51,8 @@ concurrency:
 jobs:
   analyze:
     name: ERC-7730 Analysis
-    if: github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch'
+    # Restore alongside the pull_request trigger if the workflow is re-enabled.
+    # if: github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch'
     runs-on: public-ledgerhq-shared-small
     timeout-minutes: 360
 


### PR DESCRIPTION
The `Analyze` workflow requests `runs-on: public-ledgerhq-shared-small`, a runner label not available to this repository, so its jobs never get assigned a runner and sit queued until GitHub cancels them at the 24-hour queue limit. Zero of the last 100 runs succeeded (92 `cancelled`, 4 `skipped`, 2 `action_required`), leaving a permanently pending check on every PR that touches a calldata descriptor.

- Removes the `pull_request` trigger so PRs no longer carry that stuck check.
- Keeps `workflow_dispatch` and the rest of the workflow intact, in case we decide to enable it again later — the runner issue can be fixed at that point and the trigger restored.
- Comments out the `if:` draft guard instead of deleting it, since it only applied to the `pull_request` event and should come back together with the trigger.
