### PR TITLE
fix(permit): remove non-existent version field from YetiSwap test domain type

### DIFF
--- a/registry/permit/testsv2/eip712-permit-avalanche_c_chain-yetiswap.tests.json
+++ b/registry/permit/testsv2/eip712-permit-avalanche_c_chain-yetiswap.tests.json
@@ -8,7 +8,6 @@
         "types": {
           "EIP712Domain": [
             { "name": "name", "type": "string" },
-            { "name": "version", "type": "string" },
             { "name": "chainId", "type": "uint256" },
             { "name": "verifyingContract", "type": "address" }
           ],


### PR DESCRIPTION
Follow-up to #2747 (YetiSwap permit descriptor).

`registry/permit/testsv2/eip712-permit-avalanche_c_chain-yetiswap.tests.json` declared a four-field EIP-712 domain type but supplied three values. YetiSwap has no `version` field — its `DOMAIN_TYPEHASH` is `EIP712Domain(string name,uint256 chainId,address verifyingContract)` (verified on Sourcify: chain 43114, `0x488f73cddda1de3664775ffd91623637383d6404`, full match).

The two types give different separators:

| Built from | Domain separator |
|---|---|
| the contract's real three-field type | `0x8d5fecbb9fafdb8768a4e906ac8751d1c7ded665e93286e8d5f104b5c3b7f5cd` |
| the test vector's four-field type | `0x24134fc0ec87b29dc85d76bab6aaada501d1628435ee678932dfdbbbf6bb5de4` |

So the vector described a message the contract would reject with `YTS::permit: unauthorized`.

CI never caught this because the runners assert rendered output only, and the domain match reads the `domain` values rather than the `types` list. It is a fidelity defect in test data, not a test failure — which is why it needs a deliberate fix.

One line removed. The descriptor itself is correct and untouched.

**The v1 fixture is left alone deliberately.** `registry/permit/tests/eip712-permit-avalanche_c_chain-yetiswap.tests.json` both declares and supplies `version`, so it is internally consistent; removing the type entry would create the mirror-image mismatch. Its domain is placeholder data (`"name": "Example"`) that does not describe the real contract — a broader problem shared with other v1 fixtures, and worth a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
