### PR TITLE
fix(lombard): show unlimited LBTC allowances as "Unlimited"

### DIFF
--- a/registry/lombard/calldata-lbtc-mainnet.json
+++ b/registry/lombard/calldata-lbtc-mainnet.json
@@ -12,7 +12,11 @@
             "path": "value",
             "label": "Amount to Approve",
             "format": "tokenAmount",
-            "params": { "tokenPath": "@.to" },
+            "params": {
+              "tokenPath": "@.to",
+              "threshold": "0x8000000000000000000000000000000000000000000000000000000000000000",
+              "message": "Unlimited"
+            },
             "visible": "always"
           },
           {
@@ -57,7 +61,17 @@
             "params": { "types": ["eoa", "wallet", "contract"] },
             "visible": "always"
           },
-          { "path": "value", "label": "Allowance", "format": "tokenAmount", "params": { "tokenPath": "@.to" }, "visible": "always" },
+          {
+            "path": "value",
+            "label": "Allowance",
+            "format": "tokenAmount",
+            "params": {
+              "tokenPath": "@.to",
+              "threshold": "0x8000000000000000000000000000000000000000000000000000000000000000",
+              "message": "Unlimited"
+            },
+            "visible": "always"
+          },
           { "path": "deadline", "label": "Valid Until", "format": "date", "params": { "encoding": "timestamp" } },
           { "label": "V", "path": "v", "visible": "never" },
           { "label": "R", "path": "r", "visible": "never" },

--- a/registry/lombard/calldata-lbtc-sepolia.json
+++ b/registry/lombard/calldata-lbtc-sepolia.json
@@ -15,7 +15,11 @@
             "path": "value",
             "label": "Amount to Approve",
             "format": "tokenAmount",
-            "params": { "tokenPath": "@.to" },
+            "params": {
+              "tokenPath": "@.to",
+              "threshold": "0x8000000000000000000000000000000000000000000000000000000000000000",
+              "message": "Unlimited"
+            },
             "visible": "always"
           },
           {
@@ -60,7 +64,17 @@
             "params": { "types": ["eoa", "wallet", "contract"] },
             "visible": "always"
           },
-          { "path": "value", "label": "Allowance", "format": "tokenAmount", "params": { "tokenPath": "@.to" }, "visible": "always" },
+          {
+            "path": "value",
+            "label": "Allowance",
+            "format": "tokenAmount",
+            "params": {
+              "tokenPath": "@.to",
+              "threshold": "0x8000000000000000000000000000000000000000000000000000000000000000",
+              "message": "Unlimited"
+            },
+            "visible": "always"
+          },
           { "path": "deadline", "label": "Valid Until", "format": "date", "params": { "encoding": "timestamp" } },
           { "label": "V", "path": "v", "visible": "never" },
           { "label": "R", "path": "r", "visible": "never" },

--- a/registry/lombard/testsv2/calldata-lbtc-mainnet.tests.json
+++ b/registry/lombard/testsv2/calldata-lbtc-mainnet.tests.json
@@ -60,6 +60,32 @@
         "owner": "Lombard Finance",
         "fields": [{ "label": "Amount to Send", "value": "0.10935535 LBTC" }, { "label": "Recipient", "value": "ldzx-001.eth" }]
       }
+    },
+    {
+      "description": "Approve - unlimited allowance - chain 1",
+      "rawTx": "0x02f86d01819e8405f5e1008408890f0082cb22948236a87084f8b84306f72007f36f2618a563449480b844095ea7b30000000000000000000000006a000f20005980200259b80c5102003040001068ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0",
+      "expected": {
+        "intent": "Approve",
+        "owner": "Lombard Finance",
+        "fields": [
+          { "label": "Amount to Approve", "value": "Unlimited LBTC" },
+          { "label": "Spender", "value": "0x6A000F20005980200259B80c5102003040001068" }
+        ]
+      }
+    },
+    {
+      "description": "Permit - unlimited allowance - chain 1",
+      "rawTx": "0x02f9010e01819f8405f5e1008408890f0083015f90948236a87084f8b84306f72007f36f2618a563449480b8e4d505accf000000000000000000000000e57f3834700e9fe0166c97be35e97a053d1ac5f80000000000000000000000006a000f20005980200259b80c5102003040001068ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000000000000000000000000000000000000000000000000000000006a445880000000000000000000000000000000000000000000000000000000000000001b11111111111111111111111111111111111111111111111111111111111111112222222222222222222222222222222222222222222222222222222222222222c0",
+      "expected": {
+        "intent": "Permit",
+        "owner": "Lombard Finance",
+        "fields": [
+          { "label": "Owner", "value": "ldzx-001.eth" },
+          { "label": "Spender", "value": "0x6A000F20005980200259B80c5102003040001068" },
+          { "label": "Allowance", "value": "Unlimited LBTC" },
+          { "label": "Valid Until", "value": "2026-07-01 00:00:00Z" }
+        ]
+      }
     }
   ]
 }

--- a/registry/lombard/testsv2/calldata-lbtc-sepolia.tests.json
+++ b/registry/lombard/testsv2/calldata-lbtc-sepolia.tests.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "../../../specs/erc7730-tests-v2.schema.json",
+  "descriptor": "../calldata-lbtc-sepolia.json",
+  "dataProvider": {
+    "tokens": { "0x731efa688f3679688cf60a3993b8658138953ed6": { "symbol": "LBTC", "decimals": 8, "name": "Lombard Staked Bitcoin" } }
+  },
+  "tests": [
+    {
+      "description": "Approve - unlimited allowance - chain 11155111",
+      "rawTx": "0x02f86f83aa36a7038405f5e1008408890f0082cb2294731efa688f3679688cf60a3993b8658138953ed680b844095ea7b30000000000000000000000006a000f20005980200259b80c5102003040001068ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0",
+      "expected": {
+        "intent": "Approve",
+        "owner": "Lombard Finance",
+        "fields": [
+          { "label": "Amount to Approve", "value": "Unlimited LBTC" },
+          { "label": "Spender", "value": "0x6A000F20005980200259B80c5102003040001068" }
+        ]
+      }
+    },
+    {
+      "description": "Permit - unlimited allowance - chain 11155111",
+      "rawTx": "0x02f9011083aa36a7048405f5e1008408890f0083015f9094731efa688f3679688cf60a3993b8658138953ed680b8e4d505accf000000000000000000000000e57f3834700e9fe0166c97be35e97a053d1ac5f80000000000000000000000006a000f20005980200259b80c5102003040001068ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000000000000000000000000000000000000000000000000000000006a445880000000000000000000000000000000000000000000000000000000000000001b11111111111111111111111111111111111111111111111111111111111111112222222222222222222222222222222222222222222222222222222222222222c0",
+      "expected": {
+        "intent": "Permit",
+        "owner": "Lombard Finance",
+        "fields": [
+          { "label": "Owner", "value": "0xe57f3834700E9Fe0166c97Be35E97a053d1AC5f8" },
+          { "label": "Spender", "value": "0x6A000F20005980200259B80c5102003040001068" },
+          { "label": "Allowance", "value": "Unlimited LBTC" },
+          { "label": "Valid Until", "value": "2026-07-01 00:00:00Z" }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## The problem

LBTC is the token of Lombard Finance. Two descriptors in this repository describe the LBTC contract. One descriptor covers Ethereum mainnet. The other descriptor covers the Sepolia test network.

Each descriptor lets a user grant an allowance in two places. The function `approve` grants an allowance. The function `permit` also grants an allowance. An allowance lets another address spend the tokens of the user.

If the user grants the maximum allowance, the allowance has no limit. Today the wallet shows that maximum as a number with 71 digits. The user cannot read the number. Therefore the user cannot see that the allowance has no limit.

ERC-7730 has two parameters for this problem. The `threshold` parameter holds a value. The `message` parameter holds a text. If the amount reaches the threshold, the wallet shows the text in place of the number.

## The change

This pull request adds `threshold` and `message` to all four fields. The threshold value is `2^255`. The text is "Unlimited".

The merged fix for the shared ERC-2612 permit file uses the same value (commit `b2686cc`). These four fields are ordinary `uint256` ERC-20 allowances. Therefore no smaller width applies here.

## Tests

The audit reports a gap in the tests. The only fixture for `approve` uses `value = 0`. That fixture revokes an allowance. No fixture reached the threshold. The function `permit` had no fixture. The Sepolia descriptor had no file in `testsv2` at all.

This pull request adds four test cases:

- An `approve` call with an allowance that has no limit, on mainnet.
- A `permit` message with an allowance that has no limit, on mainnet.
- The same two cases on Sepolia.

The Sepolia cases go into a new file, `registry/lombard/testsv2/calldata-lbtc-sepolia.tests.json`.

Each new `rawTx` value is an unsigned EIP-1559 payload. A local RLP encoder builds the payload. I checked the encoder against the existing `approve` fixture first. The encoder reproduces that fixture byte for byte.

I ran the tests with the Sourcify test runner that CI uses (`clear-signing-test-runner` at `dae3cda`, v0.2.2). The mainnet file gives 6 pass and 0 fail. The Sepolia file gives 2 pass and 0 fail.

## Negative control

I also ran a negative control. I kept the new tests, and I removed the change from both descriptors. All four new cases then fail. Each case shows the number that the audit reports:

```
1157920892373161954235709850086879078532699846656405640394575840079131.29639935 LBTC
```

The four failures cover the four changed fields. Therefore each new test reaches the code that this pull request changes.

Closes #2645, closes #2646

🤖 Generated with [Claude Code](https://claude.com/claude-code)
