### PR TITLE
Update clear signing Rust test lib

### DIFF
--- a/.github/actions/run-rust-tests/action.yml
+++ b/.github/actions/run-rust-tests/action.yml
@@ -21,7 +21,7 @@ runs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: llbartekll/clear-signing
-        ref: 7aea31da1a5a0363fcbe1e0ea089c7294e29229f # main @ 2026-06-22
+        ref: 10605ba78f3d6f3f13102e0f3a3ecbc44ac500dc # main @ 2026-08-13
         path: cs-runner
         persist-credentials: false
 


### PR DESCRIPTION
Moves the Rust clear-signing test runner to its current `main`.

| runner | old pin | new pin | picks up |
|---|---|---|---|
| [llbartekll/clear-signing](https://github.com/llbartekll/clear-signing) | `7aea31da` (2026-06-22) | `10605ba7` (2026-08-13) | `feat(encryption): support ERC-7730 encryption scheme` ([#10](https://github.com/llbartekll/clear-signing/pull/10)), `fix(cs-test): make owner rendered value optional` ([#11](https://github.com/llbartekll/clear-signing/pull/11)), and a clippy chore |

The encryption work is the substance of the bump. Fields carrying an ERC-7730 `encryption` annotation are now decrypted through a wallet-provided callback and rendered with the field's normal format; when no decryptor is available — which is how the runner executes — the field renders its `fallbackLabel` instead of the raw handle, the handle is reported separately, and a malformed annotation is treated as a descriptor error. `#11` makes the runner's `owner` comparison optional so a descriptor that omits `metadata.owner` no longer fails.

## Effect on the registry

Both pins were run over all 270 `testsv2/` files (507 cases) at this PR's base. **No result changes**: the per-file diff is empty, no cases are added or removed, and the `owner` change produces no difference anywhere.

The two pre-existing failures are unchanged before and after:

- `registry/flyingtulip/testsv2/calldata-PftNft.tests.json` (1/2) — `Access rights` renders `true` where the descriptor's `enum` + `metadata.enums.rights` asks for `Grant all`. This is the same bool-in-enum gap the Sourcify runner fixed in v0.2.1; the Rust runner does not implement it yet.
- `registry/rarible/testsv2/eip712-rarible-exchange-v2-meta-tx.tests.json` (0/1) — `owner` not surfaced, intent renders as `MetaTransaction`, and the typed-data fields resolve to the raw message keys.

## What it unblocks

Descriptors with `encryption` annotations cannot pass at the old pin, because it interprets the ciphertext handle as a value. Measured against the pending Zama ConfidentialWrapper descriptor and its fixtures:

`registry/zama/testsv2/calldata-ConfidentialWrapper.tests.json` → **4/16 → 16/16**, e.g. "Confidential transfer with a known encrypted amount handle", field `Amount`:

```diff
-  { "label": "Amount", "value": "77709350304069432352106265165225806852208816875303988542668854740077112.551305 cUSDC" }
+  { "label": "Amount", "value": "[Encrypted Amount]" }
```

with the same correction in the interpolated intent. The other Zama fixtures pass at both pins (`calldata-ACL` 6/6, the three `UserDecryptRequestVerification` files 5/5) since they carry no encrypted fields.

## Note for reviewers: the clear-signing checks will not exercise this change

Two reasons, both by design:

- The test workflow triggers only on `registry/**/*.json` and `ercs/**/*.json`, so a pin-only PR does not start the clear-signing jobs at all.
- Even when they do run, they load the action from the **base** ref (`uses: ./base-scripts/.github/actions/run-rust-tests`), so any PR still resolves the pin from `master`.

The new pin therefore takes effect for the next descriptor PR after this merges. Verified locally at both pins, per the numbers above.