### PR TITLE
fix(tally): name the action in the intent and decode the vote choice

### DIFF
--- a/registry/tally/eip712-tally-arbitrum-arb-token.json
+++ b/registry/tally/eip712-tally-arbitrum-arb-token.json
@@ -10,7 +10,7 @@
   "display": {
     "formats": {
       "Delegation(address delegatee,uint256 nonce,uint256 expiry)": {
-        "intent": "ARB token",
+        "intent": "Delegate ARB voting power",
         "fields": [
           { "path": "delegatee", "label": "Delegatee", "format": "raw" },
           { "path": "nonce", "label": "Nonce", "format": "raw" },

--- a/registry/tally/eip712-tally-arbitrum-core-governor.json
+++ b/registry/tally/eip712-tally-arbitrum-core-governor.json
@@ -6,14 +6,14 @@
       "domain": { "name": "L2ArbitrumGovernor", "version": "1" }
     }
   },
-  "metadata": { "owner": "L2ArbitrumGovernor" },
+  "metadata": { "owner": "L2ArbitrumGovernor", "enums": { "voteType": { "0": "Against", "1": "For", "2": "Abstain" } } },
   "display": {
     "formats": {
       "Ballot(uint256 proposalId,uint8 support)": {
-        "intent": "Arbitrum Foundation: Core Governor",
+        "intent": "Cast vote on Arbitrum Core Governor proposal",
         "fields": [
           { "path": "proposalId", "label": "Proposal id", "format": "raw" },
-          { "path": "support", "label": "Support", "format": "raw" }
+          { "path": "support", "label": "Vote", "format": "enum", "params": { "$ref": "$.metadata.enums.voteType" } }
         ]
       }
     }

--- a/registry/tally/eip712-tally-arbitrum-treasury-governor.json
+++ b/registry/tally/eip712-tally-arbitrum-treasury-governor.json
@@ -6,14 +6,14 @@
       "domain": { "name": "L2ArbitrumGovernor", "version": "1" }
     }
   },
-  "metadata": { "owner": "L2ArbitrumGovernor" },
+  "metadata": { "owner": "L2ArbitrumGovernor", "enums": { "voteType": { "0": "Against", "1": "For", "2": "Abstain" } } },
   "display": {
     "formats": {
       "Ballot(uint256 proposalId,uint8 support)": {
-        "intent": "Arbitrum Foundation: Treasury Governor",
+        "intent": "Cast vote on Arbitrum Treasury Governor proposal",
         "fields": [
           { "path": "proposalId", "label": "Proposal id", "format": "raw" },
-          { "path": "support", "label": "Support", "format": "raw" }
+          { "path": "support", "label": "Vote", "format": "enum", "params": { "$ref": "$.metadata.enums.voteType" } }
         ]
       }
     }

--- a/registry/tally/eip712-tally-ethereum-bitcoin-governor.json
+++ b/registry/tally/eip712-tally-ethereum-bitcoin-governor.json
@@ -6,14 +6,14 @@
       "domain": { "name": "GTC Governor Alpha" }
     }
   },
-  "metadata": { "owner": "GTC Governor Alpha" },
+  "metadata": { "owner": "GTC Governor Alpha", "enums": { "voteType": { "false": "Against", "true": "For" } } },
   "display": {
     "formats": {
       "Ballot(uint256 proposalId,bool support)": {
-        "intent": "Gitcoin Governor",
+        "intent": "Cast vote on Gitcoin proposal",
         "fields": [
           { "path": "proposalId", "label": "Proposal id", "format": "raw" },
-          { "path": "support", "label": "Support", "format": "raw" }
+          { "path": "support", "label": "Vote", "format": "enum", "params": { "$ref": "$.metadata.enums.voteType" } }
         ]
       }
     }

--- a/registry/tally/eip712-tally-ethereum-bravo-governor.json
+++ b/registry/tally/eip712-tally-ethereum-bravo-governor.json
@@ -6,14 +6,14 @@
       "domain": { "name": "Uniswap Governor Bravo" }
     }
   },
-  "metadata": { "owner": "Uniswap Governor Bravo" },
+  "metadata": { "owner": "Uniswap Governor Bravo", "enums": { "voteType": { "0": "Against", "1": "For", "2": "Abstain" } } },
   "display": {
     "formats": {
       "Ballot(uint256 proposalId,uint8 support)": {
-        "intent": "Uniswap Governor",
+        "intent": "Cast vote on Uniswap governance proposal",
         "fields": [
           { "path": "proposalId", "label": "Proposal id", "format": "raw" },
-          { "path": "support", "label": "Support", "format": "raw" }
+          { "path": "support", "label": "Vote", "format": "enum", "params": { "$ref": "$.metadata.enums.voteType" } }
         ]
       }
     }

--- a/registry/tally/eip712-tally-ethereum-ens-governor.json
+++ b/registry/tally/eip712-tally-ethereum-ens-governor.json
@@ -6,14 +6,14 @@
       "domain": { "name": "ENS Governor", "version": "1" }
     }
   },
-  "metadata": { "owner": "ENS Governor" },
+  "metadata": { "owner": "ENS Governor", "enums": { "voteType": { "0": "Against", "1": "For", "2": "Abstain" } } },
   "display": {
     "formats": {
       "Ballot(uint256 proposalId,uint8 support)": {
-        "intent": "ENS Governor",
+        "intent": "Cast vote on ENS governance proposal",
         "fields": [
           { "path": "proposalId", "label": "Proposal id", "format": "raw" },
-          { "path": "support", "label": "Support", "format": "raw" }
+          { "path": "support", "label": "Vote", "format": "enum", "params": { "$ref": "$.metadata.enums.voteType" } }
         ]
       }
     }

--- a/registry/tally/eip712-tally-ethereum-ens-token.json
+++ b/registry/tally/eip712-tally-ethereum-ens-token.json
@@ -10,7 +10,7 @@
   "display": {
     "formats": {
       "Delegation(address delegatee,uint256 nonce,uint256 expiry)": {
-        "intent": "ENS token",
+        "intent": "Delegate ENS voting power",
         "fields": [
           { "path": "delegatee", "label": "Delegatee", "format": "raw" },
           { "path": "nonce", "label": "Nonce", "format": "raw" },

--- a/registry/tally/eip712-tally-ethereum-gtk-token.json
+++ b/registry/tally/eip712-tally-ethereum-gtk-token.json
@@ -7,7 +7,7 @@
   "display": {
     "formats": {
       "Delegation(address delegatee,uint256 nonce,uint256 expiry)": {
-        "intent": "GTK token",
+        "intent": "Delegate GTC voting power",
         "fields": [
           { "path": "delegatee", "label": "Delegatee", "format": "raw" },
           { "path": "nonce", "label": "Nonce", "format": "raw" },

--- a/registry/tally/eip712-tally-ethereum-hop-governor.json
+++ b/registry/tally/eip712-tally-ethereum-hop-governor.json
@@ -6,14 +6,14 @@
       "domain": { "name": "HOP Governor", "version": "1" }
     }
   },
-  "metadata": { "owner": "HOP Governor" },
+  "metadata": { "owner": "HOP Governor", "enums": { "voteType": { "0": "Against", "1": "For", "2": "Abstain" } } },
   "display": {
     "formats": {
       "Ballot(uint256 proposalId,uint8 support)": {
-        "intent": "Hop Governor",
+        "intent": "Cast vote on Hop governance proposal",
         "fields": [
           { "path": "proposalId", "label": "Proposal id", "format": "raw" },
-          { "path": "support", "label": "Support", "format": "raw" }
+          { "path": "support", "label": "Vote", "format": "enum", "params": { "$ref": "$.metadata.enums.voteType" } }
         ]
       }
     }

--- a/registry/tally/eip712-tally-ethereum-hop-token.json
+++ b/registry/tally/eip712-tally-ethereum-hop-token.json
@@ -10,7 +10,7 @@
   "display": {
     "formats": {
       "Delegation(address delegatee,uint256 nonce,uint256 expiry)": {
-        "intent": "HOP token",
+        "intent": "Delegate HOP voting power",
         "fields": [
           { "path": "delegatee", "label": "Delegatee", "format": "raw" },
           { "path": "nonce", "label": "Nonce", "format": "raw" },

--- a/registry/tally/eip712-tally-ethereum-pool-token.json
+++ b/registry/tally/eip712-tally-ethereum-pool-token.json
@@ -10,7 +10,7 @@
   "display": {
     "formats": {
       "Delegation(address delegatee,uint256 nonce,uint256 expiry)": {
-        "intent": "POOL token",
+        "intent": "Delegate POOL voting power",
         "fields": [
           { "path": "delegatee", "label": "Delegatee", "format": "raw" },
           { "path": "nonce", "label": "Nonce", "format": "raw" },

--- a/registry/tally/eip712-tally-ethereum-pooltogether-governor.json
+++ b/registry/tally/eip712-tally-ethereum-pooltogether-governor.json
@@ -6,14 +6,14 @@
       "domain": { "name": "PoolTogether Governor Alpha" }
     }
   },
-  "metadata": { "owner": "PoolTogether Governor Alpha" },
+  "metadata": { "owner": "PoolTogether Governor Alpha", "enums": { "voteType": { "false": "Against", "true": "For" } } },
   "display": {
     "formats": {
       "Ballot(uint256 proposalId,bool support)": {
-        "intent": "PoolTogether Governor Alpha",
+        "intent": "Cast vote on PoolTogether proposal",
         "fields": [
           { "path": "proposalId", "label": "Proposal id", "format": "raw" },
-          { "path": "support", "label": "Support", "format": "raw" }
+          { "path": "support", "label": "Vote", "format": "enum", "params": { "$ref": "$.metadata.enums.voteType" } }
         ]
       }
     }

--- a/registry/tally/eip712-tally-ethereum-uni-token.json
+++ b/registry/tally/eip712-tally-ethereum-uni-token.json
@@ -7,7 +7,7 @@
   "display": {
     "formats": {
       "Delegation(address delegatee,uint256 nonce,uint256 expiry)": {
-        "intent": "UNI token",
+        "intent": "Delegate UNI voting power",
         "fields": [
           { "path": "delegatee", "label": "Delegatee", "format": "raw" },
           { "path": "nonce", "label": "Nonce", "format": "raw" },

--- a/registry/tally/testsv2/eip712-tally-arbitrum-arb-token.tests.json
+++ b/registry/tally/testsv2/eip712-tally-arbitrum-arb-token.tests.json
@@ -19,7 +19,7 @@
         "message": { "delegatee": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "nonce": 7, "expiry": 1790000000 }
       },
       "expected": {
-        "intent": "ARB token",
+        "intent": "Delegate ARB voting power",
         "owner": "Arbitrum",
         "fields": [
           { "label": "Delegatee", "value": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" },

--- a/registry/tally/testsv2/eip712-tally-arbitrum-core-governor.tests.json
+++ b/registry/tally/testsv2/eip712-tally-arbitrum-core-governor.tests.json
@@ -24,11 +24,71 @@
         "message": { "proposalId": "65188298694973145982045139804621336162807822964285913299589753047294933677132", "support": 1 }
       },
       "expected": {
-        "intent": "Arbitrum Foundation: Core Governor",
+        "intent": "Cast vote on Arbitrum Core Governor proposal",
         "owner": "L2ArbitrumGovernor",
         "fields": [
           { "label": "Proposal id", "value": "65188298694973145982045139804621336162807822964285913299589753047294933677132" },
-          { "label": "Support", "value": "1" }
+          { "label": "Vote", "value": "For" }
+        ]
+      }
+    },
+    {
+      "description": "Arbitrum Foundation: Core Governor - vote Against",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "Ballot": [{ "name": "proposalId", "type": "uint256" }, { "name": "support", "type": "uint8" }]
+        },
+        "primaryType": "Ballot",
+        "domain": {
+          "name": "L2ArbitrumGovernor",
+          "version": "1",
+          "chainId": 42161,
+          "verifyingContract": "0xf07ded9dc292157749b6fd268e37df6ea38395b9"
+        },
+        "message": { "proposalId": "65188298694973145982045139804621336162807822964285913299589753047294933677132", "support": 0 }
+      },
+      "expected": {
+        "intent": "Cast vote on Arbitrum Core Governor proposal",
+        "owner": "L2ArbitrumGovernor",
+        "fields": [
+          { "label": "Proposal id", "value": "65188298694973145982045139804621336162807822964285913299589753047294933677132" },
+          { "label": "Vote", "value": "Against" }
+        ]
+      }
+    },
+    {
+      "description": "Arbitrum Foundation: Core Governor - vote Abstain",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "Ballot": [{ "name": "proposalId", "type": "uint256" }, { "name": "support", "type": "uint8" }]
+        },
+        "primaryType": "Ballot",
+        "domain": {
+          "name": "L2ArbitrumGovernor",
+          "version": "1",
+          "chainId": 42161,
+          "verifyingContract": "0xf07ded9dc292157749b6fd268e37df6ea38395b9"
+        },
+        "message": { "proposalId": "65188298694973145982045139804621336162807822964285913299589753047294933677132", "support": 2 }
+      },
+      "expected": {
+        "intent": "Cast vote on Arbitrum Core Governor proposal",
+        "owner": "L2ArbitrumGovernor",
+        "fields": [
+          { "label": "Proposal id", "value": "65188298694973145982045139804621336162807822964285913299589753047294933677132" },
+          { "label": "Vote", "value": "Abstain" }
         ]
       }
     }

--- a/registry/tally/testsv2/eip712-tally-arbitrum-treasury-governor.tests.json
+++ b/registry/tally/testsv2/eip712-tally-arbitrum-treasury-governor.tests.json
@@ -24,11 +24,71 @@
         "message": { "proposalId": "87060200128729345015202003502732272248659485483823317618429660977840962607811", "support": 1 }
       },
       "expected": {
-        "intent": "Arbitrum Foundation: Treasury Governor",
+        "intent": "Cast vote on Arbitrum Treasury Governor proposal",
         "owner": "L2ArbitrumGovernor",
         "fields": [
           { "label": "Proposal id", "value": "87060200128729345015202003502732272248659485483823317618429660977840962607811" },
-          { "label": "Support", "value": "1" }
+          { "label": "Vote", "value": "For" }
+        ]
+      }
+    },
+    {
+      "description": "Arbitrum Foundation: Treasury Governor - vote Against",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "Ballot": [{ "name": "proposalId", "type": "uint256" }, { "name": "support", "type": "uint8" }]
+        },
+        "primaryType": "Ballot",
+        "domain": {
+          "name": "L2ArbitrumGovernor",
+          "version": "1",
+          "chainId": 42161,
+          "verifyingContract": "0x789fc99093b09ad01c34dc7251d0c89ce743e5a4"
+        },
+        "message": { "proposalId": "87060200128729345015202003502732272248659485483823317618429660977840962607811", "support": 0 }
+      },
+      "expected": {
+        "intent": "Cast vote on Arbitrum Treasury Governor proposal",
+        "owner": "L2ArbitrumGovernor",
+        "fields": [
+          { "label": "Proposal id", "value": "87060200128729345015202003502732272248659485483823317618429660977840962607811" },
+          { "label": "Vote", "value": "Against" }
+        ]
+      }
+    },
+    {
+      "description": "Arbitrum Foundation: Treasury Governor - vote Abstain",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "Ballot": [{ "name": "proposalId", "type": "uint256" }, { "name": "support", "type": "uint8" }]
+        },
+        "primaryType": "Ballot",
+        "domain": {
+          "name": "L2ArbitrumGovernor",
+          "version": "1",
+          "chainId": 42161,
+          "verifyingContract": "0x789fc99093b09ad01c34dc7251d0c89ce743e5a4"
+        },
+        "message": { "proposalId": "87060200128729345015202003502732272248659485483823317618429660977840962607811", "support": 2 }
+      },
+      "expected": {
+        "intent": "Cast vote on Arbitrum Treasury Governor proposal",
+        "owner": "L2ArbitrumGovernor",
+        "fields": [
+          { "label": "Proposal id", "value": "87060200128729345015202003502732272248659485483823317618429660977840962607811" },
+          { "label": "Vote", "value": "Abstain" }
         ]
       }
     }

--- a/registry/tally/testsv2/eip712-tally-ethereum-bitcoin-governor.tests.json
+++ b/registry/tally/testsv2/eip712-tally-ethereum-bitcoin-governor.tests.json
@@ -18,9 +18,30 @@
         "message": { "proposalId": "47", "support": true }
       },
       "expected": {
-        "intent": "Gitcoin Governor",
+        "intent": "Cast vote on Gitcoin proposal",
         "owner": "GTC Governor Alpha",
-        "fields": [{ "label": "Proposal id", "value": "47" }, { "label": "Support", "value": "true" }]
+        "fields": [{ "label": "Proposal id", "value": "47" }, { "label": "Vote", "value": "For" }]
+      }
+    },
+    {
+      "description": "Gitcoin Governor - vote Against",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "Ballot": [{ "name": "proposalId", "type": "uint256" }, { "name": "support", "type": "bool" }]
+        },
+        "primaryType": "Ballot",
+        "domain": { "name": "GTC Governor Alpha", "chainId": 1, "verifyingContract": "0xdbd27635a534a3d3169ef0498beb56fb9c937489" },
+        "message": { "proposalId": "47", "support": false }
+      },
+      "expected": {
+        "intent": "Cast vote on Gitcoin proposal",
+        "owner": "GTC Governor Alpha",
+        "fields": [{ "label": "Proposal id", "value": "47" }, { "label": "Vote", "value": "Against" }]
       }
     }
   ]

--- a/registry/tally/testsv2/eip712-tally-ethereum-bravo-governor.tests.json
+++ b/registry/tally/testsv2/eip712-tally-ethereum-bravo-governor.tests.json
@@ -18,9 +18,51 @@
         "message": { "proposalId": 178, "support": 1 }
       },
       "expected": {
-        "intent": "Uniswap Governor",
+        "intent": "Cast vote on Uniswap governance proposal",
         "owner": "Uniswap Governor Bravo",
-        "fields": [{ "label": "Proposal id", "value": "178" }, { "label": "Support", "value": "1" }]
+        "fields": [{ "label": "Proposal id", "value": "178" }, { "label": "Vote", "value": "For" }]
+      }
+    },
+    {
+      "description": "Uniswap Governor - vote Against",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "Ballot": [{ "name": "proposalId", "type": "uint256" }, { "name": "support", "type": "uint8" }]
+        },
+        "primaryType": "Ballot",
+        "domain": { "name": "Uniswap Governor Bravo", "chainId": 1, "verifyingContract": "0x408ed6354d4973f66138c91495f2f2fcbd8724c3" },
+        "message": { "proposalId": 178, "support": 0 }
+      },
+      "expected": {
+        "intent": "Cast vote on Uniswap governance proposal",
+        "owner": "Uniswap Governor Bravo",
+        "fields": [{ "label": "Proposal id", "value": "178" }, { "label": "Vote", "value": "Against" }]
+      }
+    },
+    {
+      "description": "Uniswap Governor - vote Abstain",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "Ballot": [{ "name": "proposalId", "type": "uint256" }, { "name": "support", "type": "uint8" }]
+        },
+        "primaryType": "Ballot",
+        "domain": { "name": "Uniswap Governor Bravo", "chainId": 1, "verifyingContract": "0x408ed6354d4973f66138c91495f2f2fcbd8724c3" },
+        "message": { "proposalId": 178, "support": 2 }
+      },
+      "expected": {
+        "intent": "Cast vote on Uniswap governance proposal",
+        "owner": "Uniswap Governor Bravo",
+        "fields": [{ "label": "Proposal id", "value": "178" }, { "label": "Vote", "value": "Abstain" }]
       }
     }
   ]

--- a/registry/tally/testsv2/eip712-tally-ethereum-ens-governor.tests.json
+++ b/registry/tally/testsv2/eip712-tally-ethereum-ens-governor.tests.json
@@ -19,11 +19,61 @@
         "message": { "proposalId": "65124996456969240058970412761127463646733711243818620698023168930879474320148", "support": 1 }
       },
       "expected": {
-        "intent": "ENS Governor",
+        "intent": "Cast vote on ENS governance proposal",
         "owner": "ENS Governor",
         "fields": [
           { "label": "Proposal id", "value": "65124996456969240058970412761127463646733711243818620698023168930879474320148" },
-          { "label": "Support", "value": "1" }
+          { "label": "Vote", "value": "For" }
+        ]
+      }
+    },
+    {
+      "description": "ENS Governor - vote Against",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "Ballot": [{ "name": "proposalId", "type": "uint256" }, { "name": "support", "type": "uint8" }]
+        },
+        "primaryType": "Ballot",
+        "domain": { "name": "ENS Governor", "version": "1", "chainId": 1, "verifyingContract": "0x323a76393544d5ecca80cd6ef2a560c6a395b7e3" },
+        "message": { "proposalId": "65124996456969240058970412761127463646733711243818620698023168930879474320148", "support": 0 }
+      },
+      "expected": {
+        "intent": "Cast vote on ENS governance proposal",
+        "owner": "ENS Governor",
+        "fields": [
+          { "label": "Proposal id", "value": "65124996456969240058970412761127463646733711243818620698023168930879474320148" },
+          { "label": "Vote", "value": "Against" }
+        ]
+      }
+    },
+    {
+      "description": "ENS Governor - vote Abstain",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "Ballot": [{ "name": "proposalId", "type": "uint256" }, { "name": "support", "type": "uint8" }]
+        },
+        "primaryType": "Ballot",
+        "domain": { "name": "ENS Governor", "version": "1", "chainId": 1, "verifyingContract": "0x323a76393544d5ecca80cd6ef2a560c6a395b7e3" },
+        "message": { "proposalId": "65124996456969240058970412761127463646733711243818620698023168930879474320148", "support": 2 }
+      },
+      "expected": {
+        "intent": "Cast vote on ENS governance proposal",
+        "owner": "ENS Governor",
+        "fields": [
+          { "label": "Proposal id", "value": "65124996456969240058970412761127463646733711243818620698023168930879474320148" },
+          { "label": "Vote", "value": "Abstain" }
         ]
       }
     }

--- a/registry/tally/testsv2/eip712-tally-ethereum-ens-token.tests.json
+++ b/registry/tally/testsv2/eip712-tally-ethereum-ens-token.tests.json
@@ -24,7 +24,7 @@
         "message": { "delegatee": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "nonce": 42, "expiry": 1798761600 }
       },
       "expected": {
-        "intent": "ENS token",
+        "intent": "Delegate ENS voting power",
         "owner": "Ethereum Name Service",
         "fields": [
           { "label": "Delegatee", "value": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" },

--- a/registry/tally/testsv2/eip712-tally-ethereum-gtk-token.tests.json
+++ b/registry/tally/testsv2/eip712-tally-ethereum-gtk-token.tests.json
@@ -18,7 +18,7 @@
         "message": { "delegatee": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "nonce": 42, "expiry": 1798761600 }
       },
       "expected": {
-        "intent": "GTK token",
+        "intent": "Delegate GTC voting power",
         "owner": "Gitcoin",
         "fields": [
           { "label": "Delegatee", "value": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" },

--- a/registry/tally/testsv2/eip712-tally-ethereum-hop-governor.tests.json
+++ b/registry/tally/testsv2/eip712-tally-ethereum-hop-governor.tests.json
@@ -19,9 +19,53 @@
         "message": { "proposalId": 128, "support": 1 }
       },
       "expected": {
-        "intent": "Hop Governor",
+        "intent": "Cast vote on Hop governance proposal",
         "owner": "HOP Governor",
-        "fields": [{ "label": "Proposal id", "value": "128" }, { "label": "Support", "value": "1" }]
+        "fields": [{ "label": "Proposal id", "value": "128" }, { "label": "Vote", "value": "For" }]
+      }
+    },
+    {
+      "description": "Hop Governor - vote Against",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "Ballot": [{ "name": "proposalId", "type": "uint256" }, { "name": "support", "type": "uint8" }]
+        },
+        "primaryType": "Ballot",
+        "domain": { "name": "HOP Governor", "version": "1", "chainId": 1, "verifyingContract": "0xed8bdb5895b8b7f9fdb3c087628fd8410e853d48" },
+        "message": { "proposalId": 128, "support": 0 }
+      },
+      "expected": {
+        "intent": "Cast vote on Hop governance proposal",
+        "owner": "HOP Governor",
+        "fields": [{ "label": "Proposal id", "value": "128" }, { "label": "Vote", "value": "Against" }]
+      }
+    },
+    {
+      "description": "Hop Governor - vote Abstain",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "Ballot": [{ "name": "proposalId", "type": "uint256" }, { "name": "support", "type": "uint8" }]
+        },
+        "primaryType": "Ballot",
+        "domain": { "name": "HOP Governor", "version": "1", "chainId": 1, "verifyingContract": "0xed8bdb5895b8b7f9fdb3c087628fd8410e853d48" },
+        "message": { "proposalId": 128, "support": 2 }
+      },
+      "expected": {
+        "intent": "Cast vote on Hop governance proposal",
+        "owner": "HOP Governor",
+        "fields": [{ "label": "Proposal id", "value": "128" }, { "label": "Vote", "value": "Abstain" }]
       }
     }
   ]

--- a/registry/tally/testsv2/eip712-tally-ethereum-hop-token.tests.json
+++ b/registry/tally/testsv2/eip712-tally-ethereum-hop-token.tests.json
@@ -19,7 +19,7 @@
         "message": { "delegatee": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "nonce": 12, "expiry": 1776816000 }
       },
       "expected": {
-        "intent": "HOP token",
+        "intent": "Delegate HOP voting power",
         "owner": "Hop",
         "fields": [
           { "label": "Delegatee", "value": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" },

--- a/registry/tally/testsv2/eip712-tally-ethereum-pool-token.tests.json
+++ b/registry/tally/testsv2/eip712-tally-ethereum-pool-token.tests.json
@@ -18,7 +18,7 @@
         "message": { "delegatee": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "nonce": 18, "expiry": 1784678400 }
       },
       "expected": {
-        "intent": "POOL token",
+        "intent": "Delegate POOL voting power",
         "owner": "PoolTogether",
         "fields": [
           { "label": "Delegatee", "value": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" },

--- a/registry/tally/testsv2/eip712-tally-ethereum-pooltogether-governor.tests.json
+++ b/registry/tally/testsv2/eip712-tally-ethereum-pooltogether-governor.tests.json
@@ -18,9 +18,30 @@
         "message": { "proposalId": 3, "support": true }
       },
       "expected": {
-        "intent": "PoolTogether Governor Alpha",
+        "intent": "Cast vote on PoolTogether proposal",
         "owner": "PoolTogether Governor Alpha",
-        "fields": [{ "label": "Proposal id", "value": "3" }, { "label": "Support", "value": "true" }]
+        "fields": [{ "label": "Proposal id", "value": "3" }, { "label": "Vote", "value": "For" }]
+      }
+    },
+    {
+      "description": "PoolTogether Governor Alpha - vote Against",
+      "data": {
+        "types": {
+          "EIP712Domain": [
+            { "name": "name", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+          ],
+          "Ballot": [{ "name": "proposalId", "type": "uint256" }, { "name": "support", "type": "bool" }]
+        },
+        "primaryType": "Ballot",
+        "domain": { "name": "PoolTogether Governor Alpha", "chainId": 1, "verifyingContract": "0xb3a87172f555ae2a2ab79be60b336d2f7d0187f0" },
+        "message": { "proposalId": 3, "support": false }
+      },
+      "expected": {
+        "intent": "Cast vote on PoolTogether proposal",
+        "owner": "PoolTogether Governor Alpha",
+        "fields": [{ "label": "Proposal id", "value": "3" }, { "label": "Vote", "value": "Against" }]
       }
     }
   ]

--- a/registry/tally/testsv2/eip712-tally-ethereum-uni-token.tests.json
+++ b/registry/tally/testsv2/eip712-tally-ethereum-uni-token.tests.json
@@ -18,7 +18,7 @@
         "message": { "delegatee": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "nonce": 12, "expiry": 1798761600 }
       },
       "expected": {
-        "intent": "UNI token",
+        "intent": "Delegate UNI voting power",
         "owner": "Uniswap",
         "fields": [
           { "label": "Delegatee", "value": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" },


### PR DESCRIPTION
## The context

Tally is a governance application. A token holder uses it to take part in the governance of a protocol. The registry holds 13 Tally descriptors.

A descriptor tells the wallet how to show a message. The `intent` is the headline of the screen. The signer reads the headline first.

The 13 descriptors divide into two groups. Six descriptors cover a `Delegation` message. A user signs that message to give the voting power to another address. Seven descriptors cover a `Ballot` message. A user signs that message to vote on a proposal.

## Defect 1 — the intent states no action

Each descriptor uses a bare noun as the intent. Examples are `"ENS Governor"` and `"UNI token"`. A noun names the contract or the token. It does not say what the signature does.

The signer does not learn that they cast a vote. The signer does not learn that they give away the voting power.

This change makes each intent a verb phrase. The audit gives the wording for each descriptor. This change uses that wording.

| Descriptor | Old intent | New intent |
|---|---|---|
| `arbitrum-arb-token` | `ARB token` | `Delegate ARB voting power` |
| `ethereum-ens-token` | `ENS token` | `Delegate ENS voting power` |
| `ethereum-gtk-token` | `GTK token` | `Delegate GTC voting power` |
| `ethereum-hop-token` | `HOP token` | `Delegate HOP voting power` |
| `ethereum-pool-token` | `POOL token` | `Delegate POOL voting power` |
| `ethereum-uni-token` | `UNI token` | `Delegate UNI voting power` |
| `arbitrum-core-governor` | `Arbitrum Foundation: Core Governor` | `Cast vote on Arbitrum Core Governor proposal` |
| `arbitrum-treasury-governor` | `Arbitrum Foundation: Treasury Governor` | `Cast vote on Arbitrum Treasury Governor proposal` |
| `ethereum-bitcoin-governor` | `Gitcoin Governor` | `Cast vote on Gitcoin proposal` |
| `ethereum-bravo-governor` | `Uniswap Governor` | `Cast vote on Uniswap governance proposal` |
| `ethereum-ens-governor` | `ENS Governor` | `Cast vote on ENS governance proposal` |
| `ethereum-hop-governor` | `Hop Governor` | `Cast vote on Hop governance proposal` |
| `ethereum-pooltogether-governor` | `PoolTogether Governor Alpha` | `Cast vote on PoolTogether proposal` |

## Defect 2 — the vote choice renders as a number

The `Ballot` message contains a `support` field. That field holds the direction of the vote. The seven governor descriptors give the field `format: "raw"`. Therefore the wallet shows a bare number.

The signer sees `1`. The signer cannot tell if `1` means For or Against. A wrong value looks the same as the correct value.

This change gives the field `format: "enum"`. The field points to a new `voteType` map in the metadata of the descriptor:

```json
{ "path": "support", "label": "Vote", "format": "enum", "params": { "$ref": "$.metadata.enums.voteType" } }
```

## The `support` field does not have one type

Five governors declare `uint8 support`. They get a map of three values:

```json
"enums": { "voteType": { "0": "Against", "1": "For", "2": "Abstain" } }
```

Two governors declare `bool support`. They get a map of two values:

```json
"enums": { "voteType": { "false": "Against", "true": "For" } }
```

The two governors with a `bool` field are `eip712-tally-ethereum-bitcoin-governor` (the Gitcoin governor) and `eip712-tally-ethereum-pooltogether-governor`. I read the format signature of each descriptor to confirm the type.

## Tests

The result is **25 pass, 0 fail**. I used the Sourcify test runner that CI uses (`clear-signing-test-runner` at `dae3cda`, v0.2.2).

Each governor fixture holds one case before this change. That case always votes For. This change adds a case for each remaining value of the map. The tests now cover the complete map, and not only one value.

## Negative control

I reverted the descriptors, and I kept the new tests. The tests then fail. They show the two defects:

```
intent   -- expected "Cast vote on ENS governance proposal", got "ENS Governor"
uint8    -- expected "For" / "Against" / "Abstain", got "1" / "0" / "2"
bool     -- expected "For" / "Against", got "true" / "false"
```

The test runner reports the first mismatch of a case only. Therefore I ran two controls. The first control reverts the complete descriptor, and it shows the intent defect. The second control reverts the enum only, and it keeps the new intent. The second control shows the vote defect.

Closes #2816, closes #2817, closes #2818, closes #2819, closes #2820, closes #2821, closes #2822, closes #2823, closes #2824, closes #2825, closes #2826, closes #2827, closes #2828

🤖 Generated with [Claude Code](https://claude.com/claude-code)
