### PR TITLE
fix(permit): render DAI permit 'allowed' as enum instead of raw bool (#2895)

### DIFF
--- a/registry/permit/common-dai-permit.json
+++ b/registry/permit/common-dai-permit.json
@@ -1,13 +1,21 @@
 {
   "$schema": "../../specs/erc7730-v2.schema.json",
   "context": { "eip712": {} },
+  "metadata": {
+    "enums": {
+      "daiPermitAllowed": {
+        "true": "Unlimited",
+        "false": "Revoke to zero"
+      }
+    }
+  },
   "display": {
     "formats": {
       "Permit(address holder,address spender,uint256 nonce,uint256 expiry,bool allowed)": {
         "intent": "Authorize spending of tokens",
         "fields": [
           { "path": "spender", "label": "Spender", "format": "raw", "visible": "always" },
-          { "path": "allowed", "label": "Unlimited spending", "format": "raw", "visible": "always" },
+          { "path": "allowed", "label": "Allowance", "format": "enum", "params": { "$ref": "$.metadata.enums.daiPermitAllowed" }, "visible": "always" },
           { "path": "expiry", "label": "Valid until", "format": "date", "params": { "encoding": "timestamp" }, "visible": "always" },
           { "label": "Holder", "path": "holder", "visible": "never" },
           { "label": "Nonce", "path": "nonce", "visible": "never" }


### PR DESCRIPTION
The DAI permit's `allowed` boolean was rendered raw, so the screen showed `Unlimited spending: true/false`. `true` grants a 2^256-1 allowance and `false` revokes it to zero — the screen stated neither, a decision-critical mismatch (audit category 6).

Switched to the `enum` format with a metadata enum so the value reads `Unlimited` vs `Revoke to zero`, matching the existing pattern in `registry/celo/calldata-celo_governance.json`.

Covers both descriptors that `includes` this file:
- `registry/permit/eip712-permit-ethereum-dai.json`
- `registry/permit/eip712-permit-polygon-dai.json`

Closes #2895.