### PR TITLE
fix(uniswap): show max Permit2 amounts as "Unlimited"

### DIFF
--- a/registry/uniswap/eip712-uniswap-permit2.json
+++ b/registry/uniswap/eip712-uniswap-permit2.json
@@ -12,7 +12,11 @@
             "path": "details.amount",
             "label": "Amount allowance",
             "format": "tokenAmount",
-            "params": { "tokenPath": "details.token" },
+            "params": {
+              "tokenPath": "details.token",
+              "threshold": "0xffffffffffffffffffffffffffffffffffffffff",
+              "message": "Unlimited"
+            },
             "visible": "always"
           },
           { "path": "details.expiration", "label": "Approval expires", "format": "date", "params": { "encoding": "timestamp" } },
@@ -28,7 +32,11 @@
             "path": "details.[].amount",
             "label": "Amount allowance",
             "format": "tokenAmount",
-            "params": { "tokenPath": "details.[].token" }
+            "params": {
+              "tokenPath": "details.[].token",
+              "threshold": "0xffffffffffffffffffffffffffffffffffffffff",
+              "message": "Unlimited"
+            }
           },
           { "path": "details.[].expiration", "label": "Approval expires", "format": "date", "params": { "encoding": "timestamp" } },
           { "label": "Sig Deadline", "path": "sigDeadline", "visible": "never" }
@@ -49,7 +57,11 @@
             "path": "permitted.amount",
             "label": "Amount",
             "format": "tokenAmount",
-            "params": { "tokenPath": "permitted.token" },
+            "params": {
+              "tokenPath": "permitted.token",
+              "threshold": "0x8000000000000000000000000000000000000000000000000000000000000000",
+              "message": "Any amount"
+            },
             "visible": "always"
           },
           { "path": "deadline", "label": "Deadline", "format": "date", "params": { "encoding": "timestamp" }, "visible": "always" }

--- a/registry/uniswap/testsv2/eip712-uniswap-permit2.tests.json
+++ b/registry/uniswap/testsv2/eip712-uniswap-permit2.tests.json
@@ -100,6 +100,147 @@
           { "label": "Approval expires", "value": "2026-05-28 20:26:40Z" }
         ]
       }
+    },
+    {
+      "description": "Authorize spending of token - unlimited allowance",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "PermitDetails": [
+            { "name": "token", "type": "address" },
+            { "name": "amount", "type": "uint160" },
+            { "name": "expiration", "type": "uint48" },
+            { "name": "nonce", "type": "uint48" }
+          ],
+          "PermitSingle": [
+            { "name": "details", "type": "PermitDetails" },
+            { "name": "spender", "type": "address" },
+            { "name": "sigDeadline", "type": "uint256" }
+          ]
+        },
+        "primaryType": "PermitSingle",
+        "domain": { "name": "Permit2", "chainId": 1, "verifyingContract": "0x000000000022D473030F116dDEE9F6B43aC78BA3" },
+        "message": {
+          "details": {
+            "token": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            "amount": "1461501637330902918203684832716283019655932542975",
+            "expiration": 1782864000,
+            "nonce": 7
+          },
+          "spender": "0xE592427A0AEce92De3Edee1F18E0157C05861564",
+          "sigDeadline": 1774915200
+        }
+      },
+      "expected": {
+        "intent": "Authorize spending of token",
+        "owner": "Uniswap Labs",
+        "fields": [
+          { "label": "Spender", "value": "0xE592427A0AEce92De3Edee1F18E0157C05861564" },
+          { "label": "Amount allowance", "value": "Unlimited USDC" },
+          { "label": "Approval expires", "value": "2026-07-01 00:00:00Z" }
+        ]
+      }
+    },
+    {
+      "description": "Authorize spending of tokens - one unlimited, one finite",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "PermitDetails": [
+            { "name": "token", "type": "address" },
+            { "name": "amount", "type": "uint160" },
+            { "name": "expiration", "type": "uint48" },
+            { "name": "nonce", "type": "uint48" }
+          ],
+          "PermitBatch": [
+            { "name": "details", "type": "PermitDetails[]" },
+            { "name": "spender", "type": "address" },
+            { "name": "sigDeadline", "type": "uint256" }
+          ]
+        },
+        "primaryType": "PermitBatch",
+        "domain": { "name": "Permit2", "chainId": 1, "verifyingContract": "0x000000000022D473030F116dDEE9F6B43aC78BA3" },
+        "message": {
+          "details": [
+            {
+              "token": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+              "amount": "1461501637330902918203684832716283019655932542975",
+              "expiration": "1780000000",
+              "nonce": "912345"
+            },
+            {
+              "token": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+              "amount": "750000000000000000",
+              "expiration": "1780000000",
+              "nonce": "912346"
+            }
+          ],
+          "spender": "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45",
+          "sigDeadline": "1775200000"
+        }
+      },
+      "expected": {
+        "intent": "Authorize spending of tokens",
+        "owner": "Uniswap Labs",
+        "fields": [
+          { "label": "Spender", "value": "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45" },
+          { "label": "Amount allowance", "value": "Unlimited USDC" },
+          { "label": "Amount allowance", "value": "0.75 WETH" },
+          { "label": "Approval expires", "value": "2026-05-28 20:26:40Z" },
+          { "label": "Approval expires", "value": "2026-05-28 20:26:40Z" }
+        ]
+      }
+    },
+    {
+      "description": "Authorize token transfer - uncapped amount",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "TokenPermissions": [
+            { "name": "token", "type": "address" },
+            { "name": "amount", "type": "uint256" }
+          ],
+          "PermitTransferFrom": [
+            { "name": "permitted", "type": "TokenPermissions" },
+            { "name": "spender", "type": "address" },
+            { "name": "nonce", "type": "uint256" },
+            { "name": "deadline", "type": "uint256" }
+          ]
+        },
+        "primaryType": "PermitTransferFrom",
+        "domain": { "name": "Permit2", "chainId": 1, "verifyingContract": "0x000000000022D473030F116dDEE9F6B43aC78BA3" },
+        "message": {
+          "permitted": {
+            "token": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            "amount": "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+          },
+          "spender": "0xE592427A0AEce92De3Edee1F18E0157C05861564",
+          "nonce": "42",
+          "deadline": "1782864000"
+        }
+      },
+      "expected": {
+        "intent": "Authorize token transfer",
+        "interpolatedIntent": "Transfer Any amount USDC",
+        "owner": "Uniswap Labs",
+        "fields": [
+          { "label": "Spender", "value": "0xE592427A0AEce92De3Edee1F18E0157C05861564" },
+          { "label": "Amount", "value": "Any amount USDC" },
+          { "label": "Deadline", "value": "2026-07-01 00:00:00Z" }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
## The problem

Permit2 is a Uniswap contract. It lets a user give a token allowance with a signature. The user does not send a transaction. Permit2 has three messages that a user can sign. Each message contains an amount.

If the amount is the maximum value, the allowance has no limit. Today the wallet shows that maximum as a very long number. The user sees 46 digits. The user cannot tell that the allowance has no limit. This is audit finding #2677.

ERC-7730 has two parameters for this problem. The `threshold` parameter holds a value. The `message` parameter holds a text. If the amount reaches the threshold, the wallet shows the text in place of the number.

## Why this change uses two different threshold values

The three fields do not have the same type. Therefore they do not get the same threshold.

**The two allowance fields.** `PermitSingle.details.amount` and `PermitBatch.details.[].amount` are `uint160`. Their threshold is `type(uint160).max`. That value is 40 hex characters, not 64.

This value is also the true sentinel of Permit2. The function `AllowanceTransfer._transfer` keeps the allowance at its full value only when the allowance is equal to `type(uint160).max`:

```solidity
uint256 maxAmount = allowed.amount;
if (maxAmount != type(uint160).max) {
    ...
    allowed.amount = uint160(maxAmount) - amount;
}
```

Each transfer decreases a smaller allowance. Therefore only the maximum value gives an allowance with no limit.

**The transfer field.** `PermitTransferFrom.permitted.amount` is `uint256`. This field is a limit for one transfer only. It is not an allowance that stays after the transfer. Its threshold is `2^255`. The file `ercs/eip712-erc2612-permit.json` uses the same value. The text is "Any amount" and not "Unlimited", because "Unlimited" can make the reader believe that the allowance stays.

## The threshold also fires on an equal value

A reader can ask if an exact `type(uint160).max` threshold ever fires. The specification answers this question. In `specs/erc-7730.md`, the `tokenAmount` example gives the field value `0xFFFFFFFF` and the threshold `0xFFFFFFFF`. The result is `Unlimited DAI`. Therefore the comparison includes the equal value.

## Tests

This change adds three test cases:

- A `PermitSingle` message with an amount that has no limit.
- A `PermitBatch` message with one unlimited entry and one normal entry. This case proves that each entry gets its own result.
- A `PermitTransferFrom` message with the maximum `uint256` amount.

Before this change, `PermitTransferFrom` had no test in `testsv2`.

I ran the tests with the Sourcify test runner that CI uses (`clear-signing-test-runner` at `dae3cda`, v0.2.2). The result is 5 pass, 0 fail.

I also ran a negative control. I kept the new tests, and I removed the change from the descriptor. The three new cases then fail. They show the problem that the audit reports:

```
1461501637330902918203684832716283019655932.542975 USDC
Transfer 115792089237316195423570985008687907853269984665640564039457584007913129.639935 USDC
```

## About the issue

Issue #2677 contains a second finding. That finding says that Permit2 has no verified source on Sonic (chain 146) and on Blast (chain 81457). Sourcify verified both contracts on 2026-07-30. I confirmed this against the live API. Therefore this pull request closes the complete issue.

Closes #2677

🤖 Generated with [Claude Code](https://claude.com/claude-code)
