### PR TITLE
test: exercise the new CI checks (do not merge)

### DIFF
--- a/registry/threshold/calldata-TBTC.json
+++ b/registry/threshold/calldata-TBTC.json
@@ -6,6 +6,19 @@
       "deployments": [
         { "chainId": 1, "address": "0x18084fbA666a33d37592fA2633fD49a74DD93a88" },
         { "chainId": 11155111, "address": "0x517f2982701695D4E52f1ECFBEf3ba31Df470161" }
+      ],
+      "abi": [
+        {
+          "type": "function",
+          "name": "approveAndCall",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            { "name": "spender", "type": "address" },
+            { "name": "amount", "type": "uint256" },
+            { "name": "extraData", "type": "bytes" }
+          ],
+          "outputs": [{ "name": "", "type": "bool" }]
+        }
       ]
     }
   },

--- a/registry/threshold/calldata-TBTCVault.json
+++ b/registry/threshold/calldata-TBTCVault.json
@@ -6,6 +6,18 @@
       "deployments": [
         { "chainId": 1, "address": "0x9C070027cdC9dc8F82416B2e5314E11DFb4FE3CD" },
         { "chainId": 11155111, "address": "0xB5679dE944A79732A75CE556191DF11F489448d5" }
+      ],
+      "abi": [
+        {
+          "type": "function",
+          "name": "requestOptimisticMint",
+          "stateMutability": "nonpayable",
+          "inputs": [
+            { "name": "fundingTxHash", "type": "bytes32" },
+            { "name": "fundingOutputIndex", "type": "uint32" }
+          ],
+          "outputs": []
+        }
       ]
     }
   },


### PR DESCRIPTION
> [!WARNING]
> **Do not merge.** This pull request exists only to check that the automation added in #2905 behaves on a real pull request. Close it once the checks have reported.

## What it changes

The deprecated `context.contract.abi` key is added to two threshold descriptors:

| File | Attested? | Test file? |
| --- | --- | --- |
| `registry/threshold/calldata-TBTC.json` | no | yes |
| `registry/threshold/calldata-TBTCVault.json` | **yes** | yes |

## What the checks should do

**`validate attested descriptors` must fail.** `calldata-TBTCVault.json` carries an attestation, and an auditor signs the exact content of a descriptor. The annotation should name the attestation file and ask for a new descriptor file instead.

**Every other check should pass.** The file names are unchanged, no attestation is orphaned, the index still builds, and both descriptors have a test file, so the clear signing tests should run for both and pass.

**A recommendations comment should appear**, naming five findings: three display formats with no `interpolatedIntent`, and the two deprecated keys this pull request adds.

## Verified locally first

I ran the real scripts from `master` against this diff. The attestation check exits 1 and names `calldata-TBTCVault.json`; the orphan check, the file name check and the index build all exit 0; `list-affected-descriptors.js` reports two affected descriptors, both with a test file.
